### PR TITLE
Improvments for scheduling on a limited sub pool.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 apply plugin: 'checkstyle'
 
 group 'org.threadly'
-version = '1.0.1-SNAPSHOT'
+version = '1.1.0-SNAPSHOT'
 
 repositories {
   mavenCentral()

--- a/build.upload
+++ b/build.upload
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 apply plugin: 'checkstyle'
 
 group 'org.threadly'
-version = '1.0.1-SNAPSHOT'
+version = '1.1.0-SNAPSHOT'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.threadly</groupId>
   <artifactId>Threadly</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Threadly</name>

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerWrapper.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerWrapper.java
@@ -38,38 +38,38 @@ public class PrioritySchedulerWrapper implements PrioritySchedulerInterface {
 
   @Override
   public void execute(Runnable command) {
-    execute(command, defaultPriority);
+    scheduler.execute(command, defaultPriority);
   }
 
   @Override
   public void execute(Runnable task, TaskPriority priority) {
-    schedule(task, 0, priority);
+    scheduler.execute(task, priority);
   }
 
   @Override
   public ListenableFuture<?> submit(Runnable task) {
-    return submit(task, defaultPriority);
+    return scheduler.submit(task, defaultPriority);
   }
 
   @Override
   public <T> ListenableFuture<T> submit(Runnable task, T result) {
-    return submit(task, result, defaultPriority);
+    return scheduler.submit(task, result, defaultPriority);
   }
 
   @Override
   public ListenableFuture<?> submit(Runnable task, TaskPriority priority) {
-    return submitScheduled(task, 0, priority);
+    return scheduler.submit(task, priority);
   }
 
   @Override
   public <T> ListenableFuture<T> submit(Runnable task, T result, 
                                         TaskPriority priority) {
-    return submitScheduled(task, result, 0, priority);
+    return scheduler.submit(task, result, priority);
   }
 
   @Override
   public <T> ListenableFuture<T> submit(Callable<T> task) {
-    return submit(task, defaultPriority);
+    return scheduler.submit(task, defaultPriority);
   }
 
   @Override
@@ -79,7 +79,7 @@ public class PrioritySchedulerWrapper implements PrioritySchedulerInterface {
   
   @Override
   public void schedule(Runnable task, long delayInMs) {
-    schedule(task, delayInMs, defaultPriority);
+    scheduler.schedule(task, delayInMs, defaultPriority);
   }
 
   @Override
@@ -90,12 +90,12 @@ public class PrioritySchedulerWrapper implements PrioritySchedulerInterface {
 
   @Override
   public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs) {
-    return submitScheduled(task, delayInMs, defaultPriority);
+    return scheduler.submitScheduled(task, delayInMs, defaultPriority);
   }
 
   @Override
   public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs) {
-    return submitScheduled(task, result, delayInMs, defaultPriority);
+    return scheduler.submitScheduled(task, result, delayInMs, defaultPriority);
   }
 
   @Override
@@ -112,7 +112,7 @@ public class PrioritySchedulerWrapper implements PrioritySchedulerInterface {
 
   @Override
   public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
-    return submitScheduled(task, delayInMs, defaultPriority);
+    return scheduler.submitScheduled(task, delayInMs, defaultPriority);
   }
 
   @Override
@@ -125,8 +125,8 @@ public class PrioritySchedulerWrapper implements PrioritySchedulerInterface {
   public void scheduleWithFixedDelay(Runnable task, 
                                      long initialDelay, 
                                      long recurringDelay) {
-    scheduleWithFixedDelay(task, initialDelay, recurringDelay, 
-                           defaultPriority);
+    scheduler.scheduleWithFixedDelay(task, initialDelay, recurringDelay, 
+                                     defaultPriority);
   }
 
   @Override

--- a/src/main/java/org/threadly/concurrent/limiter/AbstractThreadPoolLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/AbstractThreadPoolLimiter.java
@@ -1,5 +1,6 @@
 package org.threadly.concurrent.limiter;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.threadly.concurrent.RunnableContainerInterface;
@@ -108,14 +109,20 @@ abstract class AbstractThreadPoolLimiter {
    */
   protected class LimiterRunnableWrapper implements Runnable, 
                                                     RunnableContainerInterface {
+    private final Executor executor;
     private final Runnable runnable;
     
-    public LimiterRunnableWrapper(Runnable runnable) {
+    protected LimiterRunnableWrapper(Executor executor, Runnable runnable) {
+      this.executor = executor;
       this.runnable = runnable;
     }
     
     protected void doAfterRunTasks() {
       // nothing in the default implementation
+    }
+    
+    protected void submitToExecutor() {
+      this.executor.execute(this);
     }
     
     @Override

--- a/src/test/java/org/threadly/concurrent/PriorityScheduledExecutorTest.java
+++ b/src/test/java/org/threadly/concurrent/PriorityScheduledExecutorTest.java
@@ -701,8 +701,13 @@ public class PriorityScheduledExecutorTest {
   }
   
   @Test
-  public void scheduleExecutionTest() {
+  public void scheduleTest() {
     SimpleSchedulerInterfaceTest.scheduleTest(new PriorityScheduledExecutorTestFactory());
+  }
+  
+  @Test
+  public void scheduleNoDelayTest() {
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(new PriorityScheduledExecutorTestFactory());
   }
   
   @Test
@@ -730,7 +735,7 @@ public class PriorityScheduledExecutorTest {
   }
   
   @Test
-  public void scheduleExecutionFail() {
+  public void scheduleFail() {
     SimpleSchedulerInterfaceTest.scheduleFail(new PriorityScheduledExecutorTestFactory());
   }
   
@@ -749,7 +754,13 @@ public class PriorityScheduledExecutorTest {
   @Test
   public void recurringExecutionTest() {
     PriorityScheduledExecutorTestFactory psetf = new PriorityScheduledExecutorTestFactory();
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(psetf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, psetf);
+  }
+  
+  @Test
+  public void recurringExecutionInitialDelayTest() {
+    PriorityScheduledExecutorTestFactory psetf = new PriorityScheduledExecutorTestFactory();
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, psetf);
   }
   
   @Test
@@ -907,6 +918,13 @@ public class PriorityScheduledExecutorTest {
   }
   
   @Test
+  public void wrapperScheduleNoDelayTest() {
+    WrapperFactory wf = new WrapperFactory();
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(wf);
+  }
+  
+  @Test
   public void wrapperSubmitScheduledRunnableTest() throws InterruptedException, 
                                                           ExecutionException, 
                                                           TimeoutException {
@@ -934,7 +952,7 @@ public class PriorityScheduledExecutorTest {
   }
   
   @Test
-  public void wrapperScheduleExecutionFail() {
+  public void wrapperScheduleFail() {
     WrapperFactory wf = new WrapperFactory();
     
     SimpleSchedulerInterfaceTest.scheduleFail(wf);
@@ -958,7 +976,14 @@ public class PriorityScheduledExecutorTest {
   public void wrapperRecurringExecutionTest() {
     WrapperFactory wf = new WrapperFactory();
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(wf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, wf);
+  }
+  
+  @Test
+  public void wrapperRecurringExecutionInitialDelayTest() {
+    WrapperFactory wf = new WrapperFactory();
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, wf);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerTest.java
@@ -193,10 +193,17 @@ public class PrioritySchedulerStatisticTrackerTest {
   }
   
   @Test
-  public void scheduleExecutionTest() {
+  public void scheduleTest() {
     SchedulerFactory sf = new SchedulerFactory();
     
     SimpleSchedulerInterfaceTest.scheduleTest(sf);
+  }
+  
+  @Test
+  public void scheduleNoDelayTest() {
+    SchedulerFactory sf = new SchedulerFactory();
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(sf);
   }
   
   @Test
@@ -227,7 +234,7 @@ public class PrioritySchedulerStatisticTrackerTest {
   }
   
   @Test
-  public void scheduleExecutionFail() {
+  public void scheduleFail() {
     SchedulerFactory sf = new SchedulerFactory();
     
     SimpleSchedulerInterfaceTest.scheduleFail(sf);
@@ -251,7 +258,14 @@ public class PrioritySchedulerStatisticTrackerTest {
   public void recurringExecutionTest() {
     SchedulerFactory sf = new SchedulerFactory();
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(sf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, sf);
+  }
+  
+  @Test
+  public void recurringExecutionInitialDelayTest() {
+    SchedulerFactory sf = new SchedulerFactory();
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, sf);
   }
   
   @Test
@@ -405,6 +419,13 @@ public class PrioritySchedulerStatisticTrackerTest {
   }
   
   @Test
+  public void wrapperScheduleNoDelayTest() {
+    WrapperFactory wf = new WrapperFactory();
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(wf);
+  }
+  
+  @Test
   public void wrapperSubmitScheduledRunnableTest() throws InterruptedException, 
                                                           ExecutionException, 
                                                           TimeoutException {
@@ -432,7 +453,7 @@ public class PrioritySchedulerStatisticTrackerTest {
   }
   
   @Test
-  public void wrapperScheduleExecutionFail() {
+  public void wrapperScheduleFail() {
     WrapperFactory wf = new WrapperFactory();
     
     SimpleSchedulerInterfaceTest.scheduleFail(wf);
@@ -456,7 +477,14 @@ public class PrioritySchedulerStatisticTrackerTest {
   public void wrapperRecurringExecutionTest() {
     WrapperFactory wf = new WrapperFactory();
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(wf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, wf);
+  }
+  
+  @Test
+  public void wrapperRecurringExecutionInitialDelayTest() {
+    WrapperFactory wf = new WrapperFactory();
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, wf);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerWrapperTest.java
@@ -1,0 +1,54 @@
+package org.threadly.concurrent;
+
+import static org.junit.Assert.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@SuppressWarnings("javadoc")
+public class PrioritySchedulerWrapperTest {
+  private static PriorityScheduledExecutor scheduler;
+  
+  @BeforeClass
+  public static void setupClass() {
+    scheduler = new PriorityScheduledExecutor(1, 2, 1000);
+  }
+  
+  @AfterClass
+  public static void tearDownClass() {
+    scheduler.shutdown();
+    scheduler = null;
+  }
+  
+  @Test
+  public void constructorTest() {
+    PrioritySchedulerWrapper psw = new PrioritySchedulerWrapper(scheduler, TaskPriority.Low);
+    assertTrue(psw.scheduler == scheduler);
+    assertEquals(TaskPriority.Low, psw.defaultPriority);
+    psw = new PrioritySchedulerWrapper(scheduler, TaskPriority.High);
+    assertEquals(TaskPriority.High, psw.defaultPriority);
+  }
+  
+  @Test
+  public void constructorFail() {
+    try {
+      new PrioritySchedulerWrapper(null, TaskPriority.High);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      new PrioritySchedulerWrapper(scheduler, null);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void isShutdownTest() {
+    PrioritySchedulerWrapper psw = new PrioritySchedulerWrapper(scheduler, TaskPriority.Low);
+    assertEquals(scheduler.isShutdown(), psw.isShutdown());
+  }
+}

--- a/src/test/java/org/threadly/concurrent/ScheduledExecutorServiceWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/ScheduledExecutorServiceWrapperTest.java
@@ -62,14 +62,21 @@ public class ScheduledExecutorServiceWrapperTest {
   }
   
   @Test
-  public void scheduleExecutionTest() {
+  public void scheduleTest() {
     SchedulerFactory sf = new SchedulerFactory();
     
     SimpleSchedulerInterfaceTest.scheduleTest(sf);
   }
   
   @Test
-  public void scheduleExecutionFail() {
+  public void scheduleNoDelayTest() {
+    SchedulerFactory sf = new SchedulerFactory();
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(sf);
+  }
+  
+  @Test
+  public void scheduleFail() {
     SchedulerFactory sf = new SchedulerFactory();
     
     SimpleSchedulerInterfaceTest.scheduleFail(sf);
@@ -120,7 +127,14 @@ public class ScheduledExecutorServiceWrapperTest {
   public void recurringExecutionTest() {
     SchedulerFactory sf = new SchedulerFactory();
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(sf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, sf);
+  }
+  
+  @Test
+  public void recurringExecutionInitialDelayTest() {
+    SchedulerFactory sf = new SchedulerFactory();
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, sf);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/SubmitterSchedulerInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/SubmitterSchedulerInterfaceTest.java
@@ -142,7 +142,19 @@ public class SubmitterSchedulerInterfaceTest {
         // expected
       }
       try {
+        scheduler.submitScheduled((Runnable)null, null, 1000);
+        fail("Exception should have been thrown");
+      } catch (IllegalArgumentException e) {
+        // expected
+      }
+      try {
         scheduler.submitScheduled(new TestRunnable(), -1);
+        fail("Exception should have been thrown");
+      } catch (IllegalArgumentException e) {
+        // expected
+      }
+      try {
+        scheduler.submitScheduled(new TestRunnable(), null, -1);
         fail("Exception should have been thrown");
       } catch (IllegalArgumentException e) {
         // expected

--- a/src/test/java/org/threadly/concurrent/TaskSchedulerDistributorTest.java
+++ b/src/test/java/org/threadly/concurrent/TaskSchedulerDistributorTest.java
@@ -373,6 +373,13 @@ public class TaskSchedulerDistributorTest {
   }
   
   @Test
+  public void keyBasedSchedulerScheduleNoDelayTest() {
+    KeyBasedSubmitterSchedulerFactory factory = new KeyBasedSubmitterSchedulerFactory();
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(factory);
+  }
+  
+  @Test
   public void keyBasedSchedulerScheduleFail() {
     KeyBasedSubmitterSchedulerFactory factory = new KeyBasedSubmitterSchedulerFactory();
     
@@ -383,7 +390,14 @@ public class TaskSchedulerDistributorTest {
   public void keyBasedSchedulerRecurringTest() {
     KeyBasedSubmitterSchedulerFactory factory = new KeyBasedSubmitterSchedulerFactory();
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(factory);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, factory);
+  }
+  
+  @Test
+  public void keyBasedSchedulerRecurringInitialDelayTest() {
+    KeyBasedSubmitterSchedulerFactory factory = new KeyBasedSubmitterSchedulerFactory();
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, factory);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/limiter/ExecutorLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/ExecutorLimiterTest.java
@@ -96,7 +96,7 @@ public class ExecutorLimiterTest {
     for (int i = 0; i < PARALLEL_COUNT; i++) {
       TestRunnable tr = new TestRunnable();
       runnables.add(tr);
-      limiter.waitingTasks.add(limiter.new LimiterRunnableWrapper(tr));
+      limiter.waitingTasks.add(limiter.new LimiterRunnableWrapper(limiter.executor, tr));
     }
     
     limiter.consumeAvailable();

--- a/src/test/java/org/threadly/concurrent/limiter/PrioritySchedulerLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/PrioritySchedulerLimiterTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.threadly.ThreadlyTestUtil;
 import org.threadly.concurrent.BlockingTestRunnable;
 import org.threadly.concurrent.PriorityScheduledExecutor;
+import org.threadly.concurrent.PrioritySchedulerWrapper;
 import org.threadly.concurrent.SimpleSchedulerInterface;
 import org.threadly.concurrent.SimpleSchedulerInterfaceTest;
 import org.threadly.concurrent.StrictPriorityScheduledExecutor;
@@ -127,30 +128,42 @@ public class PrioritySchedulerLimiterTest {
   
   @Test
   public void executeTest() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SubmitterExecutorInterfaceTest.executeTest(sf);
+  }
+  
+  @Test
+  public void executeWithPriorityTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SubmitterExecutorInterfaceTest.executeTest(sf);
   }
   
   @Test
   public void executeNamedSubPoolTest() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, true);
     
     SubmitterExecutorInterfaceTest.executeTest(sf);
   }
   
   @Test
   public void submitRunnableTest() {
-    submitRunnableTest(false);
+    submitRunnableTest(false, false);
+  }
+  
+  @Test
+  public void submitRunnableWithPriorityTest() {
+    submitRunnableTest(true, false);
   }
   
   @Test
   public void submitRunnableNamedSubPoolTest() {
-    submitRunnableTest(true);
+    submitRunnableTest(true, true);
   }
   
-  public void submitRunnableTest(boolean nameSubPool) {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(nameSubPool);
+  public void submitRunnableTest(boolean withPriority, boolean nameSubPool) {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(withPriority, nameSubPool);
     
     try {
       SubmitterSchedulerInterface scheduler = sf.makeSubmitterScheduler(TEST_QTY, false);
@@ -193,72 +206,140 @@ public class PrioritySchedulerLimiterTest {
   
   @Test
   public void submitCallableTest() throws InterruptedException, ExecutionException {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SubmitterExecutorInterfaceTest.submitCallableTest(sf);
+  }
+  
+  @Test
+  public void submitCallableWithPriorityTest() throws InterruptedException, ExecutionException {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SubmitterExecutorInterfaceTest.submitCallableTest(sf);
   }
   
   @Test
   public void submitCallableNamedSubPoolTest() throws InterruptedException, ExecutionException {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, true);
     
     SubmitterExecutorInterfaceTest.submitCallableTest(sf);
   }
   
   @Test (expected = IllegalArgumentException.class)
-  public void executeTestFail() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+  public void executeFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SubmitterExecutorInterfaceTest.executeFail(sf);
+  }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void executeWithPriorityFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SubmitterExecutorInterfaceTest.executeFail(sf);
   }
   
   @Test (expected = IllegalArgumentException.class)
   public void submitRunnableFail() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SubmitterExecutorInterfaceTest.submitRunnableFail(sf);
+  }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void submitRunnableWithPriorityFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SubmitterExecutorInterfaceTest.submitRunnableFail(sf);
   }
   
   @Test (expected = IllegalArgumentException.class)
   public void submitCallableFail() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SubmitterExecutorInterfaceTest.submitCallableFail(sf);
+  }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void submitCallableWithPriorityFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SubmitterExecutorInterfaceTest.submitCallableFail(sf);
   }
   
   @Test
-  public void scheduleExecutionTest() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+  public void scheduleTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
     
     SimpleSchedulerInterfaceTest.scheduleTest(sf);
   }
   
   @Test
-  public void scheduleExecutionNamedSubPoolTest() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true);
+  public void scheduleWithPriorityTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SimpleSchedulerInterfaceTest.scheduleTest(sf);
   }
   
   @Test
-  public void scheduleExecutionFail() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+  public void scheduleNamedSubPoolTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, true);
+    
+    SimpleSchedulerInterfaceTest.scheduleTest(sf);
+  }
+  
+  @Test
+  public void scheduleNoDelayTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(sf);
+  }
+  
+  @Test
+  public void scheduleNoDelayWithPriorityTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(sf);
+  }
+  
+  @Test
+  public void scheduleNoDelayNamedSubPoolTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, true);
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(sf);
+  }
+  
+  @Test
+  public void scheduleFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SimpleSchedulerInterfaceTest.scheduleFail(sf);
+  }
+  
+  @Test
+  public void scheduleWithPriorityFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SimpleSchedulerInterfaceTest.scheduleFail(sf);
   }
   
   @Test
   public void submitScheduledRunnableTest() {
-    submitScheduledRunnableTest(false);
+    submitScheduledRunnableTest(false, false);
+  }
+  
+  @Test
+  public void submitScheduledRunnableWithPriorityTest() {
+    submitScheduledRunnableTest(true, false);
   }
   
   @Test
   public void submitScheduledRunnableNamedSubPoolTest() {
-    submitScheduledRunnableTest(true);
+    submitScheduledRunnableTest(true, true);
   }
   
-  public void submitScheduledRunnableTest(boolean nameSubPool) {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(nameSubPool);
+  public void submitScheduledRunnableTest(boolean withPriority, boolean nameSubPool) {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(withPriority, nameSubPool);
     // we can't defer to the interface implementation for this check
     try {
       SubmitterSchedulerInterface scheduler = sf.makeSubmitterScheduler(TEST_QTY, true);
@@ -305,7 +386,16 @@ public class PrioritySchedulerLimiterTest {
   public void submitScheduledCallableTest() throws InterruptedException, 
                                                    ExecutionException, 
                                                    TimeoutException {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SubmitterSchedulerInterfaceTest.submitScheduledCallableTest(sf);
+  }
+  
+  @Test
+  public void submitScheduledCallableWithPriorityTest() throws InterruptedException, 
+                                                               ExecutionException, 
+                                                               TimeoutException {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SubmitterSchedulerInterfaceTest.submitScheduledCallableTest(sf);
   }
@@ -314,42 +404,91 @@ public class PrioritySchedulerLimiterTest {
   public void submitScheduledCallableNamedSubPoolTest() throws InterruptedException, 
                                                                ExecutionException, 
                                                                TimeoutException {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, true);
     
     SubmitterSchedulerInterfaceTest.submitScheduledCallableTest(sf);
   }
   
   @Test
   public void submitScheduledRunnableFail() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SubmitterSchedulerInterfaceTest.submitScheduledRunnableFail(sf);
+  }
+  
+  @Test
+  public void submitScheduledRunnableWithPriorityFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SubmitterSchedulerInterfaceTest.submitScheduledRunnableFail(sf);
   }
   
   @Test
   public void submitScheduledCallableFail() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SubmitterSchedulerInterfaceTest.submitScheduledCallableFail(sf);
+  }
+  
+  @Test
+  public void submitScheduledCallableWithPriorityFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SubmitterSchedulerInterfaceTest.submitScheduledCallableFail(sf);
   }
   
   @Test
   public void recurringExecutionTest() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(sf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, sf);
+  }
+  
+  @Test
+  public void recurringExecutionWithPriorityTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, sf);
   }
   
   @Test
   public void recurringExecutionNamedSubPoolTest() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, true);
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(sf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, sf);
+  }
+  
+  @Test
+  public void recurringExecutionInitialDelayTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, sf);
+  }
+  
+  @Test
+  public void recurringExecutionInitialDelayWithPriorityTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, sf);
+  }
+  
+  @Test
+  public void recurringExecutionInitialDelayNamedSubPoolTest() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, true);
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, sf);
   }
   
   @Test
   public void recurringExecutionFail() {
-    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false);
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(false, false);
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionFail(sf);
+  }
+  
+  @Test
+  public void recurringExecutionWithPriorityFail() {
+    PrioritySchedulerLimiterFactory sf = new PrioritySchedulerLimiterFactory(true, false);
     
     SimpleSchedulerInterfaceTest.recurringExecutionFail(sf);
   }
@@ -469,10 +608,13 @@ public class PrioritySchedulerLimiterTest {
 
   private class PrioritySchedulerLimiterFactory implements SubmitterSchedulerFactory {
     private final List<PriorityScheduledExecutor> executors;
+    private final boolean addPriorityToCalls;
     private final boolean addSubPoolName;
     
-    private PrioritySchedulerLimiterFactory(boolean addSubPoolName) {
+    private PrioritySchedulerLimiterFactory(boolean addPriorityToCalls, 
+                                            boolean addSubPoolName) {
       executors = new LinkedList<PriorityScheduledExecutor>();
+      this.addPriorityToCalls = addPriorityToCalls;
       this.addSubPoolName = addSubPoolName;
     }
 
@@ -489,8 +631,8 @@ public class PrioritySchedulerLimiterTest {
     }
     
     @Override
-    public PrioritySchedulerLimiter makeSubmitterScheduler(int poolSize, 
-                                                           boolean prestartIfAvailable) {
+    public SubmitterSchedulerInterface makeSubmitterScheduler(int poolSize, 
+                                                              boolean prestartIfAvailable) {
       PriorityScheduledExecutor executor = new StrictPriorityScheduledExecutor(poolSize, poolSize, 
                                                                                1000 * 10);
       if (prestartIfAvailable) {
@@ -498,10 +640,18 @@ public class PrioritySchedulerLimiterTest {
       }
       executors.add(executor);
       
+      PrioritySchedulerLimiter limiter;
       if (addSubPoolName) {
-        return new PrioritySchedulerLimiter(executor, poolSize, "TestSubPool");
+        limiter = new PrioritySchedulerLimiter(executor, poolSize, "TestSubPool");
       } else {
-        return new PrioritySchedulerLimiter(executor, poolSize);
+        limiter = new PrioritySchedulerLimiter(executor, poolSize);
+      }
+      
+      if (addPriorityToCalls) {
+        // we wrap the limiter so all calls are providing a priority
+        return new PrioritySchedulerWrapper(limiter, TaskPriority.High);
+      } else {
+        return limiter;
       }
     }
     

--- a/src/test/java/org/threadly/concurrent/limiter/SchedulerLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/SchedulerLimiterTest.java
@@ -55,6 +55,20 @@ public class SchedulerLimiterTest {
   }
   
   @Test
+  public void isShutdownTest() {
+    PriorityScheduledExecutor executor = new StrictPriorityScheduledExecutor(1, 1, 100);
+    try {
+      SchedulerLimiter limiter = new SchedulerLimiter(executor, 1);
+      
+      assertFalse(limiter.isShutdown());
+      executor.shutdownNow();
+      assertTrue(limiter.isShutdown());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+  
+  @Test
   public void constructorEmptySubPoolNameTest() {
     PriorityScheduledExecutor executor = new StrictPriorityScheduledExecutor(1, 1, 100);
     try {
@@ -76,7 +90,7 @@ public class SchedulerLimiterTest {
       for (int i = 0; i < TEST_QTY; i++) {
         TestRunnable tr = new TestRunnable();
         runnables.add(tr);
-        limiter.waitingTasks.add(limiter.new LimiterRunnableWrapper(tr));
+        limiter.waitingTasks.add(limiter.new LimiterRunnableWrapper(limiter.executor, tr));
       }
       
       limiter.consumeAvailable();
@@ -210,7 +224,7 @@ public class SchedulerLimiterTest {
   }
   
   @Test
-  public void scheduleExecutionTest() {
+  public void scheduleTest() {
     SchedulerLimiterFactory sf = new SchedulerLimiterFactory(false);
     
     SimpleSchedulerInterfaceTest.scheduleTest(sf);
@@ -224,7 +238,21 @@ public class SchedulerLimiterTest {
   }
   
   @Test
-  public void scheduleExecutionFail() {
+  public void scheduleNoDelayTest() {
+    SchedulerLimiterFactory sf = new SchedulerLimiterFactory(false);
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(sf);
+  }
+  
+  @Test
+  public void scheduleNoDelayExecutionNamedSubPoolTest() {
+    SchedulerLimiterFactory sf = new SchedulerLimiterFactory(true);
+    
+    SimpleSchedulerInterfaceTest.scheduleNoDelayTest(sf);
+  }
+  
+  @Test
+  public void scheduleFail() {
     SchedulerLimiterFactory sf = new SchedulerLimiterFactory(false);
     
     SimpleSchedulerInterfaceTest.scheduleFail(sf);
@@ -234,14 +262,28 @@ public class SchedulerLimiterTest {
   public void recurringExecutionTest() {
     SchedulerLimiterFactory sf = new SchedulerLimiterFactory(false);
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(sf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, sf);
+  }
+  
+  @Test
+  public void recurringExecutionInitialDelayTest() {
+    SchedulerLimiterFactory sf = new SchedulerLimiterFactory(false);
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, sf);
   }
   
   @Test
   public void recurringExecutionNamedSubPoolTest() {
     SchedulerLimiterFactory sf = new SchedulerLimiterFactory(true);
     
-    SimpleSchedulerInterfaceTest.recurringExecutionTest(sf);
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(false, sf);
+  }
+  
+  @Test
+  public void recurringExecutionInitialDelayNamedSubPoolTest() {
+    SchedulerLimiterFactory sf = new SchedulerLimiterFactory(true);
+    
+    SimpleSchedulerInterfaceTest.recurringExecutionTest(true, sf);
   }
   
   @Test


### PR DESCRIPTION
This provides performance improvments for scheduled (and recurring) tasks by attempting to run on the delayed runnable thread, and only queuing if forced to do so.  Previously this would always due the worst case situation and queue after the delay has expired.

This commit also reduces code duplication by allowing the PrioritySchedulerLimiter extending from the SchedulerLimiter.

I also expanded and improved the unit test code, to make sure we get full coverage.

I will add line comments for the interesting changes.
