### PR TITLE
Add ability to query task queue length for a given thread key (second pull request)

### DIFF
--- a/src/test/java/org/threadly/concurrent/TaskExecutorDistributorTest.java
+++ b/src/test/java/org/threadly/concurrent/TaskExecutorDistributorTest.java
@@ -62,7 +62,7 @@ public class TaskExecutorDistributorTest {
   public void setup() {
     StripedLock sLock = new StripedLock(1);
     agentLock = sLock.getLock(null);  // there should be only one lock
-    distributor = new TaskExecutorDistributor(scheduler, sLock, Integer.MAX_VALUE);
+    distributor = new TaskExecutorDistributor(scheduler, sLock, Integer.MAX_VALUE, false);
   }
   
   @After
@@ -101,10 +101,10 @@ public class TaskExecutorDistributorTest {
     new TaskExecutorDistributor(1, scheduler);
     new TaskExecutorDistributor(1, scheduler, 1);
     StripedLock sLock = new StripedLock(1);
-    new TaskExecutorDistributor(scheduler, sLock, 1);
+    new TaskExecutorDistributor(scheduler, sLock, 1, false);
   }
   
-  @SuppressWarnings("unused")
+  @SuppressWarnings({ "deprecation", "unused" })
   @Test
   public void constructorFail() {
     try {
@@ -115,7 +115,7 @@ public class TaskExecutorDistributorTest {
     }
     try {
       new TaskExecutorDistributor(scheduler, null, 
-                                  Integer.MAX_VALUE);
+                                  Integer.MAX_VALUE, false);
       fail("Exception should have been thrown");
     } catch (IllegalArgumentException e) {
       // expected

--- a/src/test/java/org/threadly/concurrent/TaskSchedulerDistributorTest.java
+++ b/src/test/java/org/threadly/concurrent/TaskSchedulerDistributorTest.java
@@ -47,7 +47,7 @@ public class TaskSchedulerDistributorTest {
     StripedLock sLock = new StripedLock(1);
     agentLock = sLock.getLock(null);  // there should be only one lock
     distributor = new TaskSchedulerDistributor(scheduler, sLock, 
-                                               Integer.MAX_VALUE);
+                                               Integer.MAX_VALUE, false);
   }
   
   @After
@@ -79,7 +79,7 @@ public class TaskSchedulerDistributorTest {
     return runs;
   }
   
-  @SuppressWarnings("unused")
+  @SuppressWarnings({ "deprecation", "unused" })
   @Test
   public void constructorFail() {
     try {
@@ -90,7 +90,7 @@ public class TaskSchedulerDistributorTest {
     }
     try {
       new TaskSchedulerDistributor(scheduler, null, 
-                                   Integer.MAX_VALUE);
+                                   Integer.MAX_VALUE, false);
       fail("Exception should have been thrown");
     } catch (IllegalArgumentException e) {
       // expected
@@ -112,7 +112,7 @@ public class TaskSchedulerDistributorTest {
     new TaskSchedulerDistributor(1, scheduler);
     new TaskSchedulerDistributor(1, scheduler, 1);
     StripedLock sLock = new StripedLock(1);
-    new TaskSchedulerDistributor(scheduler, sLock, 1);
+    new TaskSchedulerDistributor(scheduler, sLock, 1, false);
   }
   
   @Test (expected = IllegalArgumentException.class)


### PR DESCRIPTION
This would solve #69....

What I don't like about this:
- It increases code complexity
- It causes a ton more constructors (I even marked two as deprecated because it's so crazy, those will be removed in 2.0.0)

But....
This does offer a low performance cost if you don't care about queue stats.  I barely was able to detect anything performance loss in benchmarks.  I am guessing the performance loss that does exist is the fact that we use inheritance in the TaskQueueWorker, and so the VM has to decide which function to execute.

I am reasonably happy with this implementation, but want feedback from @lwahlmeier on his opinion.  This is definitely NOT a must have, but if we are going to have it, I think this is the way to go about it for now.  In either case I plan to close #69 after this, I have wasted enough time with this problem, lol.
