### PR TITLE
Reduced code duplication by creating an abstract class that can be used for SubmiterExecutor's

### DIFF
--- a/src/main/java/org/threadly/concurrent/AbstractSubmitterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/AbstractSubmitterExecutor.java
@@ -1,0 +1,67 @@
+package org.threadly.concurrent;
+
+import java.util.concurrent.Callable;
+
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.ListenableFutureTask;
+
+/**
+ * <p>Since the conversion to a SubmitterExecutorInterface from an executor is often the 
+ * same (just using the {@link ListenableFutureTask} to wrap the task).  This class 
+ * provides an easy way to create a {@link SubmitterExecutorInterface}.  Take a look at 
+ * {@link ExecutorWrapper} for an easy example of how this is used.  In general this wont 
+ * be useful outside of Threadly developers, but must be a public interface since it is 
+ * used in sub-packages.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 1.3.0
+ */
+public abstract class AbstractSubmitterExecutor implements SubmitterExecutorInterface {
+  /**
+   * Should execute the provided task, or provide the task to a given 
+   * executor.
+   * 
+   * @param task Runnable ready to be ran
+   */
+  protected abstract void doExecute(Runnable task);
+  
+  @Override
+  public void execute(Runnable task) {
+    if (task == null) {
+      throw new IllegalArgumentException("Must provide task");
+    }
+    
+    doExecute(task);
+  }
+
+  @Override
+  public ListenableFuture<?> submit(Runnable task) {
+    return submit(task, null);
+  }
+
+  @Override
+  public <T> ListenableFuture<T> submit(Runnable task, T result) {
+    if (task == null) {
+      throw new IllegalArgumentException("Must provide task");
+    }
+    
+    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task, result);
+    
+    doExecute(lft);
+    
+    return lft;
+  }
+
+  @Override
+  public <T> ListenableFuture<T> submit(Callable<T> task) {
+    if (task == null) {
+      throw new IllegalArgumentException("Must provide task");
+    }
+    
+    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task);
+    
+    doExecute(lft);
+    
+    return lft;
+  }
+}

--- a/src/main/java/org/threadly/concurrent/ExecutorWrapper.java
+++ b/src/main/java/org/threadly/concurrent/ExecutorWrapper.java
@@ -1,23 +1,20 @@
 package org.threadly.concurrent;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
-
-import org.threadly.concurrent.future.ListenableFuture;
-import org.threadly.concurrent.future.ListenableFutureTask;
 
 /**
  * <p>A simple wrapper class for {@link Executor} implementations to 
  * provide {@link SubmitterExecutorInterface} capabilities.</p>
  * 
- * <p>In addition this implementation returns {@link ListenableFuture} 
+ * <p>In addition this implementation returns 
+ * {@link org.threadly.concurrent.future.ListenableFuture} 
  * future implementations, making it an easy way to convert your favorite 
  * executor to use ListenableFutures.</p>
  * 
  * @author jent - Mike Jensen
  * @since 1.0.0
  */
-public class ExecutorWrapper implements SubmitterExecutorInterface {
+public class ExecutorWrapper extends AbstractSubmitterExecutor {
   protected final Executor executor;
   
   /**
@@ -33,44 +30,9 @@ public class ExecutorWrapper implements SubmitterExecutorInterface {
     
     this.executor = executor;
   }
-  
+
   @Override
-  public void execute(Runnable task) {
-    if (task == null) {
-      throw new IllegalArgumentException("Must provide task");
-    }
-    
+  protected void doExecute(Runnable task) {
     executor.execute(task);
-  }
-
-  @Override
-  public ListenableFuture<?> submit(Runnable task) {
-    return submit(task, null);
-  }
-
-  @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result) {
-    if (task == null) {
-      throw new IllegalArgumentException("Must provide task");
-    }
-    
-    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task, result);
-    
-    executor.execute(lft);
-    
-    return lft;
-  }
-
-  @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task) {
-    if (task == null) {
-      throw new IllegalArgumentException("Must provide task");
-    }
-    
-    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task);
-    
-    executor.execute(lft);
-    
-    return lft;
   }
 }

--- a/src/main/java/org/threadly/concurrent/limiter/AbstractThreadPoolLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/AbstractThreadPoolLimiter.java
@@ -3,6 +3,7 @@ package org.threadly.concurrent.limiter;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.threadly.concurrent.AbstractSubmitterExecutor;
 import org.threadly.concurrent.RunnableContainerInterface;
 
 /**
@@ -12,7 +13,7 @@ import org.threadly.concurrent.RunnableContainerInterface;
  * @author jent - Mike Jensen
  * @since 1.0.0
  */
-abstract class AbstractThreadPoolLimiter {
+abstract class AbstractThreadPoolLimiter extends AbstractSubmitterExecutor {
   protected final int maxConcurrency;
   protected final String subPoolName;
   private final AtomicInteger currentlyRunning;

--- a/src/main/java/org/threadly/concurrent/limiter/ExecutorLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/ExecutorLimiter.java
@@ -1,13 +1,10 @@
 package org.threadly.concurrent.limiter;
 
 import java.util.Queue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 
 import org.threadly.concurrent.SubmitterExecutorInterface;
-import org.threadly.concurrent.future.ListenableFuture;
-import org.threadly.concurrent.future.ListenableFutureTask;
 
 /**
  * <p>This class is designed to limit how much parallel execution happens 
@@ -79,11 +76,7 @@ public class ExecutorLimiter extends AbstractThreadPoolLimiter
   }
 
   @Override
-  public void execute(Runnable task) {
-    if (task == null) {
-      throw new IllegalArgumentException("Must provide runnable");
-    }
-    
+  protected void doExecute(Runnable task) {
     LimiterRunnableWrapper lrw = new LimiterRunnableWrapper(executor, task);
     executeWrapper(lrw);
   }
@@ -99,36 +92,5 @@ public class ExecutorLimiter extends AbstractThreadPoolLimiter
   protected void addToQueue(LimiterRunnableWrapper lrw) {
     waitingTasks.add(lrw);
     consumeAvailable(); // call to consume in case task finished after first check
-  }
-
-  @Override
-  public ListenableFuture<?> submit(Runnable task) {
-    return submit(task, null);
-  }
-
-  @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result) {
-    if (task == null) {
-      throw new IllegalArgumentException("Must provide task");
-    }
-    
-    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task, result);
-    
-    execute(lft);
-    
-    return lft;
-  }
-
-  @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task) {
-    if (task == null) {
-      throw new IllegalArgumentException("Must provide task");
-    }
-    
-    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task);
-    
-    execute(lft);
-    
-    return lft;
   }
 }


### PR DESCRIPTION
Just saw an opportunity for reduced code duplication, so thought I would go ahead and propose it for master.  I think this will be useful in the future.  The only crummy part is that the abstract class has to be public since it is used from other packages (and thus will be included in the javadocs).  Hopefully it wont be confusing to others.
