### PR TITLE
Issue91 SingleThreadScheduler shutdownNow functionality (plus bug fixes)

### DIFF
--- a/src/main/java/org/threadly/concurrent/PriorityScheduledExecutor.java
+++ b/src/main/java/org/threadly/concurrent/PriorityScheduledExecutor.java
@@ -537,7 +537,9 @@ public class PriorityScheduledExecutor extends AbstractSubmitterScheduler
           while (it.hasNext()) {
             TaskWrapper tw = it.next();
             tw.cancel();
-            removedTasks.add(tw.task);
+            if (! (tw.task instanceof ShutdownRunnable)) {
+              removedTasks.add(tw.task);
+            }
           }
           lowPriorityQueue.clear();
         }
@@ -571,8 +573,10 @@ public class PriorityScheduledExecutor extends AbstractSubmitterScheduler
   }
 
   /**
-   * Stops any new tasks from being submitted to the pool.  But allows all currently scheduled 
-   * tasks to be run.  If scheduled tasks are present they will also be unable to reschedule.
+   * Stops any new tasks from being submitted to the pool.  But allows all tasks which are 
+   * submitted to execute, or scheduled (and have elapsed their delay time) to run.  If 
+   * recurring tasks are present they will also be unable to reschedule.  If shutdown or 
+   * shutdownNow has already been called, this will have no effect.
    * 
    * If you wish to not want to run any queued tasks you should use {#link shutdownNow()).
    */
@@ -1383,7 +1387,10 @@ public class PriorityScheduledExecutor extends AbstractSubmitterScheduler
   }
   
   /**
-   * <p>Runnable to be run after all current tasks to finish the shutdown sequence.</p>
+   * <p>Runnable to be run after tasks already ready to execute.  That way this can be 
+   * submitted with a .execute(Runnable) to ensure that the shutdown is fair for tasks 
+   * that were already ready to be run/executed.  Once this runs the shutdown sequence 
+   * will be finished, and no remaining asks in the queue can be executed.</p>
    * 
    * @author jent - Mike Jensen
    * @since 1.0.0

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerStatisticTracker.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerStatisticTracker.java
@@ -192,6 +192,26 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduledExecutor
     highPriorityExecutionDelay = new ConcurrentArrayList<Long>(0, endPadding);
   }
   
+  @Override
+  public List<Runnable> shutdownNow() {
+    // we must unwrap our statistic tracker runnables
+    List<Runnable> wrappedRunnables = super.shutdownNow();
+    List<Runnable> result = new ArrayList<Runnable>(wrappedRunnables.size());
+    
+    Iterator<Runnable> it = wrappedRunnables.iterator();
+    while (it.hasNext()) {
+      Runnable r = it.next();
+      if (r instanceof RunnableStatWrapper) {
+        RunnableStatWrapper statWrapper = (RunnableStatWrapper)r;
+        result.add(statWrapper.toRun);
+      } else {
+        result.add(r);
+      }
+    }
+    
+    return result;
+  }
+  
   /**
    * Clears all collected rolling statistics.  These are the statistics 
    * used for averages and are limited by window sizes.

--- a/src/main/java/org/threadly/concurrent/SingleThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/SingleThreadScheduler.java
@@ -1,5 +1,7 @@
 package org.threadly.concurrent;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -89,19 +91,14 @@ public class SingleThreadScheduler extends AbstractSubmitterScheduler
       }
     }
     
-    if (result.stopped) {
+    if (result.isStopped()) {
       throw new IllegalStateException("Scheduler has been shutdown");
     }
     
     return result.scheduler;
   }
   
-  /**
-   * Stops the scheduler from running more tasks.  Because of how the 
-   * {@link NoThreadScheduler} works, this wont actually any tasks 
-   * till after the current tick call finishes.
-   */
-  public void shutdown() {
+  private List<Runnable> shutdown(boolean stopImmediately) {
     SchedulerManager sm = sManager.get();
     if (sm == null) {
       sm = new SchedulerManager(threadFactory);
@@ -110,14 +107,38 @@ public class SingleThreadScheduler extends AbstractSubmitterScheduler
       }
     }
     
-    sm.stop();
+    return sm.stop(stopImmediately);
+  }
+
+  /**
+   * Stops any new tasks from being submitted to the pool.  But allows all tasks which are 
+   * submitted to execute, or scheduled (and have elapsed their delay time) to run.  If 
+   * recurring tasks are present they will also be unable to reschedule.  This call will 
+   * not block to wait for the shutdown of the scheduler to finish.  If shutdown or 
+   * shutdownNow has already been called, this will have no effect.
+   * 
+   * If you wish to not want to run any queued tasks you should use {#link shutdownNow()).
+   */
+  public void shutdown() {
+    shutdown(false);
+  }
+
+  /**
+   * Stops any new tasks from being submitted to the pool.  If any tasks are waiting for 
+   * execution they will be prevented from being run.  If a task is currently running it 
+   * will be allowed to finish (though this call will not block waiting for it to finish).
+   * 
+   * @return returns a list of runnables which were waiting in the queue to be run at time of shutdown
+   */
+  public List<Runnable> shutdownNow() {
+    return shutdown(true);
   }
 
   @Override
   public boolean isShutdown() {
     SchedulerManager sm = sManager.get();
     if (sm != null) {
-      return sm.stopped;
+      return sm.isStopped();
     } else {
       // if not created yet, the not shutdown
       return false;
@@ -159,44 +180,91 @@ public class SingleThreadScheduler extends AbstractSubmitterScheduler
     protected final NoThreadScheduler scheduler;
     protected final Thread execThread;
     private final Object startStopLock;
-    private volatile boolean stopped;
-    private boolean started;
+    private boolean started;  // locked around startStopLock
+    private volatile boolean shutdownStarted;
+    private volatile boolean shutdownFinished;
     
     protected SchedulerManager(ThreadFactory threadFactory) {
       scheduler = new NoThreadScheduler(true);  // true so we wont tight loop in the run
       execThread = threadFactory.newThread(this);
       startStopLock = new Object();
       started = false;
-      stopped = false;
+      shutdownStarted = false;
+      shutdownFinished = false;
     }
     
+    /**
+     * Call to check if stop has been called.
+     * 
+     * @return true if stop has been called (weather shutdown has finished or not)
+     */
     public boolean isStopped() {
-      return stopped;
+      return shutdownStarted;
     }
     
-    public void start() {
+    /**
+     * Call to start the thread to run tasks.  If already started this call will have 
+     * no effect.
+     */
+    protected void start() {
       synchronized (startStopLock) {
-        if (! started && ! stopped) {
+        if (! started && ! shutdownStarted) {
           started = true;
           execThread.start();
         }
       }
     }
     
-    public void stop() {
+    /**
+     * Call to stop the thread which is running tasks.  If this has already been stopped this call 
+     * will have no effect.  Regardless if true or false is passed in, running tasks will NOT be 
+     * Interrupted or stopped.  True will only prevent ANY extra tasks from running, while a false 
+     * will let tasks ready to run complete before shutting down.
+     * 
+     * @param stopImmediately false if the scheduler should let ready tasks run, true stops scheduler immediately
+     * @return if stopImmediately, this will include tasks which were queued to run, otherwise will be an empty list
+     */
+    protected List<Runnable> stop(boolean stopImmediately) {
       synchronized (startStopLock) {
-        stopped = true;
-        
-        if (started) {
-          // send interrupt to unblock if currently waiting for tasks
-          execThread.interrupt();
+        if (! shutdownStarted) {
+          shutdownStarted = true;
+          
+          if (started) {
+            if (stopImmediately) {
+              return finishShutdown();
+            } else {
+              /* add to the end of the ready to execute queue a task which 
+               * will finish the shutdown of the scheduler. 
+               */
+              scheduler.execute(new Runnable() {
+                @Override
+                public void run() {
+                  finishShutdown();
+                }
+              });
+            }
+          }
         }
       }
+
+      return Collections.emptyList();
+    }
+    
+    /**
+     * Finishes shutdown process, and clears any tasks that remain in the queue.
+     * 
+     * @return a list of runnables which remained in the queue after shutdown
+     */
+    private List<Runnable> finishShutdown() {
+      shutdownFinished = true;
+      scheduler.cancelTick();
+      
+      return scheduler.clearTasks();
     }
     
     @Override
     public void run() {
-      while (! stopped) {
+      while (! shutdownFinished) {
         try {
           scheduler.tick();
         } catch (RuntimeException e) {

--- a/src/test/java/org/threadly/concurrent/SchedulerServiceInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/SchedulerServiceInterfaceTest.java
@@ -1,8 +1,7 @@
 package org.threadly.concurrent;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.threadly.TestConstants.SCHEDULE_DELAY;
+import static org.junit.Assert.*;
+import static org.threadly.TestConstants.*;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/threadly/concurrent/SingleThreadSchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/SingleThreadSchedulerTest.java
@@ -1,12 +1,16 @@
 package org.threadly.concurrent;
 
 import static org.junit.Assert.*;
+import static org.threadly.TestConstants.*;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Test;
+import org.threadly.BlockingTestRunnable;
+import org.threadly.test.concurrent.TestCondition;
 import org.threadly.test.concurrent.TestRunnable;
 
 @SuppressWarnings("javadoc")
@@ -30,12 +34,96 @@ public class SingleThreadSchedulerTest extends SchedulerServiceInterfaceTest {
     sts.shutdown();
     
     assertTrue(sts.isShutdown());
+    
+    sts = new SingleThreadScheduler();
+    sts.shutdownNow();
+    
+    assertTrue(sts.isShutdown());
+  }
+  
+  @Test
+  public void shutdownTest() {
+    SingleThreadScheduler sts = new SingleThreadScheduler();
+    TestRunnable lastRunnable = null;
+    for (int i = 0; i < TEST_QTY; i++) {
+      /* adding a run time to have chances that there will be 
+       * runnables waiting to execute after shutdown call.
+       */
+      lastRunnable = new TestRunnable(5);
+      sts.execute(lastRunnable);
+    }
+    
+    sts.shutdown();
+    
+    // runnable should finish
+    lastRunnable.blockTillFinished();
+  }
+  
+  @Test
+  public void shutdownRecurringTest() {
+    final SingleThreadScheduler sts = new SingleThreadScheduler();
+    TestRunnable tr = new TestRunnable();
+    sts.scheduleWithFixedDelay(tr, 0, 0);
+    
+    tr.blockTillStarted();
+    
+    sts.shutdown();
+    
+    new TestCondition() {
+      @Override
+      public boolean get() {
+        return ! sts.sManager.get().execThread.isAlive();
+      }
+    }.blockTillTrue();
+  }
+  
+  @Test
+  public void shutdownNowTest() {
+    SingleThreadScheduler sts = new SingleThreadScheduler();
+    
+    // execute one runnable which will not complete
+    BlockingTestRunnable btr = new BlockingTestRunnable();
+    sts.execute(btr);
+
+    try {
+      List<TestRunnable> expectedRunnables = new ArrayList<TestRunnable>(TEST_QTY);
+      for (int i = 0; i < TEST_QTY; i++) {
+        TestRunnable tr = new TestRunnable();
+        expectedRunnables.add(tr);
+        sts.execute(tr);
+      }
+      
+      btr.blockTillStarted();
+      
+      List<Runnable> canceledRunnables = sts.shutdownNow();
+      // unblock now so that others can run (if the unit test fails)
+      btr.unblock();
+      
+      assertNotNull(canceledRunnables);
+      assertTrue(canceledRunnables.containsAll(expectedRunnables));
+      assertTrue(expectedRunnables.containsAll(canceledRunnables));
+      
+      Iterator<TestRunnable> it = expectedRunnables.iterator();
+      while (it.hasNext()) {
+        assertEquals(0, it.next().getRunCount());
+      }
+    } finally {
+      btr.unblock();
+    }
   }
   
   @Test (expected = IllegalStateException.class)
   public void shutdownExecutionFail() {
     SingleThreadScheduler sts = new SingleThreadScheduler();
     sts.shutdown();
+    
+    sts.execute(new TestRunnable());
+  }
+  
+  @Test (expected = IllegalStateException.class)
+  public void shutdownNowExecutionFail() {
+    SingleThreadScheduler sts = new SingleThreadScheduler();
+    sts.shutdownNow();
     
     sts.execute(new TestRunnable());
   }


### PR DESCRIPTION
 There is a bit more included in this commit than I originally expected.  This adds "shutdownNow" to the SingleThreadScheduler.  But it also improves the logic for the normal "shutdown" call as well.

The key to adding this implementation is adding a call to interrupt the .tick() call in NoThreadScheduler (which is only a protected visible function).

Once I wrote unit tests for the SingleThreadScheduler, I added similar unit tests to the PriorityScheduledExecutor unit tests.  This uncovered a couple other small defects/defencies in both the PriorityScheduledExecutor as well as the PrioritySchedulerStatisticTracker.  So those improvements are also included in this pull request.

There is a lot in this, so I will comment the changes to indicate what is going on.
