### PR TITLE
Fix for ExceptionUtils.makeRuntime where the makeRuntime call was included in stack

### DIFF
--- a/src/main/java/org/threadly/util/ExceptionUtils.java
+++ b/src/main/java/org/threadly/util/ExceptionUtils.java
@@ -140,7 +140,7 @@ public class ExceptionUtils {
       StackTraceElement[] originalstack = result.getStackTrace();
       StackTraceElement[] newStack = new StackTraceElement[originalstack.length - 1];
       
-      System.arraycopy(originalstack, 0, 
+      System.arraycopy(originalstack, 1, 
                        newStack, 0, newStack.length);
       
       result.setStackTrace(newStack);

--- a/src/test/java/org/threadly/util/ExceptionUtilsTest.java
+++ b/src/test/java/org/threadly/util/ExceptionUtilsTest.java
@@ -328,7 +328,7 @@ public class ExceptionUtilsTest {
     // verify stack trace does not contain Util.makeRuntime inside it for when it created a new exception
     StackTraceElement[] stack = resultException.getStackTrace();
     for (StackTraceElement ste : stack) {
-      assertFalse(ste.getClass().getName().equals(ExceptionUtils.class.getName()));
+      assertFalse(ste.getClassName().equals(ExceptionUtils.class.getName()));
     }
 
     // verify the cause was our original exception


### PR DESCRIPTION
I was leaving off the base stack element, instead of removing from the head stack element.  In addition the unit tests were not testing what I thought they were (so those were fixed first to fail, and then the fix was applied).
