### PR TITLE
Performance improvement in PriorityScheduler from seperate execute and schedule queues

### DIFF
--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerServiceWrapper.java
@@ -71,7 +71,11 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     OneTimeTaskWrapper ottw = pScheduler.new OneTimeTaskWrapper(taskFuture, 
                                                                 pScheduler.getDefaultPriority(), 
                                                                 delayInMillis);
-    pScheduler.addToQueue(ottw);
+    if (delayInMillis == 0) {
+      pScheduler.addToExecuteQueue(ottw);
+    } else {
+      pScheduler.addToScheduleQueue(ottw);
+    }
     
     return new ScheduledFutureDelegate<Object>(taskFuture, ottw);
   }
@@ -82,7 +86,11 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     OneTimeTaskWrapper ottw = pScheduler.new OneTimeTaskWrapper(taskFuture, 
                                                                 pScheduler.getDefaultPriority(), 
                                                                 delayInMillis);
-    pScheduler.addToQueue(ottw);
+    if (delayInMillis == 0) {
+      pScheduler.addToExecuteQueue(ottw);
+    } else {
+      pScheduler.addToScheduleQueue(ottw);
+    }
     
     return new ScheduledFutureDelegate<V>(taskFuture, ottw);
   }
@@ -98,7 +106,7 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     RecurringDelayTaskWrapper rdtw = pScheduler.new RecurringDelayTaskWrapper(taskFuture, 
                                                                               pScheduler.getDefaultPriority(), 
                                                                               initialDelayInMs, delayInMs);
-    pScheduler.addToQueue(rdtw);
+    pScheduler.addToScheduleQueue(rdtw);
     
     return new ScheduledFutureDelegate<Object>(taskFuture, rdtw);
   }
@@ -114,7 +122,7 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     RecurringRateTaskWrapper rrtw = pScheduler.new RecurringRateTaskWrapper(taskFuture, 
                                                                             pScheduler.getDefaultPriority(), 
                                                                             initialDelayInMillis, periodInMillis);
-    pScheduler.addToQueue(rrtw);
+    pScheduler.addToScheduleQueue(rrtw);
     
     return new ScheduledFutureDelegate<Object>(taskFuture, rrtw);
   }

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerStatisticTracker.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerStatisticTracker.java
@@ -271,13 +271,13 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler {
         while (getCurrentPoolSize() >= getMaxPoolSize() && 
                availableWorkers.size() < WORKER_CONTENTION_LEVEL &&   // only care if there is worker contention
                ! getShutdownFinishing() &&
-               ! highPriorityQueue.isEmpty() && // if there are no waiting high priority tasks, we don't care 
+               ! highPriorityConsumer.isQueueEmpty() && 
                (waitAmount = task.getDelayEstimateInMillis() - lastHighDelay) > LOW_PRIORITY_WAIT_TOLLERANCE_IN_MS) {
           workersLock.wait(waitAmount);
           Clock.systemNanoTime(); // update for getDelayEstimateInMillis
         }
         // check if we should reset the high delay for future low priority tasks
-        if (highPriorityQueue.isEmpty()) {
+        if (highPriorityConsumer.isQueueEmpty()) {
           lastHighDelay = 0;
         }
         

--- a/src/main/java/org/threadly/concurrent/collections/ConsumerIterator.java
+++ b/src/main/java/org/threadly/concurrent/collections/ConsumerIterator.java
@@ -5,10 +5,13 @@ package org.threadly.concurrent.collections;
  * function has been replaced with {@link #remove()} to consume items as it iterates over the 
  * structure.</p>
  * 
+ * @deprecated There is no replacement, this was only used in the now deprecated {@link DynamicDelayQueue}
+ * 
  * @author jent - Mike Jensen
  * @since 1.0.0
  * @param <E> Parameter for types of item to be returned by {@link #remove()} and {@link #peek()}
  */
+@Deprecated
 public interface ConsumerIterator<E> {
   /**
    * Check if there are additional items to consume.

--- a/src/main/java/org/threadly/concurrent/collections/DynamicDelayQueue.java
+++ b/src/main/java/org/threadly/concurrent/collections/DynamicDelayQueue.java
@@ -22,10 +22,13 @@ import org.threadly.util.ListUtils;
  * <p>In order to allow an item to be repositioned like this, the item must implement the 
  * {@link DynamicDelayedUpdater} interface.</p>
  * 
+ * @deprecated There is no replacement, please open a github issue if this class is useful to you
+ * 
  * @author jent - Mike Jensen
  * @since 1.0.0
  * @param <T> Parameter to indicate what type of item is contained in the queue
  */
+@Deprecated
 public class DynamicDelayQueue<T extends Delayed> implements Queue<T>, 
                                                              BlockingQueue<T> {
   // tuned for performance

--- a/src/main/java/org/threadly/concurrent/collections/DynamicDelayedUpdater.java
+++ b/src/main/java/org/threadly/concurrent/collections/DynamicDelayedUpdater.java
@@ -7,9 +7,12 @@ package org.threadly.concurrent.collections;
  * Threadly uses an idea of delay items which can adjust there delay time, but this must be done 
  * in conjunction with the DynamicDelayQueue.</p>
  * 
+ * @deprecated There is no replacement, please open a github issue if this class is useful to you
+ * 
  * @author jent - Mike Jensen
  * @since 1.0.0
  */
+@Deprecated
 public interface DynamicDelayedUpdater {
   /**
    * Call that will happen from the Queue when it is ready for the item to update or changes it's 

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
@@ -13,6 +13,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.threadly.concurrent.PriorityScheduler.OneTimeTaskWrapper;
 import org.threadly.concurrent.PriorityScheduler.QueueManager;
 import org.threadly.concurrent.PriorityScheduler.RecurringTaskWrapper;
 import org.threadly.concurrent.PriorityScheduler.TaskWrapper;
@@ -42,7 +43,7 @@ public class PrioritySchedulerQueueManagerTest {
   @Before
   public void setup() {
     queueManager = pScheduler.new QueueManager(new ConfigurableThreadFactory(), 
-                                               THREAD_NAME, TaskPriority.High) {
+                                               THREAD_NAME) {
       @Override
       protected void startupService() {
         // we override this so we can avoid starting threads in these tests
@@ -66,15 +67,15 @@ public class PrioritySchedulerQueueManagerTest {
   @Test (expected = IllegalThreadStateException.class)
   public void threadFactoryReturnRunningThreadFail() {
     queueManager = pScheduler.new QueueManager(new StartingThreadFactory(), 
-                                               THREAD_NAME, TaskPriority.High);
+                                               THREAD_NAME);
     queueManager.start();
   }
   
   @Test
   public void removeCallableTest() {
     TestCallable callable = new TestCallable();
-    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new ListenableFutureTask<Object>(false, callable),
-                                                         TaskPriority.High, 0);
+    OneTimeTaskWrapper task = pScheduler.new OneTimeTaskWrapper(new ListenableFutureTask<Object>(false, callable),
+                                                                TaskPriority.High, 0);
     
     assertFalse(queueManager.remove(callable));
     
@@ -92,7 +93,7 @@ public class PrioritySchedulerQueueManagerTest {
   @Test
   public void removeRunnableTest() {
     TestRunnable runnable = new TestRunnable();
-    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(runnable, TaskPriority.High, 0);
+    OneTimeTaskWrapper task = pScheduler.new OneTimeTaskWrapper(runnable, TaskPriority.High, 0);
     
     assertFalse(queueManager.remove(runnable));
     
@@ -109,7 +110,7 @@ public class PrioritySchedulerQueueManagerTest {
   
   @Test
   public void addExecuteTest() {
-    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    OneTimeTaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
     
     queueManager.addExecute(task);
     
@@ -169,7 +170,7 @@ public class PrioritySchedulerQueueManagerTest {
   
   @Test
   public void getNextTaskExecuteOnlyTest() throws InterruptedException {
-    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    OneTimeTaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
     
     queueManager.addExecute(task);
     
@@ -201,7 +202,7 @@ public class PrioritySchedulerQueueManagerTest {
   
   @Test
   public void getNextTaskExecuteAheadOfScheduledTest() throws InterruptedException {
-    TaskWrapper executeTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    OneTimeTaskWrapper executeTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
     queueManager.addExecute(executeTask);
     TestUtils.blockTillClockAdvances();
     TaskWrapper scheduleTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
@@ -216,7 +217,7 @@ public class PrioritySchedulerQueueManagerTest {
     TaskWrapper scheduleTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
     queueManager.addScheduled(scheduleTask);
     TestUtils.blockTillClockAdvances();
-    TaskWrapper executeTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    OneTimeTaskWrapper executeTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
     queueManager.addExecute(executeTask);
 
     assertTrue(scheduleTask == queueManager.getNextTask());

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
@@ -1,0 +1,225 @@
+package org.threadly.concurrent;
+
+import static org.junit.Assert.*;
+import static org.threadly.TestConstants.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.threadly.concurrent.PriorityScheduler.QueueManager;
+import org.threadly.concurrent.PriorityScheduler.RecurringTaskWrapper;
+import org.threadly.concurrent.PriorityScheduler.TaskWrapper;
+import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.test.concurrent.TestRunnable;
+import org.threadly.test.concurrent.TestUtils;
+import org.threadly.util.Clock;
+
+@SuppressWarnings("javadoc")
+public class PrioritySchedulerQueueManagerTest {
+  private static final String THREAD_NAME = "fooThread";
+  private static PriorityScheduler pScheduler;
+  
+  @BeforeClass
+  public static void setupClass() {
+    pScheduler = new PriorityScheduler(1, 1, 1000);
+  }
+  
+  @AfterClass
+  public static void tearDownClass() {
+    pScheduler.shutdownNow();
+    pScheduler = null;
+  }
+  
+  private QueueManager queueManager;
+  
+  @Before
+  public void setup() {
+    queueManager = pScheduler.new QueueManager(new ConfigurableThreadFactory(), 
+                                               THREAD_NAME, TaskPriority.High) {
+      @Override
+      protected void startupService() {
+        // we override this so we can avoid starting threads in these tests
+        runningThread = Thread.currentThread();
+      }
+
+      @Override
+      protected void shutdownService() {
+        // override since the service was never started
+        runningThread = null;
+      }
+    };
+  }
+  
+  @After
+  public void tearDown() {
+    queueManager.stopIfRunning();
+    queueManager = null;
+  }
+  
+  @Test (expected = IllegalThreadStateException.class)
+  public void threadFactoryReturnRunningThreadFail() {
+    queueManager = pScheduler.new QueueManager(new StartingThreadFactory(), 
+                                               THREAD_NAME, TaskPriority.High);
+    queueManager.start();
+  }
+  
+  @Test
+  public void removeCallableTest() {
+    TestCallable callable = new TestCallable();
+    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new ListenableFutureTask<Object>(false, callable),
+                                                         TaskPriority.High, 0);
+    
+    assertFalse(queueManager.remove(callable));
+    
+    queueManager.executeQueue.add(task);
+
+    assertTrue(queueManager.remove(callable));
+    assertFalse(queueManager.remove(callable));
+    
+    queueManager.scheduleQueue.addFirst(task);
+
+    assertTrue(queueManager.remove(callable));
+    assertFalse(queueManager.remove(callable));
+  }
+  
+  @Test
+  public void removeRunnableTest() {
+    TestRunnable runnable = new TestRunnable();
+    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(runnable, TaskPriority.High, 0);
+    
+    assertFalse(queueManager.remove(runnable));
+    
+    queueManager.executeQueue.add(task);
+
+    assertTrue(queueManager.remove(runnable));
+    assertFalse(queueManager.remove(runnable));
+    
+    queueManager.scheduleQueue.addFirst(task);
+
+    assertTrue(queueManager.remove(runnable));
+    assertFalse(queueManager.remove(runnable));
+  }
+  
+  @Test
+  public void addExecuteTest() {
+    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    
+    queueManager.addExecute(task);
+    
+    assertTrue(queueManager.isRunning());
+    assertEquals(1, queueManager.executeQueue.size());
+    assertEquals(0, queueManager.scheduleQueue.size());
+  }
+  
+  @Test
+  public void addScheduledTest() {
+    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 10);
+    
+    queueManager.addScheduled(task);
+    
+    assertTrue(queueManager.isRunning());
+    assertEquals(0, queueManager.executeQueue.size());
+    assertEquals(1, queueManager.scheduleQueue.size());
+  }
+  
+  @Test
+  public void addScheduledOrderTest() {
+    List<TaskWrapper> orderedList = new ArrayList<TaskWrapper>(TEST_QTY);
+    for (int i = 0; i < TEST_QTY; i++) {
+      orderedList.add(pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, i));
+    }
+    List<TaskWrapper> randomList = new ArrayList<TaskWrapper>(orderedList);
+    Collections.shuffle(randomList);
+    
+    Iterator<TaskWrapper> it = randomList.iterator();
+    while (it.hasNext()) {
+      queueManager.addScheduled(it.next());
+    }
+    
+    Iterator<TaskWrapper> expectedIt = orderedList.iterator();
+    Iterator<TaskWrapper> resultIt = queueManager.scheduleQueue.iterator();
+    while (expectedIt.hasNext()) {
+      assertTrue(expectedIt.next() == resultIt.next());
+    }
+  }
+  
+  @Test
+  public void addScheduledLastTest() {
+    RecurringTaskWrapper task = pScheduler.new RecurringDelayTaskWrapper(new TestRunnable(), 
+                                                                         TaskPriority.High, 10, 10);
+    
+    queueManager.addScheduledLast(task);
+    
+    assertFalse(queueManager.isRunning());
+    assertEquals(0, queueManager.executeQueue.size());
+    assertEquals(1, queueManager.scheduleQueue.size());
+  }
+  
+  @Test
+  public void getNextTaskNotRunningTest() throws InterruptedException {
+    assertNull(queueManager.getNextTask());
+  }
+  
+  @Test
+  public void getNextTaskExecuteOnlyTest() throws InterruptedException {
+    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    
+    queueManager.addExecute(task);
+    
+    assertTrue(task == queueManager.getNextTask());
+  }
+  
+  @Test
+  public void getNextTaskScheduleOnlyTest() throws InterruptedException {
+    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    
+    queueManager.addScheduled(task);
+    
+    assertTrue(task == queueManager.getNextTask());
+  }
+  
+  @Test
+  public void getNextTaskScheduleDelayTest() throws InterruptedException {
+    TaskWrapper task = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, DELAY_TIME);
+    queueManager.addScheduled(task);
+    
+    TaskWrapper resultTask;
+    long startTime = Clock.accurateForwardProgressingMillis();
+    resultTask = queueManager.getNextTask();
+    long endTime = Clock.accurateForwardProgressingMillis();
+    
+    assertTrue(task == resultTask);
+    assertTrue((endTime - startTime) >= DELAY_TIME);
+  }
+  
+  @Test
+  public void getNextTaskExecuteAheadOfScheduledTest() throws InterruptedException {
+    TaskWrapper executeTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    queueManager.addExecute(executeTask);
+    TestUtils.blockTillClockAdvances();
+    TaskWrapper scheduleTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    queueManager.addScheduled(scheduleTask);
+
+    assertTrue(executeTask == queueManager.getNextTask());
+    assertTrue(scheduleTask == queueManager.getNextTask());
+  }
+  
+  @Test
+  public void getNextTaskScheduledAheadOfExecuteTest() throws InterruptedException {
+    TaskWrapper scheduleTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    queueManager.addScheduled(scheduleTask);
+    TestUtils.blockTillClockAdvances();
+    TaskWrapper executeTask = pScheduler.new OneTimeTaskWrapper(new TestRunnable(), TaskPriority.High, 0);
+    queueManager.addExecute(executeTask);
+
+    assertTrue(scheduleTask == queueManager.getNextTask());
+    assertTrue(executeTask == queueManager.getNextTask());
+  }
+}

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerTest.java
@@ -427,17 +427,21 @@ public class PrioritySchedulerTest extends SchedulerServiceInterfaceTest {
     try {
       PriorityScheduler result = factory.makePriorityScheduler(1, 1, 1000);
       // add directly to avoid starting the consumer
-      result.highPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                 TaskPriority.High, 0));
-      result.highPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                 TaskPriority.High, 0));
+      result.highPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.High, 0));
+      result.highPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.High, 0));
       
       assertEquals(2, result.getScheduledTaskCount());
       
-      result.lowPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                TaskPriority.Low, 0));
-      result.lowPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                TaskPriority.Low, 0));
+      result.lowPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.Low, 0));
+      result.lowPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.Low, 0));
       
       assertEquals(4, result.getScheduledTaskCount());
       assertEquals(4, result.getScheduledTaskCount(null));
@@ -452,17 +456,21 @@ public class PrioritySchedulerTest extends SchedulerServiceInterfaceTest {
     try {
       PriorityScheduler result = factory.makePriorityScheduler(1, 1, 1000);
       // add directly to avoid starting the consumer
-      result.highPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                 TaskPriority.High, 0));
-      result.highPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                 TaskPriority.High, 0));
+      result.highPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.High, 0));
+      result.highPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.High, 0));
       
       assertEquals(0, result.getScheduledTaskCount(TaskPriority.Low));
       
-      result.lowPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                TaskPriority.Low, 0));
-      result.lowPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                TaskPriority.Low, 0));
+      result.lowPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.Low, 0));
+      result.lowPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.Low, 0));
       
       assertEquals(2, result.getScheduledTaskCount(TaskPriority.Low));
     } finally {
@@ -476,17 +484,21 @@ public class PrioritySchedulerTest extends SchedulerServiceInterfaceTest {
     try {
       PriorityScheduler result = factory.makePriorityScheduler(1, 1, 1000);
       // add directly to avoid starting the consumer
-      result.highPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                 TaskPriority.High, 0));
-      result.highPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                 TaskPriority.High, 0));
+      result.highPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.High, 0));
+      result.highPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.High, 0));
       
       assertEquals(2, result.getScheduledTaskCount(TaskPriority.High));
       
-      result.lowPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                TaskPriority.Low, 0));
-      result.lowPriorityQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                TaskPriority.Low, 0));
+      result.lowPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.Low, 0));
+      result.lowPriorityConsumer
+            .executeQueue.add(result.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                            TaskPriority.Low, 0));
       
       assertEquals(2, result.getScheduledTaskCount(TaskPriority.High));
     } finally {
@@ -737,12 +749,13 @@ public class PrioritySchedulerTest extends SchedulerServiceInterfaceTest {
       PriorityScheduler scheduler = priorityFactory.makePriorityScheduler(1, 1, 1000);
       scheduler.prestartAllCoreThreads();
       int behindWaitTime = -1 * (DELAY_TIME + PriorityScheduler.LOW_PRIORITY_WAIT_TOLLERANCE_IN_MS + 1);
-      scheduler.highPriorityQueue.add(scheduler.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                                       TaskPriority.High, 
-                                                                       behindWaitTime));
+      scheduler.highPriorityConsumer
+               .scheduleQueue.add(scheduler.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                                   TaskPriority.High, 
+                                                                   behindWaitTime));
       // this will start the consumer, allowing the previous task to get a worker
-      scheduler.addToQueue(scheduler.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                            TaskPriority.High, 1000));
+      scheduler.addToScheduleQueue(scheduler.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                                    TaskPriority.High, 1000));
       
       TestRunnable lowPriorityRunnable = new TestRunnable();
       scheduler.execute(lowPriorityRunnable, TaskPriority.Low);
@@ -992,8 +1005,7 @@ public class PrioritySchedulerTest extends SchedulerServiceInterfaceTest {
       new TestCondition() {
         @Override
         public boolean get() {
-          int queuedTaskQty = scheduler.lowPriorityQueue.size() + scheduler.highPriorityQueue.size();
-          return queuedTaskQty == expectedRunnables.size();
+          return scheduler.getScheduledTaskCount() == expectedRunnables.size();
         }
       }.blockTillTrue();
       
@@ -1057,21 +1069,21 @@ public class PrioritySchedulerTest extends SchedulerServiceInterfaceTest {
       assertFalse(scheduler.highPriorityConsumer.isRunning());
       assertFalse(scheduler.lowPriorityConsumer.isRunning());
       
-      scheduler.addToQueue(scheduler.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                            TaskPriority.High, 
-                                                            taskDelay));
+      scheduler.addToScheduleQueue(scheduler.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                                    TaskPriority.High, 
+                                                                    taskDelay));
 
-      assertEquals(1, scheduler.highPriorityQueue.size());
-      assertEquals(0, scheduler.lowPriorityQueue.size());
+      assertEquals(1, scheduler.highPriorityConsumer.scheduleQueue.size());
+      assertEquals(0, scheduler.lowPriorityConsumer.scheduleQueue.size());
       assertTrue(scheduler.highPriorityConsumer.isRunning());
       assertFalse(scheduler.lowPriorityConsumer.isRunning());
       
-      scheduler.addToQueue(scheduler.new OneTimeTaskWrapper(new TestRunnable(), 
-                                                            TaskPriority.Low, 
-                                                            taskDelay));
+      scheduler.addToScheduleQueue(scheduler.new OneTimeTaskWrapper(new TestRunnable(), 
+                                                                    TaskPriority.Low, 
+                                                                    taskDelay));
 
-      assertEquals(1, scheduler.highPriorityQueue.size());
-      assertEquals(1, scheduler.lowPriorityQueue.size());
+      assertEquals(1, scheduler.highPriorityConsumer.scheduleQueue.size());
+      assertEquals(1, scheduler.lowPriorityConsumer.scheduleQueue.size());
       assertTrue(scheduler.highPriorityConsumer.isRunning());
       assertTrue(scheduler.lowPriorityConsumer.isRunning());
     } finally {

--- a/src/test/java/org/threadly/concurrent/collections/DynamicDelayQueueTest.java
+++ b/src/test/java/org/threadly/concurrent/collections/DynamicDelayQueueTest.java
@@ -19,7 +19,7 @@ import org.threadly.concurrent.TestDelayed;
 import org.threadly.concurrent.collections.DynamicDelayQueue;
 import org.threadly.util.Clock;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class DynamicDelayQueueTest {
   private DynamicDelayQueue<TestDelayed> testQueue;
   


### PR DESCRIPTION
This uses some lessons learned from NoThreadScheduler about a possible performance improvement from having a seperate execute queue, and a schedule queue.  This reduces the lock contention, but greatly increases the code complexity.  Because of that, this change is pretty high risk.  It completely changes queue management in the PriorityScheduler.  I have tried to deal with some of that risk by trying to ensure high unit testing.  Needless to say we may want this as only a SNAPSHOT for some time.

The fun stuff....Here is the improvement in the benchmarks (each one for the full cycle of add, run, finish):
  Execute Task   - 14.6% improvement
  Recurring task -  4.1% improvement
  Scheduled task -  3.6% improvement

...at least some improvement in every benchmark we currently have