### PR TITLE
This resolves issue #126

### DIFF
--- a/src/main/java/org/threadly/concurrent/AbstractService.java
+++ b/src/main/java/org/threadly/concurrent/AbstractService.java
@@ -87,11 +87,25 @@ public abstract class AbstractService {
   protected abstract void shutdownService();
   
   /**
-   * Call to check if the service has been started, and not shutdown yet.
+   * Call to check if the service has been started, and not shutdown yet.  If you need a check 
+   * that will be consistent while both new and while running please see {@link #hasBeenStopped()}.
    * 
    * @return {@code true} if the service is currently running
    */
   public boolean isRunning() {
     return state.get() == 1;
+  }
+  
+  /**
+   * Call to check if the service has been stopped (and thus can no longer be used).  This is 
+   * different from {@link #isRunning()} in that it will return {@code false} until 
+   * {@link #stop()} or {@link #stopIfRunning()} has been invoked.  Thus allowing you to make a 
+   * check that's state will be consistent when it is new and while it is running.
+   * 
+   * @return {@code true} if the server has been stopped
+   * @since 3.5.0
+   */
+  public boolean hasBeenStopped() {
+    return state.get() == 2;
   }
 }

--- a/src/main/java/org/threadly/concurrent/SingleThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/SingleThreadScheduler.java
@@ -89,7 +89,7 @@ public class SingleThreadScheduler extends AbstractSubmitterScheduler
   protected NoThreadScheduler getRunningScheduler() throws RejectedExecutionException {
     SchedulerManager result = getSchedulerManager();
     
-    if (! result.isRunning()) {
+    if (result.hasBeenStopped()) {
       throw new RejectedExecutionException("Thread pool shutdown");
     }
     
@@ -198,7 +198,7 @@ public class SingleThreadScheduler extends AbstractSubmitterScheduler
   public boolean isShutdown() {
     SchedulerManager sm = sManager.get();
     if (sm != null) {
-      return ! sm.isRunning();
+      return sm.hasBeenStopped();
     } else {
       // if not created yet, the not shutdown
       return false;

--- a/src/main/java/org/threadly/concurrent/SingleThreadSchedulerServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/SingleThreadSchedulerServiceWrapper.java
@@ -47,7 +47,7 @@ public class SingleThreadSchedulerServiceWrapper extends AbstractExecutorService
   @Override
   public boolean isTerminated() {
     SchedulerManager sm = singleThreadScheduler.sManager.get();
-    if (sm == null || sm.isRunning()) {
+    if (sm == null || ! sm.hasBeenStopped()) {
       return false;
     } else {
       return ! sm.execThread.isAlive();

--- a/src/test/java/org/threadly/concurrent/AbstractServiceTest.java
+++ b/src/test/java/org/threadly/concurrent/AbstractServiceTest.java
@@ -23,12 +23,22 @@ public class AbstractServiceTest {
   }
   
   @Test
-  public void startTest() {
+  public void startAndIsRunningTest() {
     assertFalse(service.isRunning());
     
     service.start();
     
     assertTrue(service.isRunning());
+  }
+  
+  @Test
+  public void hasBeenStoppedTest() {
+    assertFalse(service.hasBeenStopped());
+    service.start();
+    assertFalse(service.hasBeenStopped());
+    
+    service.stop();
+    assertTrue(service.hasBeenStopped());
   }
   
   @Test (expected = IllegalStateException.class)


### PR DESCRIPTION
The problem was that we don't "start" the SchedulerService until after we have been able to set the AtomicReference.
We do this because we don't want to start a bunch of threads that we will just have to shut down until the reference is set.  To solve this I added a new function in AbstractService called: hasBeenShutdown().  That way the state for both new and running will be consistent, and we can continue to provide it tasks before the thread to start it has been executed.