### PR TITLE
This resolves issue #126

### DIFF
--- a/src/main/java/org/threadly/concurrent/AbstractService.java
+++ b/src/main/java/org/threadly/concurrent/AbstractService.java
@@ -87,11 +87,25 @@ public abstract class AbstractService {
   protected abstract void shutdownService();
   
   /**
-   * Call to check if the service has been started, and not shutdown yet.
+   * Call to check if the service has been started, and not shutdown yet.  If you need a check 
+   * that will be consistent while both new and while running please see {@link #hasBeenStopped()}.
    * 
    * @return {@code true} if the service is currently running
    */
   public boolean isRunning() {
     return state.get() == 1;
+  }
+  
+  /**
+   * Call to check if the service has been stopped (and thus can no longer be used).  This is 
+   * different from {@link #isRunning()} in that it will return {@code false} until 
+   * {@link #stop()} or {@link #stopIfRunning()} has been invoked.  Thus allowing you to make a 
+   * check that's state will be consistent when it is new and while it is running.
+   * 
+   * @return {@code true} if the server has been stopped
+   * @since 3.5.0
+   */
+  public boolean hasBeenStopped() {
+    return state.get() == 2;
   }
 }

--- a/src/main/java/org/threadly/concurrent/AbstractService.java
+++ b/src/main/java/org/threadly/concurrent/AbstractService.java
@@ -88,7 +88,7 @@ public abstract class AbstractService {
   
   /**
    * Call to check if the service has been started, and not shutdown yet.  If you need a check 
-   * that will be consistent while both new and while running please see {@link #hasBeenStopped()}.
+   * that will be consistent while both new and while running please see {@link #hasStopped()}.
    * 
    * @return {@code true} if the service is currently running
    */
@@ -105,7 +105,7 @@ public abstract class AbstractService {
    * @return {@code true} if the server has been stopped
    * @since 3.5.0
    */
-  public boolean hasBeenStopped() {
+  public boolean hasStopped() {
     return state.get() == 2;
   }
 }

--- a/src/main/java/org/threadly/concurrent/SingleThreadSchedulerServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/SingleThreadSchedulerServiceWrapper.java
@@ -47,7 +47,7 @@ public class SingleThreadSchedulerServiceWrapper extends AbstractExecutorService
   @Override
   public boolean isTerminated() {
     SchedulerManager sm = singleThreadScheduler.sManager.get();
-    if (sm == null || sm.isRunning()) {
+    if (sm == null || ! sm.hasBeenStopped()) {
       return false;
     } else {
       return ! sm.execThread.isAlive();

--- a/src/test/java/org/threadly/concurrent/AbstractServiceTest.java
+++ b/src/test/java/org/threadly/concurrent/AbstractServiceTest.java
@@ -23,12 +23,22 @@ public class AbstractServiceTest {
   }
   
   @Test
-  public void startTest() {
+  public void startAndIsRunningTest() {
     assertFalse(service.isRunning());
     
     service.start();
     
     assertTrue(service.isRunning());
+  }
+  
+  @Test
+  public void hasBeenStoppedTest() {
+    assertFalse(service.hasBeenStopped());
+    service.start();
+    assertFalse(service.hasBeenStopped());
+    
+    service.stop();
+    assertTrue(service.hasBeenStopped());
   }
   
   @Test (expected = IllegalStateException.class)

--- a/src/test/java/org/threadly/concurrent/AbstractServiceTest.java
+++ b/src/test/java/org/threadly/concurrent/AbstractServiceTest.java
@@ -32,13 +32,13 @@ public class AbstractServiceTest {
   }
   
   @Test
-  public void hasBeenStoppedTest() {
-    assertFalse(service.hasBeenStopped());
+  public void hasStoppedTest() {
+    assertFalse(service.hasStopped());
     service.start();
-    assertFalse(service.hasBeenStopped());
+    assertFalse(service.hasStopped());
     
     service.stop();
-    assertTrue(service.hasBeenStopped());
+    assertTrue(service.hasStopped());
   }
   
   @Test (expected = IllegalStateException.class)


### PR DESCRIPTION
The problem was that we don't "start" the SchedulerService until after we have been able to set the AtomicReference.  We do this because we don't want to start a bunch of threads that we will just have to shut down until the reference is set.

This pointed to a defecency in AbstractService, which is an inability to check if a service is in either a new or running state.  To solve that I created: hasBeenShutdown().  That way the state for both new and running will be consistent, and we can continue to use it with the idea that operations on the service before it is started will be handled once the start operation occurs...this may not make sense for all services, but I think it's a good ability to have.

With that said, I was not able to take advantage of this change in SingleThreadScheduler.  It became obvious that the lifecycle of "SchedulerManager" does not follow the one that was designed for most services.  Specifically it can be shutdown without ever being started.  We had also previously not used the "shutdownService" and made our own stop function because of the fact that there are two ways it may need to be stopped.  Because of that I decided to stop extending AbstractService and instead just make this implementation more specific to its design.