### PR TITLE
This resolves issue #124

### DIFF
--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerServiceWrapper.java
@@ -68,13 +68,11 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
   @Override
   protected ListenableScheduledFuture<?> schedule(Runnable command, long delayInMillis) {
     ListenableRunnableFuture<Object> taskFuture = new ListenableFutureTask<Object>(false, command);
-    OneTimeTaskWrapper ottw = pScheduler.new OneTimeTaskWrapper(taskFuture, 
-                                                                pScheduler.getDefaultPriority(), 
-                                                                delayInMillis);
+    OneTimeTaskWrapper ottw = new OneTimeTaskWrapper(taskFuture, delayInMillis);
     if (delayInMillis == 0) {
-      pScheduler.addToExecuteQueue(ottw);
+      pScheduler.addToExecuteQueue(pScheduler.getDefaultPriority(), ottw);
     } else {
-      pScheduler.addToScheduleQueue(ottw);
+      pScheduler.addToScheduleQueue(pScheduler.getDefaultPriority(), ottw);
     }
     
     return new ScheduledFutureDelegate<Object>(taskFuture, ottw);
@@ -83,13 +81,11 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
   @Override
   protected <V> ListenableScheduledFuture<V> schedule(Callable<V> callable, long delayInMillis) {
     ListenableRunnableFuture<V> taskFuture = new ListenableFutureTask<V>(false, callable);
-    OneTimeTaskWrapper ottw = pScheduler.new OneTimeTaskWrapper(taskFuture, 
-                                                                pScheduler.getDefaultPriority(), 
-                                                                delayInMillis);
+    OneTimeTaskWrapper ottw = new OneTimeTaskWrapper(taskFuture, delayInMillis);
     if (delayInMillis == 0) {
-      pScheduler.addToExecuteQueue(ottw);
+      pScheduler.addToExecuteQueue(pScheduler.getDefaultPriority(), ottw);
     } else {
-      pScheduler.addToScheduleQueue(ottw);
+      pScheduler.addToScheduleQueue(pScheduler.getDefaultPriority(), ottw);
     }
     
     return new ScheduledFutureDelegate<V>(taskFuture, ottw);
@@ -103,10 +99,11 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     task = new ThrowableHandlingRecurringRunnable(scheduler, task);
     
     ListenableRunnableFuture<Object> taskFuture = new ListenableFutureTask<Object>(true, task);
-    RecurringDelayTaskWrapper rdtw = pScheduler.new RecurringDelayTaskWrapper(taskFuture, 
-                                                                              pScheduler.getDefaultPriority(), 
-                                                                              initialDelayInMs, delayInMs);
-    pScheduler.addToScheduleQueue(rdtw);
+    TaskPriority priority = pScheduler.getDefaultPriority();
+    RecurringDelayTaskWrapper rdtw = new RecurringDelayTaskWrapper(taskFuture, 
+                                                                   pScheduler.getQueueManager(priority),
+                                                                   initialDelayInMs, delayInMs);
+    pScheduler.addToScheduleQueue(priority, rdtw);
     
     return new ScheduledFutureDelegate<Object>(taskFuture, rdtw);
   }
@@ -119,10 +116,11 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     task = new ThrowableHandlingRecurringRunnable(pScheduler, task);
     
     ListenableRunnableFuture<Object> taskFuture = new ListenableFutureTask<Object>(true, task);
-    RecurringRateTaskWrapper rrtw = pScheduler.new RecurringRateTaskWrapper(taskFuture, 
-                                                                            pScheduler.getDefaultPriority(), 
-                                                                            initialDelayInMillis, periodInMillis);
-    pScheduler.addToScheduleQueue(rrtw);
+    TaskPriority priority = pScheduler.getDefaultPriority();
+    RecurringRateTaskWrapper rrtw = new RecurringRateTaskWrapper(taskFuture, 
+                                                                 pScheduler.getQueueManager(priority),
+                                                                 initialDelayInMillis, periodInMillis);
+    pScheduler.addToScheduleQueue(priority, rrtw);
     
     return new ScheduledFutureDelegate<Object>(taskFuture, rrtw);
   }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest.java
@@ -1,0 +1,14 @@
+package org.threadly.concurrent;
+
+import org.junit.Before;
+import org.threadly.concurrent.PrioritySchedulerStatisticTracker.StatisticWorkerPool;
+import org.threadly.concurrent.PrioritySchedulerStatisticTracker.StatsManager;
+
+@SuppressWarnings("javadoc")
+public class PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest extends PrioritySchedulerWorkerPoolTest {
+  @Before
+  public void setup() {
+    workerPool = new StatisticWorkerPool(new ConfigurableThreadFactory(), 1, 1, DEFAULT_KEEP_ALIVE_TIME, 
+                                         PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, new StatsManager());
+  }
+}

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerTest.java
@@ -40,7 +40,7 @@ public class PrioritySchedulerStatisticTrackerTest extends PrioritySchedulerTest
   public void constructorNullFactoryTest() {
     PriorityScheduler ps = new PrioritySchedulerStatisticTracker(1, 1, 1, TaskPriority.High, 1, null);
     // should be set with default
-    assertNotNull(ps.threadFactory);
+    assertNotNull(ps.workerPool.threadFactory);
   }
   
   @SuppressWarnings("unused")

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerTaskWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerTaskWrapperTest.java
@@ -53,14 +53,11 @@ public class PrioritySchedulerTaskWrapperTest {
     }
     
     protected TestWrapper(int delay) {
-      this(new TestRunnable(), 
-           TaskPriority.High, delay);
+      this(new TestRunnable(), delay);
     }
     
-    protected TestWrapper(Runnable task,
-                          TaskPriority priority, 
-                          int delayInMs) {
-      super(task, priority);
+    protected TestWrapper(Runnable task, int delayInMs) {
+      super(task);
       
       this.delayInMs = delayInMs;
       executingCalled = false;
@@ -73,7 +70,7 @@ public class PrioritySchedulerTaskWrapperTest {
     }
     
     @Override
-    protected long getDelayEstimateInMillis() {
+    protected long getDelayEstimateInMs() {
       return delayInMs;
     }
 

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerWorkerPoolTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerWorkerPoolTest.java
@@ -1,0 +1,318 @@
+package org.threadly.concurrent;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.PriorityScheduler.Worker;
+import org.threadly.concurrent.PriorityScheduler.WorkerPool;
+import org.threadly.test.concurrent.TestCondition;
+import org.threadly.test.concurrent.TestUtils;
+
+@SuppressWarnings("javadoc")
+public class PrioritySchedulerWorkerPoolTest {
+  protected static int DEFAULT_KEEP_ALIVE_TIME = 1000;
+  
+  protected WorkerPool workerPool;
+  
+  @Before
+  public void setup() {
+    workerPool = new WorkerPool(new ConfigurableThreadFactory(), 1, 1, DEFAULT_KEEP_ALIVE_TIME, 
+                                PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS);
+  }
+  
+  @After
+  public void cleanup() {
+    workerPool.startShutdown();
+    workerPool.finishShutdown();
+    workerPool = null;
+  }
+  
+  @Test
+  public void shutdownStartTest() {
+    assertFalse(workerPool.isShutdownStarted());
+    assertTrue(workerPool.startShutdown());
+    assertTrue(workerPool.isShutdownStarted());
+  }
+  
+  @Test
+  public void shutdownFinishTest() {
+    assertFalse(workerPool.isShutdownFinished());
+    workerPool.finishShutdown();
+    assertTrue(workerPool.isShutdownFinished());
+  }
+  
+  @Test
+  public void getAndSetCorePoolSizeTest() {
+    int corePoolSize = 10;
+    workerPool.setMaxPoolSize(corePoolSize + 10);
+    workerPool.setCorePoolSize(corePoolSize);
+      
+    assertEquals(corePoolSize, workerPool.getCorePoolSize());
+  }
+  
+  @Test
+  public void getAndSetCorePoolSizeAboveMaxTest() {
+    int corePoolSize = workerPool.getMaxPoolSize() * 2;
+    workerPool.setCorePoolSize(corePoolSize);
+    
+    assertEquals(corePoolSize, workerPool.getCorePoolSize());
+    assertEquals(corePoolSize, workerPool.getMaxPoolSize());
+  }
+  
+  @Test
+  public void lowerSetCorePoolSizeCleansWorkerTest() {
+    workerPool.setKeepAliveTime(0);
+    
+    workerPool.setCorePoolSize(5);
+    workerPool.prestartAllCoreThreads();
+    // must allow core thread timeout for this to work
+    workerPool.allowCoreThreadTimeOut(true);
+    TestUtils.blockTillClockAdvances();
+    
+    workerPool.setCorePoolSize(1);
+    
+    // verify worker was cleaned up
+    assertEquals(0, workerPool.getCurrentPoolSize());
+  }
+  
+  @Test
+  public void setCorePoolSizeFail() {
+    // verify no negative values
+    try {
+      workerPool.setCorePoolSize(-1);
+      fail("Exception should have been thrown");
+    } catch (IllegalArgumentException expected) {
+      // ignored
+    }
+  }
+  
+  @Test
+  public void getAndSetMaxPoolSizeTest() {
+    int newMaxPoolSize = workerPool.getMaxPoolSize() * 2;
+    workerPool.setMaxPoolSize(newMaxPoolSize);
+    
+    assertEquals(newMaxPoolSize, workerPool.getMaxPoolSize());
+  }
+  
+  @Test
+  public void getAndSetMaxPoolSizeBelowCoreTest() {
+    workerPool.setCorePoolSize(5);
+    workerPool.setMaxPoolSize(1);
+    
+    assertEquals(1, workerPool.getMaxPoolSize());
+    assertEquals(1, workerPool.getCorePoolSize());
+  }
+  
+  @Test
+  public void lowerSetMaxPoolSizeCleansWorkerTest() {
+    workerPool.setKeepAliveTime(0);
+    
+    workerPool.setCorePoolSize(5);
+    workerPool.prestartAllCoreThreads();
+    // must allow core thread timeout for this to work
+    workerPool.allowCoreThreadTimeOut(true);
+    TestUtils.blockTillClockAdvances();
+    
+    workerPool.setMaxPoolSize(1);
+    
+    // verify worker was cleaned up
+    assertEquals(0, workerPool.getCurrentPoolSize());
+  }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void setMaxPoolSizeFail() {
+    workerPool.setMaxPoolSize(-1); // should throw exception for negative value
+    fail("Exception should have been thrown");
+  }
+  
+  @Test
+  public void getAndSetLowPriorityWaitTest() {
+    assertEquals(PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, workerPool.getMaxWaitForLowPriority());
+    
+    long lowPriorityWait = Long.MAX_VALUE;
+    workerPool.setMaxWaitForLowPriority(lowPriorityWait);
+    
+    assertEquals(lowPriorityWait, workerPool.getMaxWaitForLowPriority());
+  }
+  
+  @Test
+  public void setLowPriorityWaitFail() {
+    try {
+      workerPool.setMaxWaitForLowPriority(-1);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    
+    assertEquals(PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, workerPool.getMaxWaitForLowPriority());
+  }
+  
+  @Test
+  public void getAndSetKeepAliveTimeTest() {
+    assertEquals(DEFAULT_KEEP_ALIVE_TIME, workerPool.getKeepAliveTime());
+    
+    long keepAliveTime = Long.MAX_VALUE;
+    workerPool.setKeepAliveTime(keepAliveTime);
+    
+    assertEquals(keepAliveTime, workerPool.getKeepAliveTime());
+  }
+  
+  @Test
+  public void lowerSetKeepAliveTimeCleansWorkerTest() {
+    workerPool.prestartAllCoreThreads();
+    // must allow core thread timeout for this to work
+    workerPool.allowCoreThreadTimeOut(true);
+    TestUtils.blockTillClockAdvances();
+    
+    workerPool.setKeepAliveTime(0);
+    
+    // verify worker was cleaned up
+    assertEquals(0, workerPool.getCurrentPoolSize());
+  }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void setKeepAliveTimeFail() {
+    workerPool.setKeepAliveTime(-1L); // should throw exception for negative value
+    fail("Exception should have been thrown");
+  }
+  
+  @Test
+  public void allowCoreThreadTimeOutTest() {
+    int corePoolSize = 5;
+    
+    workerPool.setCorePoolSize(corePoolSize);
+    workerPool.prestartAllCoreThreads();
+    workerPool.setKeepAliveTime(0);
+    
+    workerPool.allowCoreThreadTimeOut(false);
+    TestUtils.blockTillClockAdvances();
+    synchronized (workerPool.workersLock) {
+      workerPool.expireOldWorkers();
+    }
+    
+    assertEquals(corePoolSize, workerPool.getCurrentPoolSize());
+    
+    workerPool.allowCoreThreadTimeOut(true);
+    TestUtils.blockTillClockAdvances();
+    synchronized (workerPool.workersLock) {
+      workerPool.expireOldWorkers();
+    }
+    
+    assertEquals(0, workerPool.getCurrentPoolSize());
+  }
+  
+  @Test
+  public void prestartAllCoreThreadsTest() {
+    int corePoolSize = 5;
+    workerPool.setCorePoolSize(corePoolSize);
+    
+    assertEquals(0, workerPool.getCurrentPoolSize());
+    
+    workerPool.prestartAllCoreThreads();
+    
+    assertEquals(corePoolSize, workerPool.getCurrentPoolSize());
+  }
+  
+  @Test
+  public void makeNewWorkerTest() {
+    assertEquals(0, workerPool.getCurrentPoolSize());
+    
+    Worker w = workerPool.makeNewWorker();
+    assertNotNull(w);
+    assertTrue(w.thread.isAlive());
+    assertEquals(1, workerPool.getCurrentPoolSize());
+  }
+  
+  @Test
+  public void getExistingWorkerTest() {
+    synchronized (workerPool.workersLock) {
+      // add an idle worker
+      Worker testWorker = workerPool.makeNewWorker();
+      workerPool.workerDone(testWorker);
+      
+      assertEquals(1, workerPool.availableWorkers.size());
+      
+      try {
+        Worker returnedWorker = workerPool.getExistingWorker(100);
+        assertTrue(returnedWorker == testWorker);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+  
+  @Test
+  public void expireOldWorkersTest() {
+    workerPool.setKeepAliveTime(0);
+    
+    synchronized (workerPool.workersLock) {
+      // add an idle worker
+      Worker testWorker = workerPool.makeNewWorker();
+      workerPool.workerDone(testWorker);
+      
+      assertEquals(1, workerPool.availableWorkers.size());
+      
+      TestUtils.blockTillClockAdvances();
+      
+      synchronized (workerPool.workersLock) {
+        workerPool.expireOldWorkers();
+      }
+      
+      // should not have collected yet due to core size == 1
+      assertEquals(1, workerPool.availableWorkers.size());
+      
+      workerPool.allowCoreThreadTimeOut(true);
+      
+      TestUtils.blockTillClockAdvances();
+      
+      workerPool.expireOldWorkers();
+      
+      // verify collected now
+      assertEquals(0, workerPool.availableWorkers.size());
+    }
+  }
+  
+  @Test
+  public void killWorkerTest() {
+    final Worker w = workerPool.makeNewWorker();
+    workerPool.workerDone(w);
+    
+    workerPool.killWorker(w);
+    assertEquals(0, workerPool.getCurrentPoolSize());
+    assertTrue(workerPool.availableWorkers.isEmpty());
+    new TestCondition() {
+      @Override
+      public boolean get() {
+        return ! w.thread.isAlive();
+      }
+    }.blockTillTrue();
+  }
+  
+  @Test
+  public void workerDoneTest() {
+    workerPool.workerDone(workerPool.makeNewWorker());
+    
+    assertEquals(1, workerPool.availableWorkers.size());
+    
+    workerPool.setKeepAliveTime(0);
+    workerPool.workerDone(workerPool.makeNewWorker());
+    
+    assertEquals(1, workerPool.availableWorkers.size());
+    
+    workerPool.setKeepAliveTime(1000);
+    workerPool.startShutdown();
+    workerPool.finishShutdown();
+    final Worker w = workerPool.makeNewWorker();
+    workerPool.workerDone(w);
+    
+    assertEquals(0, workerPool.availableWorkers.size());
+    new TestCondition() {
+      @Override
+      public boolean get() {
+        return ! w.thread.isAlive();
+      }
+    }.blockTillTrue();
+  }
+}

--- a/src/test/java/org/threadly/util/debug/ProfilerTest.java
+++ b/src/test/java/org/threadly/util/debug/ProfilerTest.java
@@ -18,7 +18,7 @@ public class ProfilerTest {
   private static final int POLL_INTERVAL = 1;
   private static final int MIN_RESPONSE_LENGTH = 10;
   
-  private Profiler profiler;
+  protected Profiler profiler;
   
   @Before
   public void setup() {
@@ -31,7 +31,7 @@ public class ProfilerTest {
     profiler = null;
   }
   
-  private void blockForProfilerSample() {
+  protected void blockForProfilerSample() {
     new TestCondition() {
       @Override
       public boolean get() {
@@ -47,45 +47,45 @@ public class ProfilerTest {
     Profiler p;
     
     p = new Profiler();
-    assertNotNull(p.threadTraces);
-    assertEquals(0, p.threadTraces.size());
-    assertEquals(Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS, p.pollIntervalInMs);
-    assertNull(p.collectorThread.get());
-    assertNull(p.dumpingThread);
+    assertNotNull(p.pStore.threadTraces);
+    assertEquals(0, p.pStore.threadTraces.size());
+    assertEquals(Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS, p.pStore.pollIntervalInMs);
+    assertNull(p.pStore.collectorThread.get());
+    assertNull(p.pStore.dumpingThread);
     assertNull(p.outputFile);
     assertNotNull(p.startStopLock);
     
     p = new Profiler(dumpFile);
-    assertNotNull(p.threadTraces);
-    assertEquals(0, p.threadTraces.size());
-    assertEquals(Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS, p.pollIntervalInMs);
-    assertNull(p.collectorThread.get());
-    assertNull(p.dumpingThread);
+    assertNotNull(p.pStore.threadTraces);
+    assertEquals(0, p.pStore.threadTraces.size());
+    assertEquals(Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS, p.pStore.pollIntervalInMs);
+    assertNull(p.pStore.collectorThread.get());
+    assertNull(p.pStore.dumpingThread);
     assertEquals(dumpFile, p.outputFile);
     assertNotNull(p.startStopLock);
     
     p = new Profiler(testPollInterval);
-    assertNotNull(p.threadTraces);
-    assertEquals(0, p.threadTraces.size());
-    assertEquals(testPollInterval, p.pollIntervalInMs);
-    assertNull(p.collectorThread.get());
-    assertNull(p.dumpingThread);
+    assertNotNull(p.pStore.threadTraces);
+    assertEquals(0, p.pStore.threadTraces.size());
+    assertEquals(testPollInterval, p.pStore.pollIntervalInMs);
+    assertNull(p.pStore.collectorThread.get());
+    assertNull(p.pStore.dumpingThread);
     assertNull(p.outputFile);
     assertNotNull(p.startStopLock);
     
     p = new Profiler(dumpFile, testPollInterval);
-    assertNotNull(p.threadTraces);
-    assertEquals(0, p.threadTraces.size());
-    assertEquals(testPollInterval, p.pollIntervalInMs);
-    assertNull(p.collectorThread.get());
-    assertNull(p.dumpingThread);
+    assertNotNull(p.pStore.threadTraces);
+    assertEquals(0, p.pStore.threadTraces.size());
+    assertEquals(testPollInterval, p.pStore.pollIntervalInMs);
+    assertNull(p.pStore.collectorThread.get());
+    assertNull(p.pStore.dumpingThread);
     assertEquals(dumpFile, p.outputFile);
     assertNotNull(p.startStopLock);
   }
   
   @Test
   public void getProfileThreadsIteratorTest() {
-    Iterator<Thread> it = profiler.getProfileThreadsIterator();
+    Iterator<Thread> it = profiler.pStore.getProfileThreadsIterator();
     
     assertNotNull(it);
     assertTrue(it.hasNext());
@@ -94,7 +94,7 @@ public class ProfilerTest {
   
   @Test (expected = NoSuchElementException.class)
   public void profileThreadsIteratorNextFail() {
-    Iterator<Thread> it = profiler.getProfileThreadsIterator();
+    Iterator<Thread> it = profiler.pStore.getProfileThreadsIterator();
     
     while (it.hasNext()) {
       assertNotNull(it.next());
@@ -106,7 +106,7 @@ public class ProfilerTest {
   
   @Test (expected = UnsupportedOperationException.class)
   public void profileThreadsIteratorRemoveFail() {
-    Iterator<Thread> it = profiler.getProfileThreadsIterator();
+    Iterator<Thread> it = profiler.pStore.getProfileThreadsIterator();
     it.next();
     
     // not currently supported
@@ -122,6 +122,10 @@ public class ProfilerTest {
   @Test
   public void isRunningTest() {
     assertFalse(profiler.isRunning());
+    
+    /* verification of isRunning after start happens in 
+     * startWithoutExecutorTest and startWitExecutorTest
+     */
   }
   
   @Test
@@ -167,7 +171,7 @@ public class ProfilerTest {
     profiler.start();
     // verify there are some samples
     blockForProfilerSample();
-    final Thread runningThread = profiler.collectorThread.get();
+    final Thread runningThread = profiler.pStore.collectorThread.get();
     profiler.stop();
     
     // verify stopped
@@ -180,7 +184,7 @@ public class ProfilerTest {
     
     profiler.reset();
     
-    assertEquals(0, profiler.threadTraces.size());
+    assertEquals(0, profiler.pStore.threadTraces.size());
     assertEquals(0, profiler.getCollectedSampleQty());
   }
   


### PR DESCRIPTION
This makes it so that garbage collection of PriorityScheduler, PrioritySchedulerStatisticTracker, and the Profiler will make sure started threads are stopped and also able to be garbage collected.  I had previously solved this in the SingleThreadScheduler (which was easier than these classes were).

In general the strategy to solve this was make the inner classes which were not static, to actually be static.  This required shared memory from the parent classes with those inner classes be encapsilated in a new inner class that will just store that data (also static).  This is necessary because non-static classes referenced by threads will hold a reference to their parent classes, preventing them from having the finalizer called on them.  Once we can ensure the finalizer will be called, that finalizer goes through the operation needed to stop/shutdown the running threads (in a graceful way).  Once those threads are shut down these static classes can also be collected.

This does increase the jar size, and in some ways makes the code cleaner, and in other ways makes it more complicated.  I am not super happy with these changes but I do think this bug fix is important.