### PR TITLE
This changes the PriorityScheduler high vs low priority task logic

### DIFF
--- a/src/main/java/org/threadly/concurrent/ContainerHelper.java
+++ b/src/main/java/org/threadly/concurrent/ContainerHelper.java
@@ -1,7 +1,9 @@
 package org.threadly.concurrent;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
@@ -223,5 +225,23 @@ public class ContainerHelper {
         return false;
       }
     }
+  }
+  
+  /**
+   * Takes in a list of runnable containers, and instead makes a list of the runnables which are 
+   * contained in each item of the list.
+   * 
+   * @param sourceList List of runnable containers to get interior runnable from
+   * @return A list of runnables which were contained in the source list
+   * @since 4.0.0
+   */
+  public static List<Runnable> getContainedRunnables(List<? extends RunnableContainerInterface> sourceList) {
+    List<Runnable> result = new ArrayList<Runnable>(sourceList.size());
+    Iterator<? extends RunnableContainerInterface> it = sourceList.iterator();
+    while (it.hasNext()) {
+      result.add(it.next().getContainedRunnable());
+    }
+    
+    return result;
   }
 }

--- a/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
@@ -442,14 +442,8 @@ public class NoThreadScheduler extends AbstractSubmitterScheduler
       }
       scheduledQueue.clear();
     }
-      
-    List<Runnable> result = new ArrayList<Runnable>(containers.size());
-    Iterator<TaskContainer> it = containers.iterator();
-    while (it.hasNext()) {
-      result.add(it.next().runnable);
-    }
     
-    return result;
+    return ContainerHelper.getContainedRunnables(containers);
   }
   
   /**

--- a/src/main/java/org/threadly/test/concurrent/TestRunnable.java
+++ b/src/main/java/org/threadly/test/concurrent/TestRunnable.java
@@ -182,8 +182,7 @@ public class TestRunnable implements Runnable {
    * @param timeout time to wait for run to be called before throwing exception
    * @param expectedRunCount run count to wait for
    */
-  public void blockTillFinished(int timeout, 
-                                int expectedRunCount) {
+  public void blockTillFinished(int timeout, int expectedRunCount) {
     final int blockRunCount = expectedRunCount;
     
     new TestCondition() {

--- a/src/test/java/org/threadly/BlockingTestRunnable.java
+++ b/src/test/java/org/threadly/BlockingTestRunnable.java
@@ -4,7 +4,7 @@ import org.threadly.test.concurrent.TestRunnable;
 
 @SuppressWarnings("javadoc")
 public class BlockingTestRunnable extends TestRunnable {
-  private boolean unblocked = false;
+  private volatile boolean unblocked = false;
   
   @Override
   public void handleRunStart() throws InterruptedException {
@@ -13,6 +13,10 @@ public class BlockingTestRunnable extends TestRunnable {
         this.wait();
       }
     }
+  }
+  
+  public boolean isUnblocked() {
+    return unblocked;
   }
   
   public void unblock() {

--- a/src/test/java/org/threadly/concurrent/BlockingQueueConsumerTest.java
+++ b/src/test/java/org/threadly/concurrent/BlockingQueueConsumerTest.java
@@ -76,9 +76,13 @@ public class BlockingQueueConsumerTest {
   
   @Test (expected = IllegalThreadStateException.class)
   public void startFail() {
-    queueConsumer = new BlockingQueueConsumer<Object>(new StartingThreadFactory(), 
-                                                      queue, acceptor);
-    queueConsumer.start();
+    StartingThreadFactory threadFactory = new StartingThreadFactory();
+    try {
+      queueConsumer = new BlockingQueueConsumer<Object>(threadFactory, queue, acceptor);
+      queueConsumer.start();
+    } finally {
+      threadFactory.killThreads();
+    }
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/ContainerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/ContainerHelperTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 import static org.threadly.TestConstants.*;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -67,6 +68,22 @@ public class ContainerHelperTest {
     TestCallable tc = new TestCallable();
     assertFalse(ContainerHelper.isContained(new TestRunnableContainer(new TestRunnable()), tc));
     assertFalse(ContainerHelper.isContained(new TestRunnable(), tc));
+  }
+  
+  @Test
+  public void getContainedRunnablesTest() {
+    List<TestRunnableContainer> containers = new ArrayList<TestRunnableContainer>(TEST_QTY);
+    for (int i = 0; i < TEST_QTY; i++) {
+      containers.add(new TestRunnableContainer(new TestRunnable()));
+    }
+    
+    List<Runnable> resultList = ContainerHelper.getContainedRunnables(containers);
+    assertEquals(containers.size(), resultList.size());
+    
+    Iterator<TestRunnableContainer> it = containers.iterator();
+    while (it.hasNext()) {
+      assertTrue(resultList.contains(it.next().r));
+    }
   }
   
   private static class TestRunnableContainer implements RunnableContainerInterface, Runnable {

--- a/src/test/java/org/threadly/concurrent/KeyDistributedExecutorTest.java
+++ b/src/test/java/org/threadly/concurrent/KeyDistributedExecutorTest.java
@@ -37,9 +37,9 @@ public class KeyDistributedExecutorTest {
   
   @BeforeClass
   public static void setupClass() {
-    scheduler = new StrictPriorityScheduler(PARALLEL_LEVEL * 2);
-    
     ThreadlyTestUtil.setIgnoreExceptionHandler();
+    
+    scheduler = new StrictPriorityScheduler(PARALLEL_LEVEL * 2);
   }
   
   @AfterClass
@@ -345,7 +345,7 @@ public class KeyDistributedExecutorTest {
     TestRunnable followRunnable = new TestRunnable();
     distributor.addTask(key, exceptionRunnable);
     distributor.addTask(key, followRunnable);
-    exceptionRunnable.blockTillStarted();
+    exceptionRunnable.blockTillFinished();
     followRunnable.blockTillStarted();  // verify that it ran despite the exception
     
     assertEquals(1, teh.getCallCount());

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
@@ -3,18 +3,12 @@ package org.threadly.concurrent;
 import static org.junit.Assert.*;
 import static org.threadly.TestConstants.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.threadly.concurrent.PriorityScheduler.OneTimeTaskWrapper;
 import org.threadly.concurrent.PriorityScheduler.QueueManager;
-import org.threadly.concurrent.PriorityScheduler.RecurringDelayTaskWrapper;
-import org.threadly.concurrent.PriorityScheduler.RecurringTaskWrapper;
+import org.threadly.concurrent.PriorityScheduler.QueueSet;
 import org.threadly.concurrent.PriorityScheduler.TaskWrapper;
 import org.threadly.concurrent.PriorityScheduler.WorkerPool;
 import org.threadly.concurrent.future.ListenableFutureTask;
@@ -32,8 +26,9 @@ public class PrioritySchedulerQueueManagerTest {
   @Before
   public void setup() {
     ConfigurableThreadFactory threadFactory = new ConfigurableThreadFactory();
-    workerPool = new WorkerPool(threadFactory, 1, PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS);
-    queueManager = new QueueManager(workerPool, TaskPriority.High, THREAD_NAME) {
+    workerPool = new WorkerPool(threadFactory, 1);
+    queueManager = new QueueManager(workerPool, THREAD_NAME, 
+                                    PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS) {
       @Override
       protected void startupService() {
         // we override this so we can avoid starting threads in these tests
@@ -58,25 +53,29 @@ public class PrioritySchedulerQueueManagerTest {
   
   @Test (expected = IllegalThreadStateException.class)
   public void threadFactoryReturnRunningThreadFail() {
-    WorkerPool workerPool = new WorkerPool(new StartingThreadFactory(), 1, 
-                                           PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS);
-    queueManager = new QueueManager(workerPool, TaskPriority.High, THREAD_NAME);
-    queueManager.start();
+    StartingThreadFactory threadFactory = new StartingThreadFactory();
+    try {
+      WorkerPool workerPool = new WorkerPool(threadFactory, 1);
+      queueManager = new QueueManager(workerPool, THREAD_NAME, 
+                                      PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS);
+    } finally {
+      threadFactory.killThreads();
+    }
   }
   
   @Test
   public void removeCallableTest() {
     TestCallable callable = new TestCallable();
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new ListenableFutureTask<Object>(false, callable), 0);
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new ListenableFutureTask<Object>(false, callable), 0, null);
     
     assertFalse(queueManager.remove(callable));
     
-    queueManager.executeQueue.add(task);
+    queueManager.highPriorityQueueSet.executeQueue.add(task);
 
     assertTrue(queueManager.remove(callable));
     assertFalse(queueManager.remove(callable));
     
-    queueManager.scheduleQueue.addFirst(task);
+    queueManager.lowPriorityQueueSet.scheduleQueue.addFirst(task);
 
     assertTrue(queueManager.remove(callable));
     assertFalse(queueManager.remove(callable));
@@ -85,133 +84,169 @@ public class PrioritySchedulerQueueManagerTest {
   @Test
   public void removeRunnableTest() {
     TestRunnable runnable = new TestRunnable();
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(runnable, 0);
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(runnable, 0, null);
     
     assertFalse(queueManager.remove(runnable));
     
-    queueManager.executeQueue.add(task);
+    queueManager.highPriorityQueueSet.executeQueue.add(task);
 
     assertTrue(queueManager.remove(runnable));
     assertFalse(queueManager.remove(runnable));
     
-    queueManager.scheduleQueue.addFirst(task);
+    queueManager.lowPriorityQueueSet.scheduleQueue.addFirst(task);
 
     assertTrue(queueManager.remove(runnable));
     assertFalse(queueManager.remove(runnable));
   }
   
   @Test
-  public void addExecuteTest() {
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 0);
+  public void getNextReadyTaskNotRunningTest() throws InterruptedException {
+    queueManager.stop();
     
-    queueManager.addExecute(task);
-    
-    assertTrue(queueManager.isRunning());
-    assertEquals(1, queueManager.executeQueue.size());
-    assertEquals(0, queueManager.scheduleQueue.size());
+    assertNull(queueManager.getNextReadyTask());
   }
   
   @Test
-  public void addScheduledTest() {
-    TaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 10);
-    
-    queueManager.addScheduled(task);
-    
-    assertTrue(queueManager.isRunning());
-    assertEquals(0, queueManager.executeQueue.size());
-    assertEquals(1, queueManager.scheduleQueue.size());
+  public void getNextReadyTaskExecuteOnlyHighTest() throws InterruptedException {
+    getNextReadyTaskExecuteTest(queueManager.highPriorityQueueSet);
   }
   
   @Test
-  public void addScheduledOrderTest() {
-    List<TaskWrapper> orderedList = new ArrayList<TaskWrapper>(TEST_QTY);
-    for (int i = 0; i < TEST_QTY; i++) {
-      orderedList.add(new OneTimeTaskWrapper(new TestRunnable(), i));
-    }
-    List<TaskWrapper> randomList = new ArrayList<TaskWrapper>(orderedList);
-    Collections.shuffle(randomList);
+  public void getNextReadyTaskExecuteOnlyLowTest() throws InterruptedException {
+    getNextReadyTaskExecuteTest(queueManager.lowPriorityQueueSet);
+  }
+  
+  private void getNextReadyTaskExecuteTest(QueueSet queueSet) throws InterruptedException {
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 0, queueSet.executeQueue);
     
-    Iterator<TaskWrapper> it = randomList.iterator();
-    while (it.hasNext()) {
-      queueManager.addScheduled(it.next());
-    }
+    queueSet.addExecute(task);
     
-    Iterator<TaskWrapper> expectedIt = orderedList.iterator();
-    Iterator<TaskWrapper> resultIt = queueManager.scheduleQueue.iterator();
-    while (expectedIt.hasNext()) {
-      assertTrue(expectedIt.next() == resultIt.next());
-    }
+    assertTrue(task == queueManager.getNextReadyTask());
   }
   
   @Test
-  public void addScheduledLastTest() {
-    RecurringTaskWrapper task = new RecurringDelayTaskWrapper(new TestRunnable(), queueManager, 10, 10);
-    
-    queueManager.addScheduledLast(task);
-    
-    assertFalse(queueManager.isRunning());
-    assertEquals(0, queueManager.executeQueue.size());
-    assertEquals(1, queueManager.scheduleQueue.size());
+  public void getNextReadyTaskScheduleOnlyHighTest() throws InterruptedException {
+    getNextReadyTaskScheduledTest(queueManager.highPriorityQueueSet);
   }
   
   @Test
-  public void getNextTaskNotRunningTest() throws InterruptedException {
-    assertNull(queueManager.getNextTask());
+  public void getNextReadyTaskScheduleOnlyLowTest() throws InterruptedException {
+    getNextReadyTaskScheduledTest(queueManager.lowPriorityQueueSet);
+  }
+  
+  private void getNextReadyTaskScheduledTest(QueueSet queueSet) throws InterruptedException {
+    TaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 0, queueSet.scheduleQueue);
+    
+    queueSet.addScheduled(task);
+    
+    assertTrue(task == queueManager.getNextReadyTask());
   }
   
   @Test
-  public void getNextTaskExecuteOnlyTest() throws InterruptedException {
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 0);
-    
-    queueManager.addExecute(task);
-    
-    assertTrue(task == queueManager.getNextTask());
-  }
-  
-  @Test
-  public void getNextTaskScheduleOnlyTest() throws InterruptedException {
-    TaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 0);
-    
-    queueManager.addScheduled(task);
-    
-    assertTrue(task == queueManager.getNextTask());
-  }
-  
-  @Test
-  public void getNextTaskScheduleDelayTest() throws InterruptedException {
-    TaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME);
-    queueManager.addScheduled(task);
+  public void getNextReadyTaskScheduleDelayTest() throws InterruptedException {
+    long startTime = Clock.accurateForwardProgressingMillis();
+    TaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME, 
+                                              queueManager.highPriorityQueueSet.scheduleQueue);
+    queueManager.highPriorityQueueSet.addScheduled(task);
     
     TaskWrapper resultTask;
-    long startTime = Clock.accurateForwardProgressingMillis();
-    resultTask = queueManager.getNextTask();
+    resultTask = queueManager.getNextReadyTask();
     long endTime = Clock.accurateForwardProgressingMillis();
     
     assertTrue(task == resultTask);
-    assertTrue((endTime - startTime) >= DELAY_TIME);
+    assertTrue(endTime - startTime >= DELAY_TIME);
   }
   
   @Test
-  public void getNextTaskExecuteAheadOfScheduledTest() throws InterruptedException {
-    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(new TestRunnable(), 0);
-    queueManager.addExecute(executeTask);
+  public void getNextReadyTaskExecuteAheadOfScheduledTest() throws InterruptedException {
+    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(new TestRunnable(), 0, 
+                                                            queueManager.highPriorityQueueSet.executeQueue);
+    queueManager.highPriorityQueueSet.addExecute(executeTask);
     TestUtils.blockTillClockAdvances();
-    TaskWrapper scheduleTask = new OneTimeTaskWrapper(new TestRunnable(), 0);
-    queueManager.addScheduled(scheduleTask);
+    TaskWrapper scheduleTask = new OneTimeTaskWrapper(new TestRunnable(), 0, 
+                                                      queueManager.highPriorityQueueSet.scheduleQueue);
+    queueManager.highPriorityQueueSet.addScheduled(scheduleTask);
 
-    assertTrue(executeTask == queueManager.getNextTask());
-    assertTrue(scheduleTask == queueManager.getNextTask());
+    assertTrue(executeTask == queueManager.getNextReadyTask());
+    assertTrue(scheduleTask == queueManager.getNextReadyTask());
   }
   
   @Test
-  public void getNextTaskScheduledAheadOfExecuteTest() throws InterruptedException {
-    TaskWrapper scheduleTask = new OneTimeTaskWrapper(new TestRunnable(), 0);
-    queueManager.addScheduled(scheduleTask);
+  public void getNextReadyTaskScheduledAheadOfExecuteTest() throws InterruptedException {
+    TaskWrapper scheduleTask = new OneTimeTaskWrapper(new TestRunnable(), 0, 
+                                                      queueManager.highPriorityQueueSet.scheduleQueue);
+    queueManager.highPriorityQueueSet.addScheduled(scheduleTask);
     TestUtils.blockTillClockAdvances();
-    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(new TestRunnable(), 0);
-    queueManager.addExecute(executeTask);
+    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(new TestRunnable(), 0, 
+                                                            queueManager.highPriorityQueueSet.executeQueue);
+    queueManager.highPriorityQueueSet.addExecute(executeTask);
 
-    assertTrue(scheduleTask == queueManager.getNextTask());
-    assertTrue(executeTask == queueManager.getNextTask());
+    assertTrue(scheduleTask == queueManager.getNextReadyTask());
+    assertTrue(executeTask == queueManager.getNextReadyTask());
+  }
+  
+  @Test
+  public void getNextReadyTaskHighPriorityDelayedTest() throws InterruptedException {
+    TaskWrapper scheduleTask = new OneTimeTaskWrapper(new TestRunnable(), 1000, 
+                                                      queueManager.highPriorityQueueSet.scheduleQueue);
+    queueManager.highPriorityQueueSet.addScheduled(scheduleTask);
+    TestUtils.blockTillClockAdvances();
+    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(new TestRunnable(), 0, 
+                                                            queueManager.lowPriorityQueueSet.executeQueue);
+    queueManager.lowPriorityQueueSet.addExecute(executeTask);
+
+    assertTrue(executeTask == queueManager.getNextReadyTask());
+  }
+  
+  @Test
+  public void getNextReadyTaskHighPriorityReadyFirstTest() throws InterruptedException {
+    long startTime = Clock.accurateForwardProgressingMillis();
+    TaskWrapper highTask = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME, 
+                                                  queueManager.highPriorityQueueSet.scheduleQueue);
+    TaskWrapper lowTask = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME * 10, 
+                                                 queueManager.lowPriorityQueueSet.scheduleQueue);
+    queueManager.highPriorityQueueSet.addScheduled(highTask);
+    queueManager.lowPriorityQueueSet.addScheduled(lowTask);
+
+    assertTrue(highTask == queueManager.getNextReadyTask());
+    long endTime = Clock.accurateForwardProgressingMillis();
+    assertTrue(endTime - startTime >= DELAY_TIME);
+  }
+  
+  @Test
+  public void getNextReadyTaskLowPriorityReadyFirstTest() throws InterruptedException {
+    long startTime = Clock.accurateForwardProgressingMillis();
+    TaskWrapper highTask = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME * 10, 
+                                                  queueManager.highPriorityQueueSet.scheduleQueue);
+    TaskWrapper lowTask = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME, 
+                                                 queueManager.lowPriorityQueueSet.scheduleQueue);
+    queueManager.highPriorityQueueSet.addScheduled(highTask);
+    queueManager.lowPriorityQueueSet.addScheduled(lowTask);
+
+    assertTrue(lowTask == queueManager.getNextReadyTask());
+    long endTime = Clock.accurateForwardProgressingMillis();
+    assertTrue(endTime - startTime >= DELAY_TIME);
+  }
+  
+  @Test
+  public void getAndSetLowPriorityWaitTest() {
+    assertEquals(PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, queueManager.getMaxWaitForLowPriority());
+    
+    long lowPriorityWait = Long.MAX_VALUE;
+    queueManager.setMaxWaitForLowPriority(lowPriorityWait);
+    
+    assertEquals(lowPriorityWait, queueManager.getMaxWaitForLowPriority());
+  }
+  
+  @Test
+  public void setLowPriorityWaitFail() {
+    try {
+      queueManager.setMaxWaitForLowPriority(-1);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    
+    assertEquals(PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, queueManager.getMaxWaitForLowPriority());
   }
 }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueSetTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueSetTest.java
@@ -1,0 +1,186 @@
+package org.threadly.concurrent;
+
+import static org.junit.Assert.*;
+import static org.threadly.TestConstants.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.PriorityScheduler.OneTimeTaskWrapper;
+import org.threadly.concurrent.PriorityScheduler.QueueSet;
+import org.threadly.concurrent.PriorityScheduler.TaskWrapper;
+import org.threadly.concurrent.PriorityScheduler.WorkerPool;
+import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.test.concurrent.TestRunnable;
+
+@SuppressWarnings("javadoc")
+public class PrioritySchedulerQueueSetTest {
+  private QueueSet queueSet;
+  
+  @Before
+  public void setup() {
+    ConfigurableThreadFactory threadFactory = new ConfigurableThreadFactory();
+    queueSet = new QueueSet(Thread.currentThread(), new WorkerPool(threadFactory, 1));
+  }
+  
+  @After
+  public void cleanup() {
+    queueSet = null;
+  }
+  
+  @Test
+  public void addExecuteTest() {
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 0, null);
+    
+    queueSet.addExecute(task);
+    
+    assertEquals(1, queueSet.executeQueue.size());
+    assertEquals(0, queueSet.scheduleQueue.size());
+  }
+  
+  @Test
+  public void addScheduledTest() {
+    TaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 10, null);
+    
+    queueSet.addScheduled(task);
+    
+    assertEquals(0, queueSet.executeQueue.size());
+    assertEquals(1, queueSet.scheduleQueue.size());
+  }
+  
+  @Test
+  public void addScheduledOrderTest() {
+    List<TaskWrapper> orderedList = new ArrayList<TaskWrapper>(TEST_QTY);
+    for (int i = 0; i < TEST_QTY; i++) {
+      orderedList.add(new OneTimeTaskWrapper(new TestRunnable(), i, null));
+    }
+    List<TaskWrapper> randomList = new ArrayList<TaskWrapper>(orderedList);
+    Collections.shuffle(randomList);
+    
+    Iterator<TaskWrapper> it = randomList.iterator();
+    while (it.hasNext()) {
+      queueSet.addScheduled(it.next());
+    }
+    
+    Iterator<TaskWrapper> expectedIt = orderedList.iterator();
+    Iterator<TaskWrapper> resultIt = queueSet.scheduleQueue.iterator();
+    while (expectedIt.hasNext()) {
+      assertTrue(expectedIt.next() == resultIt.next());
+    }
+  }
+  
+  @Test
+  public void removeCallableTest() {
+    TestCallable callable = new TestCallable();
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new ListenableFutureTask<Object>(false, callable), 0, null);
+    
+    assertFalse(queueSet.remove(callable));
+    
+    queueSet.executeQueue.add(task);
+
+    assertTrue(queueSet.remove(callable));
+    assertFalse(queueSet.remove(callable));
+    
+    queueSet.scheduleQueue.addFirst(task);
+
+    assertTrue(queueSet.remove(callable));
+    assertFalse(queueSet.remove(callable));
+  }
+  
+  @Test
+  public void removeRunnableTest() {
+    TestRunnable runnable = new TestRunnable();
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(runnable, 0, null);
+    
+    assertFalse(queueSet.remove(runnable));
+    
+    queueSet.executeQueue.add(task);
+
+    assertTrue(queueSet.remove(runnable));
+    assertFalse(queueSet.remove(runnable));
+    
+    queueSet.scheduleQueue.addFirst(task);
+
+    assertTrue(queueSet.remove(runnable));
+    assertFalse(queueSet.remove(runnable));
+  }
+  
+  @Test
+  public void queueSizeTest() {
+    assertEquals(0, queueSet.queueSize());
+    
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 0, null);
+    
+    queueSet.executeQueue.add(task);
+    queueSet.scheduleQueue.addFirst(task);
+    
+    assertEquals(2, queueSet.queueSize());
+  }
+  
+  @Test
+  public void drainQueueIntoTest() {
+    List<TaskWrapper> depositList = new ArrayList<TaskWrapper>();
+    
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), 0, null);
+    
+    queueSet.executeQueue.add(task);
+    
+    queueSet.drainQueueInto(depositList);
+    
+    assertTrue(depositList.contains(task));
+    
+    depositList.clear();
+    
+    queueSet.scheduleQueue.add(task);
+    
+    queueSet.drainQueueInto(depositList);
+    
+    assertTrue(depositList.contains(task));
+  }
+  
+  @Test
+  public void getNextTaskEmptyTest() {
+    assertNull(queueSet.getNextTask());
+  }
+  
+  @Test
+  public void getNextTaskExecuteOnlyTest() {
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME, null);
+    queueSet.executeQueue.add(task);
+    
+    assertTrue(queueSet.getNextTask() == task);
+  }
+  
+  @Test
+  public void getNextTaskScheduleOnlyTest() {
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME, null);
+    queueSet.scheduleQueue.add(task);
+    
+    assertTrue(queueSet.getNextTask() == task);
+  }
+  
+  @Test
+  public void getNextTaskExecuteFirstTest() {
+    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(new TestRunnable(), 0, null);
+    OneTimeTaskWrapper scheduleTask = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME, null);
+    queueSet.executeQueue.add(executeTask);
+    queueSet.scheduleQueue.add(scheduleTask);
+    
+    assertTrue(queueSet.getNextTask() == executeTask);
+  }
+  
+  @Test
+  public void getNextTaskScheduleFirstTest() {
+    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(new TestRunnable(), DELAY_TIME, null);
+    OneTimeTaskWrapper scheduleTask = new OneTimeTaskWrapper(new TestRunnable(), 0, null);
+    queueSet.executeQueue.add(executeTask);
+    queueSet.scheduleQueue.add(scheduleTask);
+    
+    assertTrue(queueSet.getNextTask() == scheduleTask);
+  }
+}

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest.java
@@ -8,7 +8,6 @@ import org.threadly.concurrent.PrioritySchedulerStatisticTracker.StatsManager;
 public class PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest extends PrioritySchedulerWorkerPoolTest {
   @Before
   public void setup() {
-    workerPool = new StatisticWorkerPool(new ConfigurableThreadFactory(), 1, 
-                                         PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, new StatsManager());
+    workerPool = new StatisticWorkerPool(new ConfigurableThreadFactory(), 1, new StatsManager());
   }
 }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerTest.java
@@ -123,9 +123,7 @@ public class PrioritySchedulerStatisticTrackerTest extends PrioritySchedulerTest
       
       assertEquals(-1, scheduler.getAverageTaskRunTime(), 0);
       assertEquals(-1, scheduler.getHighPriorityAvgExecutionDelay(), 0);
-      assertEquals(-1, scheduler.getHighPriorityThreadAvailablePercent(), 0);
       assertEquals(-1, scheduler.getLowPriorityAvgExecutionDelay(), 0);
-      assertEquals(-1, scheduler.getLowPriorityThreadAvailablePercent(), 0);
     } finally {
       scheduler.shutdownNow();
     }
@@ -215,49 +213,6 @@ public class PrioritySchedulerStatisticTrackerTest extends PrioritySchedulerTest
                    scheduler.getTotalExecutionCount());
       assertEquals(lowPriorityCount, scheduler.getLowPriorityTotalExecutionCount());
       assertEquals(highPriorityCount, scheduler.getHighPriorityTotalExecutionCount());
-    } finally {
-      scheduler.shutdownNow();
-    }
-  }
-  
-  @Test
-  public void getThreadAvailablePercentTest() {
-    PrioritySchedulerStatisticTracker scheduler = new PrioritySchedulerStatisticTracker(1);
-    try {
-      assertEquals(-1, scheduler.getThreadAvailablePercent(), 0);
-      assertEquals(-1, scheduler.getLowPriorityThreadAvailablePercent(), 0);
-      assertEquals(-1, scheduler.getHighPriorityThreadAvailablePercent(), 0);
-      
-      TestRunnable tr = new TestRunnable();
-      scheduler.execute(tr, TaskPriority.High);
-      tr.blockTillFinished();
-      
-      assertEquals(0, scheduler.getThreadAvailablePercent(), 0);
-      assertEquals(-1, scheduler.getLowPriorityThreadAvailablePercent(), 0);
-      assertEquals(0, scheduler.getHighPriorityThreadAvailablePercent(), 0);
-      
-      tr = new TestRunnable();
-      scheduler.execute(tr, TaskPriority.High);
-      tr.blockTillFinished();
-      
-      assertEquals(50, scheduler.getThreadAvailablePercent(), 0);
-      assertEquals(-1, scheduler.getLowPriorityThreadAvailablePercent(), 0);
-      assertEquals(50, scheduler.getHighPriorityThreadAvailablePercent(), 0);
-      
-      tr = new TestRunnable();
-      scheduler.execute(tr, TaskPriority.Low);
-      tr.blockTillFinished();
-      
-      assertEquals(100, scheduler.getLowPriorityThreadAvailablePercent(), 0);
-      assertEquals(50, scheduler.getHighPriorityThreadAvailablePercent(), 0);
-      
-      tr = new TestRunnable();
-      scheduler.execute(tr, TaskPriority.Low);
-      tr.blockTillFinished();
-      
-      assertEquals(75, scheduler.getThreadAvailablePercent(), 0);
-      assertEquals(100, scheduler.getLowPriorityThreadAvailablePercent(), 0);
-      assertEquals(50, scheduler.getHighPriorityThreadAvailablePercent(), 0);
     } finally {
       scheduler.shutdownNow();
     }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerTaskWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerTaskWrapperTest.java
@@ -44,7 +44,7 @@ public class PrioritySchedulerTaskWrapperTest {
   private class TestWrapper extends TaskWrapper {
     private final int delayInMs;
     @SuppressWarnings("unused")
-    private boolean executingCalled;
+    private boolean canExecuteCalled;
     @SuppressWarnings("unused")
     private boolean runCalled;
     
@@ -60,7 +60,7 @@ public class PrioritySchedulerTaskWrapperTest {
       super(task);
       
       this.delayInMs = delayInMs;
-      executingCalled = false;
+      canExecuteCalled = false;
       runCalled = false;
     }
 
@@ -70,7 +70,7 @@ public class PrioritySchedulerTaskWrapperTest {
     }
     
     @Override
-    protected long getDelayEstimateInMs() {
+    protected long getDelayInMs(long now) {
       return delayInMs;
     }
 
@@ -80,8 +80,9 @@ public class PrioritySchedulerTaskWrapperTest {
     }
 
     @Override
-    public void executing() {
-      executingCalled = true;
+    public boolean canExecute() {
+      canExecuteCalled = true;
+      return true;
     }
   }
 }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerWorkerPoolTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerWorkerPoolTest.java
@@ -17,8 +17,7 @@ public class PrioritySchedulerWorkerPoolTest {
   
   @Before
   public void setup() {
-    workerPool = new WorkerPool(new ConfigurableThreadFactory(), 1, 
-                                PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS);
+    workerPool = new WorkerPool(new ConfigurableThreadFactory(), 1);
   }
   
   @After
@@ -51,6 +50,16 @@ public class PrioritySchedulerWorkerPoolTest {
   }
   
   @Test
+  public void setPoolSizeSmallerTest() {
+    workerPool.setPoolSize(10);
+    workerPool.prestartAllThreads();
+    
+    workerPool.setPoolSize(1);
+      
+    assertEquals(1, workerPool.getMaxPoolSize());
+  }
+  
+  @Test
   public void setCorePoolSizeFail() {
     // verify no negative values
     try {
@@ -65,28 +74,6 @@ public class PrioritySchedulerWorkerPoolTest {
   public void setPoolSizeFail() {
     workerPool.setPoolSize(-1); // should throw exception for negative value
     fail("Exception should have been thrown");
-  }
-  
-  @Test
-  public void getAndSetLowPriorityWaitTest() {
-    assertEquals(PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, workerPool.getMaxWaitForLowPriority());
-    
-    long lowPriorityWait = Long.MAX_VALUE;
-    workerPool.setMaxWaitForLowPriority(lowPriorityWait);
-    
-    assertEquals(lowPriorityWait, workerPool.getMaxWaitForLowPriority());
-  }
-  
-  @Test
-  public void setLowPriorityWaitFail() {
-    try {
-      workerPool.setMaxWaitForLowPriority(-1);
-      fail("Exception should have thrown");
-    } catch (IllegalArgumentException e) {
-      // expected
-    }
-    
-    assertEquals(PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, workerPool.getMaxWaitForLowPriority());
   }
   
   @Test
@@ -112,7 +99,7 @@ public class PrioritySchedulerWorkerPoolTest {
   }
   
   @Test
-  public void getExistingWorkerTest() {
+  public void getWorkerTest() {
     synchronized (workerPool.workersLock) {
       // add an idle worker
       Worker testWorker = workerPool.makeNewWorker();
@@ -121,7 +108,7 @@ public class PrioritySchedulerWorkerPoolTest {
       assertEquals(1, workerPool.availableWorkers.size());
       
       try {
-        Worker returnedWorker = workerPool.getExistingWorker(100);
+        Worker returnedWorker = workerPool.getWorker();
         assertTrue(returnedWorker == testWorker);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/src/test/java/org/threadly/concurrent/SingleThreadSchedulerSchedulerManagerTest.java
+++ b/src/test/java/org/threadly/concurrent/SingleThreadSchedulerSchedulerManagerTest.java
@@ -18,6 +18,11 @@ public class SingleThreadSchedulerSchedulerManagerTest {
   @SuppressWarnings("unused")
   @Test (expected = IllegalThreadStateException.class)
   public void constructorFail() {
-    new SchedulerManager(new StartingThreadFactory());
+    StartingThreadFactory threadFactory = new StartingThreadFactory();
+    try {
+      new SchedulerManager(threadFactory);
+    } finally {
+      threadFactory.killThreads();
+    }
   }
 }

--- a/src/test/java/org/threadly/concurrent/SubmitterExecutorInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/SubmitterExecutorInterfaceTest.java
@@ -211,8 +211,6 @@ public abstract class SubmitterExecutorInterfaceTest {
       ListenableFuture<?> future = executor.submit(tr);
       // no exception should propagate
       
-      tr.blockTillFinished();
-      assertTrue(future.isDone());
       try {
         future.get();
         fail("Exception should have thrown");

--- a/src/test/java/org/threadly/concurrent/TestRuntimeFailureRunnable.java
+++ b/src/test/java/org/threadly/concurrent/TestRuntimeFailureRunnable.java
@@ -25,7 +25,7 @@ public class TestRuntimeFailureRunnable extends TestRunnable {
   }
 
   @Override
-  public void handleRunFinish() {
+  public void handleRunStart() {
     if (toThrowException != null) {
       throw toThrowException;
     } else {


### PR DESCRIPTION
This changes the logic so that low priority tasks wont be executed if there are any high priority tasks UNLESS they have waited up to the max low priority wait time (assuming the high priority tasks are not being delayed that much, high priority always has priority).
It also changes from having two threads to consume tasks to just one.  This one thread now gets a worker first, then decides which task should be provided to that worker.  Because we get the worker first this resolves #75.
This does increase the jar size, and does not really change the performance (if anything it might be _slightly_ slower, but the benchmarks show a statistically insignificant difference).