### PR TITLE
This improves the rate the profiler can collect samples

### DIFF
--- a/src/test/java/org/threadly/util/debug/ControlledThreadProfilerTest.java
+++ b/src/test/java/org/threadly/util/debug/ControlledThreadProfilerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.threadly.test.concurrent.TestUtils;
+import org.threadly.util.debug.Profiler.ThreadSample;
 
 @SuppressWarnings("javadoc")
 public class ControlledThreadProfilerTest extends ProfilerTest {
@@ -20,6 +21,7 @@ public class ControlledThreadProfilerTest extends ProfilerTest {
   private ControlledThreadProfiler ctProfiler;
   
   @Before
+  @Override
   public void setup() {
     ctProfiler = new ControlledThreadProfiler(POLL_INTERVAL);
     profiler = ctProfiler;
@@ -75,20 +77,21 @@ public class ControlledThreadProfilerTest extends ProfilerTest {
   
   @Test
   public void getProfileThreadsIteratorEmptyTest() {
-    Iterator<Thread> it = profiler.pStore.getProfileThreadsIterator();
+    Iterator<?> it = profiler.pStore.getProfileThreadsIterator();
     
     assertNotNull(it);
     assertFalse(it.hasNext());
   }
   
   @Test
+  @Override
   public void getProfileThreadsIteratorTest() {
     ctProfiler.addProfiledThread(Thread.currentThread());
-    Iterator<Thread> it = profiler.pStore.getProfileThreadsIterator();
+    Iterator<? extends ThreadSample> it = profiler.pStore.getProfileThreadsIterator();
     
     assertNotNull(it);
     assertTrue(it.hasNext());
-    assertTrue(it.next() == Thread.currentThread());
+    assertTrue(it.next().getThread() == Thread.currentThread());
     // should only have the one added thread
     assertFalse(it.hasNext());
   }
@@ -99,6 +102,7 @@ public class ControlledThreadProfilerTest extends ProfilerTest {
     // not relevant for this class
   }
   
+  @Override
   @SuppressWarnings("unused")
   @Test (expected = IllegalArgumentException.class)
   public void constructorFail() {
@@ -245,6 +249,7 @@ public class ControlledThreadProfilerTest extends ProfilerTest {
   }
   
   @Test
+  @Override
   public void dumpStringTest() {
     ctProfiler.addProfiledThread(Thread.currentThread());
     
@@ -267,6 +272,7 @@ public class ControlledThreadProfilerTest extends ProfilerTest {
   }
   
   @Test
+  @Override
   public void dumpOutputStreamTest() {
     ctProfiler.addProfiledThread(Thread.currentThread());
     

--- a/src/test/java/org/threadly/util/debug/ProfilerTest.java
+++ b/src/test/java/org/threadly/util/debug/ProfilerTest.java
@@ -85,7 +85,7 @@ public class ProfilerTest {
   
   @Test
   public void getProfileThreadsIteratorTest() {
-    Iterator<Thread> it = profiler.pStore.getProfileThreadsIterator();
+    Iterator<?> it = profiler.pStore.getProfileThreadsIterator();
     
     assertNotNull(it);
     assertTrue(it.hasNext());
@@ -94,7 +94,7 @@ public class ProfilerTest {
   
   @Test (expected = NoSuchElementException.class)
   public void profileThreadsIteratorNextFail() {
-    Iterator<Thread> it = profiler.pStore.getProfileThreadsIterator();
+    Iterator<?> it = profiler.pStore.getProfileThreadsIterator();
     
     while (it.hasNext()) {
       assertNotNull(it.next());
@@ -106,7 +106,7 @@ public class ProfilerTest {
   
   @Test (expected = UnsupportedOperationException.class)
   public void profileThreadsIteratorRemoveFail() {
-    Iterator<Thread> it = profiler.pStore.getProfileThreadsIterator();
+    Iterator<?> it = profiler.pStore.getProfileThreadsIterator();
     it.next();
     
     // not currently supported

--- a/src/test/java/org/threadly/util/debug/ProfilerThreadIteratorTest.java
+++ b/src/test/java/org/threadly/util/debug/ProfilerThreadIteratorTest.java
@@ -22,51 +22,9 @@ public class ProfilerThreadIteratorTest {
   }
   
   @Test
-  public void refreshThreadsTest() {
-    ti.refreshThreads();
-    
-    assertTrue(ti.threads.length > 0);
-    assertTrue(ti.enumerateCount > 0);
-    assertEquals(0, ti.currentIndex);
-  }
-  
-  @Test
-  public void refreshThreadsNullPreviousThreadsTest() {
-    ti.refreshThreads();
-    Thread t = new Thread();
-    ti.threads = new Thread[ti.enumerateCount * 10];
-    for (int i = 0; i < ti.threads.length; i++) {
-      ti.threads[i] = t;
-    }
-    ti.enumerateCount = ti.threads.length;
-    
-    ti.refreshThreads();
-    
-    for (int i = ti.enumerateCount; i < ti.threads.length; i++) {
-      assertNull(ti.threads[i]);
-    }
-  }
-  
-  @Test
-  public void hasNextTest() {
-    assertFalse(ti.hasNext());
-    
-    ti.refreshThreads();
-    
-    assertTrue(ti.hasNext());
-    
-    ti.currentIndex = ti.enumerateCount;
-    
-    assertFalse(ti.hasNext());
-  }
-  
-  @Test
-  public void nextTest() {
-    ti.refreshThreads();
-    Thread t = new Thread();
-    ti.threads[0] = t;
-    
-    assertTrue(t == ti.next());
+  public void constructorTest() {
+    assertNotNull(ti.it);
+    assertTrue(ti.it.hasNext());
   }
   
   @Test (expected = UnsupportedOperationException.class)


### PR DESCRIPTION
It turns out that using Thread.getAllStackTraces() is more efficent than calling Thread.enumerate(Thread[]).  Even though we made good improvements in maintaining that array as thread counts don't change, that enumeration happens on the ThreadGroup, and requires synchronization between each one.  getAllStackTraces makes two native calls, one to get all the threads (which constructs the array), and two to dump the stack trace elements for all the threads.  It then constructs a map and adds in the threads to their relative stack traces.
Ultimately this is about 10x faster than the previous version, though does require some additional code and jar space.