### PR TITLE
Added a "Watchdog" implementation

### DIFF
--- a/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
@@ -160,7 +160,7 @@ public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureC
 
   @Override
   public boolean cancel(boolean interruptThread) {
-    if (done || canceled) {
+    if (done) {
       return false;
     }
     

--- a/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
@@ -160,6 +160,10 @@ public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureC
 
   @Override
   public boolean cancel(boolean interruptThread) {
+    if (done || canceled) {
+      return false;
+    }
+    
     boolean canceled;
     synchronized (resultLock) {
       if (! done) {

--- a/src/main/java/org/threadly/concurrent/future/Watchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/Watchdog.java
@@ -84,8 +84,9 @@ public class Watchdog {
   /**
    * Watch a given {@link ListenableFuture} to ensure that it completes within the constructed 
    * time limit.  If the future is not marked as done by the time limit then it will be 
-   * completed by invoking {@link ListenableFuture#cancel(boolean)} with {@code true} to interrupt 
-   * the running thread.
+   * completed by invoking {@link ListenableFuture#cancel(boolean)}.  Weather a {@code true} or 
+   * {@code false} will be provided to interrupt the running thread is dependent on how this 
+   * {@link Watchdog} was constructed.
    * 
    * @param future Future to inspect to ensure completion
    */

--- a/src/main/java/org/threadly/concurrent/future/Watchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/Watchdog.java
@@ -1,0 +1,195 @@
+package org.threadly.concurrent.future;
+
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.threadly.concurrent.SimpleSchedulerInterface;
+import org.threadly.concurrent.SingleThreadScheduler;
+import org.threadly.util.Clock;
+
+/**
+ * <p>This class is to guarantee that a given {@link ListenableFuture} is completed within a 
+ * timeout.  Once the timeout is reached, if the future has not already completed this will 
+ * attempt to invoke {@link ListenableFuture#cancel(boolean)}.  The future should then throw a 
+ * {@link java.util.concurrent.CancellationException} on a {@link ListenableFuture#get()} call.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 4.0.0
+ */
+public class Watchdog {
+  private static final AtomicReference<SingleThreadScheduler> STATIC_SCHEDULER;
+  
+  static {
+    STATIC_SCHEDULER = new AtomicReference<SingleThreadScheduler>();
+  }
+  
+  private static final SimpleSchedulerInterface getStaticScheduler() {
+    SingleThreadScheduler sts = STATIC_SCHEDULER.get();
+    if (sts == null) {
+      sts = new SingleThreadScheduler();
+      if (! STATIC_SCHEDULER.compareAndSet(null, sts)) {
+        sts.shutdownNow();
+        sts = STATIC_SCHEDULER.get();
+      }
+    }
+    
+    return sts;
+  }
+  
+  protected final SimpleSchedulerInterface scheduler;
+  protected final long timeoutInMillis;
+  protected final boolean sendInterruptToTrackedThreads;
+  protected final Runnable checkRunner;
+  protected final Queue<FutureWrapper> futures;
+  // -1 = not scheduled, 0 = scheduled, 1 = running, 2 = more added while running
+  private final AtomicInteger checkRunnerStatus;
+  
+  /**
+   * Constructs a new {@link Watchdog}.  This constructor will use a default static scheduler 
+   * (which is lazily constructed).  This should be fine in most cases, but you can provide your 
+   * own scheduler if you want to avoid the thread creation (which is shared among all instances 
+   * that were constructed with this constructor).
+   * 
+   * @param timeoutInMillis Time in milliseconds that futures will be set to error if they are not done
+   * @param sendInterruptToTrackedThreads If {@code true}, and a thread is provided with the future, 
+   *                                        an interrupt will be sent on timeout
+   */
+  public Watchdog(long timeoutInMillis, boolean sendInterruptToTrackedThreads) {
+    this(getStaticScheduler(), timeoutInMillis, sendInterruptToTrackedThreads);
+  }
+  
+  /**
+   * Constructs a new {@link Watchdog} with a scheduler of your choosing.  It is critical that 
+   * this scheduler has a free thread available to inspect futures which may not have completed in 
+   * the given timeout.  You may want to use a limiter to ensure that there are threads available.
+   * 
+   * @param scheduler Scheduler to schedule task to look for expired futures
+   * @param timeoutInMillis Time in milliseconds that futures will be set to error if they are not done
+   * @param sendInterruptToTrackedThreads If {@code true}, and a thread is provided with the future, 
+   *                                        an interrupt will be sent on timeout
+   */
+  public Watchdog(SimpleSchedulerInterface scheduler, long timeoutInMillis, 
+                  boolean sendInterruptToTrackedThreads) {
+    this.scheduler = scheduler;
+    this.timeoutInMillis = timeoutInMillis;
+    this.sendInterruptToTrackedThreads = sendInterruptToTrackedThreads;
+    this.checkRunner = new CheckRunner();
+    this.futures = new ConcurrentLinkedQueue<FutureWrapper>();
+    this.checkRunnerStatus = new AtomicInteger(-1);
+  }
+  
+  /**
+   * Watch a given {@link ListenableFuture} to ensure that it completes within the constructed 
+   * time limit.  If the future is not marked as done by the time limit then it will be 
+   * completed by invoking {@link ListenableFuture#cancel(boolean)} with {@code true} to interrupt 
+   * the running thread.
+   * 
+   * @param future Future to inspect to ensure completion
+   */
+  public void watch(ListenableFuture<?> future) {
+    if (future == null || future.isDone()) {
+      return;
+    }
+    
+    final FutureWrapper fw = new FutureWrapper(future);
+    futures.add(fw);
+    // we attempt to remove the future on completion to reduce inspection needed
+    future.addListener(new Runnable() {
+      @Override
+      public void run() {
+        futures.remove(fw);
+      }
+    });
+    
+    while (true) {
+      if (checkRunnerStatus.get() == -1) {
+        if (checkRunnerStatus.compareAndSet(-1, 0)) {
+          scheduler.schedule(checkRunner, timeoutInMillis);
+          return;
+        }
+      } else if (checkRunnerStatus.get() == 1) {
+        if (checkRunnerStatus.compareAndSet(1, 2)) {
+          return;
+        }
+      } else {
+        // either already scheduled, or already marked as more added
+        return;
+      }
+    }
+  }
+
+  /**
+   * <p>Just a simple wrapper class so we can hold not just the future, but what time the future 
+   * will expire at.</p>
+   * 
+   * @author jent - Mike Jensen
+   * @since 4.0.0
+   */
+  private class FutureWrapper {
+    public final long expireTime;
+    private final ListenableFuture<?> future;
+
+    public FutureWrapper(ListenableFuture<?> future) {
+      this.expireTime = Clock.accurateForwardProgressingMillis() + timeoutInMillis;
+      this.future = future;
+    }
+  }
+
+  /**
+   * <p>This runnable inspects over the queue looking for futures which have expired and need to 
+   * be canceled.  It may reschedule itself if it is not able to fully examine the queue (because 
+   * not all items are currently ready for inspection).</p>
+   * 
+   * @author jent - Mike Jensen
+   * @since 4.0.0
+   */
+  private class CheckRunner implements Runnable {
+    @Override
+    public void run() {
+      checkRunnerStatus.set(1);
+      
+      Clock.systemNanoTime(); // update for accurate time checking
+      Iterator<FutureWrapper> it = futures.iterator();
+      FutureWrapper fw = null;
+      while (it.hasNext()) {
+        fw = it.next();
+        if (Clock.lastKnownForwardProgressingMillis() >= fw.expireTime) {
+          try {
+            fw.future.cancel(sendInterruptToTrackedThreads);
+          } finally {
+            fw = null;
+            it.remove();
+          }
+        } else {
+          /* since futures are added in order of expiration, 
+          we know at this point we don't need to inspect any more items*/
+          break;
+        }
+      }
+      
+      if (fw != null) {
+        long nextRunDelay = fw.expireTime - Clock.lastKnownForwardProgressingMillis();
+        if (nextRunDelay <= 0) {
+          scheduler.execute(this);
+        } else {
+          scheduler.schedule(this, nextRunDelay);
+        }
+      } else {
+        while (true) {
+          if (checkRunnerStatus.get() == 1) {
+            if (checkRunnerStatus.compareAndSet(1, -1)) {
+              return;
+            }
+          } else if (checkRunnerStatus.get() == 2) {
+            // will be set back to 1 when this restarts
+            scheduler.execute(this);
+            return;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/future/WatchdogTest.java
+++ b/src/test/java/org/threadly/concurrent/future/WatchdogTest.java
@@ -1,0 +1,87 @@
+package org.threadly.concurrent.future;
+
+import static org.junit.Assert.*;
+import static org.threadly.TestConstants.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.NoThreadScheduler;
+import org.threadly.test.concurrent.TestUtils;
+
+@SuppressWarnings("javadoc")
+public class WatchdogTest {
+  private NoThreadScheduler scheduler;
+  private Watchdog watchdog;
+  
+  @Before
+  public void setup() {
+    scheduler = new NoThreadScheduler();
+    watchdog = new Watchdog(scheduler, 1, true);
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler = null;
+    watchdog = null;
+  }
+  
+  @Test
+  public void emptySchedulerConstructorTest() {
+    watchdog = new Watchdog(1, true);
+    
+    assertNotNull(watchdog.scheduler);
+  }
+  
+  @Test
+  public void alreadyDoneFutureWatchTest() {
+    ListenableFuture<Object> future = FutureUtils.immediateResultFuture(null);
+    watchdog.watch(future);
+    
+    assertTrue(watchdog.futures.isEmpty());
+  }
+  
+  @Test
+  public void futureFinishTest() {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<Object>();
+    
+    watchdog.watch(slf);
+    
+    assertEquals(1, watchdog.futures.size());
+    
+    slf.setResult(null);
+    
+    assertTrue(watchdog.futures.isEmpty());
+  }
+  
+  @Test
+  public void expiredFutureTest() {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<Object>();
+    watchdog.watch(slf);
+    
+    TestUtils.blockTillClockAdvances();
+    
+    assertEquals(1, scheduler.tick(null));
+    
+    assertTrue(slf.isCancelled());
+    assertTrue(watchdog.futures.isEmpty());
+  }
+  
+  @Test
+  public void rescheduledFutureCheckTest() throws InterruptedException {
+    watchdog = new Watchdog(scheduler, DELAY_TIME * 2, true);
+    SettableListenableFuture<Object> slf1 = new SettableListenableFuture<Object>();
+    watchdog.watch(slf1);
+    TestUtils.sleep(DELAY_TIME);
+    SettableListenableFuture<Object> slf2 = new SettableListenableFuture<Object>();
+    watchdog.watch(slf2);
+    
+    assertEquals(1, scheduler.blockingTick(null));
+    assertTrue(slf1.isCancelled());
+    assertFalse(slf2.isCancelled());
+    
+    assertEquals(1, scheduler.blockingTick(null));
+    assertTrue(slf1.isCancelled());
+    assertTrue(slf2.isCancelled());
+  }
+}


### PR DESCRIPTION
This also changes the SettableListenableFuture so that it can now be canceled.  If you want a thread that is processing the SLF to be interrupted on cancellation you must set it via "setRunningThread".
The watchdog works by accepting in future's and if they do not complete in the time specified at construction they will have .cancel() called on them.  You can determine at construction if these cancellation calls should send an interrupt or not.  If you want to handle timeouts from these cases you need to catch the unchecked "CancellationException".  If using a FutureCallback, it will be called as a failure with a CancellationException being the failure cause.

This will be a 4.0.0 change due to the behavior change of cancelation in SettableListenableFuture.  I want to get an agreement on the watchdog implementation before we possibly add executors that depend on it.