### PR TITLE
Improvements to SettableListenableFuture and the Profiler

### DIFF
--- a/src/main/java/org/threadly/concurrent/RunnableChain.java
+++ b/src/main/java/org/threadly/concurrent/RunnableChain.java
@@ -1,6 +1,6 @@
 package org.threadly.concurrent;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 
 import org.threadly.util.ExceptionUtils;
@@ -24,7 +24,7 @@ public class RunnableChain implements Runnable {
   public RunnableChain(boolean exceptionStopsChain, 
                        Iterable<? extends Runnable> toRun) {
     if (toRun == null) {
-      toRun = new ArrayList<Runnable>(0);
+      toRun = Collections.emptyList();
     }
     
     this.exceptionStopsChain = exceptionStopsChain;

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -39,11 +39,25 @@ public class SettableListenableFutureTest {
     fail("Should have thrown exception");
   }
   
+  @Test
+  public void setResultResultTest() {
+    slf = new SettableListenableFuture<String>(false);
+    slf.setResult(null);
+    slf.setResult(null);
+  }
+  
   @Test (expected = IllegalStateException.class)
   public void setFailureResultFail() {
     slf.setFailure(null);
     slf.setResult(null);
     fail("Should have thrown exception");
+  }
+  
+  @Test
+  public void setFailureResultTest() {
+    slf = new SettableListenableFuture<String>(false);
+    slf.setFailure(null);
+    slf.setResult(null);
   }
   
   @Test (expected = IllegalStateException.class)
@@ -53,11 +67,53 @@ public class SettableListenableFutureTest {
     fail("Should have thrown exception");
   }
   
+  @Test
+  public void setResultFailureTest() {
+    slf = new SettableListenableFuture<String>(false);
+    slf.setResult(null);
+    slf.setFailure(null);
+  }
+  
   @Test (expected = IllegalStateException.class)
   public void setFailureFailureFail() {
     slf.setFailure(null);
     slf.setFailure(null);
     fail("Should have thrown exception");
+  }
+  
+  @Test
+  public void setFailureFailureTest() {
+    slf = new SettableListenableFuture<String>(false);
+    slf.setFailure(null);
+    slf.setFailure(null);
+  }
+  
+  @Test (expected = IllegalStateException.class)
+  public void cancelSetResultFail() {
+    slf.cancel(false);
+    slf.setResult(null);
+    fail("Should have thrown exception");
+  }
+  
+  @Test
+  public void cancelSetResultTest() {
+    slf = new SettableListenableFuture<String>(false);
+    slf.cancel(false);
+    slf.setResult(null);
+  }
+  
+  @Test (expected = IllegalStateException.class)
+  public void cancelSetFailureFail() {
+    slf.cancel(false);
+    slf.setFailure(null);
+    fail("Should have thrown exception");
+  }
+  
+  @Test
+  public void cancelSetFailureTest() {
+    slf = new SettableListenableFuture<String>(false);
+    slf.cancel(false);
+    slf.setFailure(null);
   }
   
   @Test (expected = IllegalStateException.class)


### PR DESCRIPTION
I included both of these in the same commit/pull request since neither is _too_ big.
* The first is a new optional behavior in the SettableListenableFuture.  You can construct it so that if it has already completed it will just ignore future setResult or setFuture requests.  I know in the new ambush project we have to cancel these possible annoyingly (I think litesockets has a few places it is catching this IllegalStateException as well).
* The second improvement is to be able to start the profiler with an automatic stop time.  This is primarly so that it can make it safer to exposue the profiler in production systems.  By forcing a limited run time (as well as the fact that it wont run concurrently), it can become a much safer way to expose the profiler.