### PR TITLE
Invocation tee

### DIFF
--- a/src/main/java/org/threadly/concurrent/event/DefaultExecutorListenerHelper.java
+++ b/src/main/java/org/threadly/concurrent/event/DefaultExecutorListenerHelper.java
@@ -65,6 +65,9 @@ public class DefaultExecutorListenerHelper<T> extends ListenerHelper<T> {
   
   @Override
   public void addListener(T listener, Executor executor) {
+    if (listener == null) {
+      return;
+    }
     if (executor == null) {
       executor = taskDistributor.getSubmitterForKey(listener);
     }

--- a/src/main/java/org/threadly/concurrent/event/DefaultExecutorRunnableListenerHelper.java
+++ b/src/main/java/org/threadly/concurrent/event/DefaultExecutorRunnableListenerHelper.java
@@ -49,6 +49,9 @@ public class DefaultExecutorRunnableListenerHelper extends RunnableListenerHelpe
   
   @Override
   public void addListener(Runnable listener, Executor executor) {
+    if (listener == null) {
+      return;
+    }
     if (executor == null) {
       executor = taskDistributor.getSubmitterForKey(listener);
     }

--- a/src/main/java/org/threadly/concurrent/event/InvocationTee.java
+++ b/src/main/java/org/threadly/concurrent/event/InvocationTee.java
@@ -1,0 +1,37 @@
+package org.threadly.concurrent.event;
+
+/**
+ * <p>Simple utility for multiplying invocations across multiple instances of a given interface.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 4.3.0
+ */
+public class InvocationTee {
+  /**
+   * This creates a tee proxy for a given class with a set of instances of said interface.  Any 
+   * invocation to the returned instance (proxy), will be multiple to all provided instances.  If 
+   * provided arguments are mutable, and an instance mutates that argument, future invoked 
+   * instances may see that modification.  It is not deterministic which order the instances will 
+   * be invoked in.  
+   * 
+   * Under the hood this depends on {@link ListenerHelper}, and thus has the same limitations.  
+   * Most specifically the provided {@code teeInterface} must in fact be an interface, and not a 
+   * an abstract class, or other non-interface types.  In addition any invocations called to this 
+   * must be a {@code void} return type.
+   * 
+   * @param <T> Type representing interface to multiple invocations of
+   * @param teeInterface Interface class for which the returned instance must implement
+   * @param instances Instances of said interface which invocations should be multiplied to
+   * @return A returned interface which will map all invocations to all provided interfaces
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T tee(Class<? super T> teeInterface, T ... instances) {
+    ListenerHelper<T> lh = ListenerHelper.build(teeInterface);
+    
+    for (T instance : instances) {
+      lh.addListener(instance);
+    }
+    
+    return lh.call();
+  }
+}

--- a/src/main/java/org/threadly/concurrent/event/ListenerHelper.java
+++ b/src/main/java/org/threadly/concurrent/event/ListenerHelper.java
@@ -118,7 +118,9 @@ public class ListenerHelper<T> {
    * @param executor {@link Executor} to call listener on, or {@code null}
    */
   public void addListener(T listener, Executor executor) {
-    ArgumentVerifier.assertNotNull(listener, "listener");
+    if (listener == null) {
+      return;
+    }
     
     boolean addingFromCallingThread = Thread.holdsLock(listenersLock);
     synchronized (listenersLock) {

--- a/src/main/java/org/threadly/concurrent/event/ListenerHelper.java
+++ b/src/main/java/org/threadly/concurrent/event/ListenerHelper.java
@@ -4,6 +4,9 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -74,6 +77,22 @@ public class ListenerHelper<T> {
     return (T) Proxy.newProxyInstance(listenerInterface.getClassLoader(), 
                                       new Class<?>[] { listenerInterface }, 
                                       new ListenerCaller());
+  }
+  
+  /**
+   * Return a collection of the currently subscribed listener instances.  This returned collection 
+   * can NOT be modified.
+   * 
+   * @return A non-null collection of currently subscribed listeners
+   */
+  public Collection<T> getSubscribedListeners() {
+    synchronized (listenersLock) {
+      if (listeners == null) {
+        return Collections.emptyList();
+      } else {
+        return Collections.unmodifiableList(new ArrayList<T>(listeners.keySet()));
+      }
+    }
   }
   
   /**

--- a/src/main/java/org/threadly/concurrent/event/RunnableListenerHelper.java
+++ b/src/main/java/org/threadly/concurrent/event/RunnableListenerHelper.java
@@ -8,7 +8,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.threadly.concurrent.ContainerHelper;
-import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.ExceptionUtils;
 
 /**
@@ -151,7 +150,9 @@ public class RunnableListenerHelper {
    * @param executor executor listener should run on, or {@code null}
    */
   public void addListener(Runnable listener, Executor executor) {
-    ArgumentVerifier.assertNotNull(listener, "listener");
+    if (listener == null) {
+      return;
+    }
     
     boolean addingFromCallingThread = Thread.holdsLock(listenersLock);
     synchronized (listenersLock) {

--- a/src/main/java/org/threadly/concurrent/event/RunnableListenerHelper.java
+++ b/src/main/java/org/threadly/concurrent/event/RunnableListenerHelper.java
@@ -1,5 +1,8 @@
 package org.threadly.concurrent.event;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -39,6 +42,22 @@ public class RunnableListenerHelper {
     this.callOnce = callListenersOnce;
     this.done = new AtomicBoolean(false);
     this.listeners = null;
+  }
+  
+  /**
+   * Return a collection of the currently subscribed listener instances.  This returned collection 
+   * can NOT be modified.
+   * 
+   * @return A non-null collection of currently subscribed listeners
+   */
+  public Collection<Runnable> getSubscribedListeners() {
+    synchronized (listenersLock) {
+      if (listeners == null) {
+        return Collections.emptyList();
+      } else {
+        return Collections.unmodifiableList(new ArrayList<Runnable>(listeners.keySet()));
+      }
+    }
   }
   
   /**

--- a/src/test/java/org/threadly/concurrent/event/InvocationTeeTest.java
+++ b/src/test/java/org/threadly/concurrent/event/InvocationTeeTest.java
@@ -1,0 +1,29 @@
+package org.threadly.concurrent.event;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.threadly.test.concurrent.TestRunnable;
+
+@SuppressWarnings("javadoc")
+public class InvocationTeeTest {
+  @Test
+  public void invokTest() {
+    TestRunnable tr = new TestRunnable();
+    Runnable r = InvocationTee.tee(Runnable.class, null, tr);
+    r.run();
+    assertTrue(tr.ranOnce());
+  }
+  
+  @Test
+  public void invokTwiceTest() {
+    TestRunnable tr1 = new TestRunnable();
+    TestRunnable tr2 = new TestRunnable();
+    Runnable r = InvocationTee.tee(Runnable.class, tr1, null, tr2, null);
+    r.run();
+    r.run();
+    
+    assertEquals(2, tr1.getRunCount());
+    assertEquals(2, tr2.getRunCount());
+  }
+}

--- a/src/test/java/org/threadly/concurrent/event/ListenerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/event/ListenerHelperTest.java
@@ -38,6 +38,12 @@ public class ListenerHelperTest {
   }
   
   @Test
+  public void addNullListenerTest() {
+    makeListenerHelper(TestInterface.class).addListener(null);
+    // no exception thrown
+  }
+  
+  @Test
   public void addListenerTest() {
     ListenerHelper<TestInterface> ch = makeListenerHelper(TestInterface.class);
     TestImp ti = new TestImp();
@@ -90,11 +96,6 @@ public class ListenerHelperTest {
     ch.call().call(secondCallInt, secondCallStr);
     assertEquals(secondCallInt, addedListener.lastInt);
     assertEquals(secondCallStr, addedListener.lastString);
-  }
-  
-  @Test (expected = IllegalArgumentException.class)
-  public void addListenerFail() {
-    makeListenerHelper(TestInterface.class).addListener(null);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/event/ListenerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/event/ListenerHelperTest.java
@@ -38,6 +38,17 @@ public class ListenerHelperTest {
   }
   
   @Test
+  public void getSubscribedListenersTest() {
+    ListenerHelper<TestInterface> lh = makeListenerHelper(TestInterface.class);
+    assertTrue(lh.getSubscribedListeners().isEmpty());
+    TestImp ti = new TestImp();
+    lh.addListener(ti);
+    assertTrue(lh.getSubscribedListeners().contains(ti));
+    lh.removeListener(ti);
+    assertTrue(lh.getSubscribedListeners().isEmpty());
+  }
+  
+  @Test
   public void addNullListenerTest() {
     makeListenerHelper(TestInterface.class).addListener(null);
     // no exception thrown

--- a/src/test/java/org/threadly/concurrent/event/RunnableListenerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/event/RunnableListenerHelperTest.java
@@ -35,6 +35,16 @@ public class RunnableListenerHelperTest {
   }
   
   @Test
+  public void getSubscribedListenersTest() {
+    assertTrue(onceHelper.getSubscribedListeners().isEmpty());
+    TestRunnable tr = new TestRunnable();
+    onceHelper.addListener(tr);
+    assertTrue(onceHelper.getSubscribedListeners().contains(tr));
+    onceHelper.removeListener(tr);
+    assertTrue(onceHelper.getSubscribedListeners().isEmpty());
+  }
+  
+  @Test
   public void addNullListenerTest() {
     onceHelper.addListener(null);
     repeatedHelper.addListener(null);

--- a/src/test/java/org/threadly/concurrent/event/RunnableListenerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/event/RunnableListenerHelperTest.java
@@ -35,6 +35,13 @@ public class RunnableListenerHelperTest {
   }
   
   @Test
+  public void addNullListenerTest() {
+    onceHelper.addListener(null);
+    repeatedHelper.addListener(null);
+    // no exception thrown
+  }
+  
+  @Test
   public void runListenerNoExecutorTest() {
     TestRunnable tr = new TestRunnable();
     onceHelper.runListener(tr, null, true);

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -39,12 +39,12 @@ public class ListenableFutureTaskTest extends RunnableFutureTest {
     return new ListenableFutureTask<T>(false, task);
   }
   
-  @Test (expected = IllegalArgumentException.class)
-  public void addListenerFail() {
+  @Test
+  public void addNullListenerTest() {
     ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
     
     future.addListener(null);
-    fail("Exception should have thrown");
+    // no exception should have been thrown
   }
   
   @Test


### PR DESCRIPTION
This adds just a little API around our ListenerHelper to make an easy way to multiple calls for a given interface to multiple instances.

@blendmaster I took your idea for the "TeeProxy" and made it into this.  Instead of renaming ListenerHelper I made this small static function to make a bit nicer API around this use case.  Let me know if you have any suggestions on the API (or otherwise).

@lwahlmeier go ahead and merge it if it looks good to you