### PR TITLE
KeyedLimiters: A new limiter type that limits based off an object key

### DIFF
--- a/src/main/java/org/threadly/concurrent/limiter/AbstractKeyedLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/AbstractKeyedLimiter.java
@@ -1,0 +1,294 @@
+package org.threadly.concurrent.limiter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.threadly.concurrent.AbstractSubmitterExecutor;
+import org.threadly.concurrent.RunnableCallableAdapter;
+import org.threadly.concurrent.RunnableContainer;
+import org.threadly.concurrent.SubmitterExecutor;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.concurrent.future.ListenableRunnableFuture;
+import org.threadly.concurrent.lock.StripedLock;
+import org.threadly.util.ArgumentVerifier;
+import org.threadly.util.StringUtils;
+
+/**
+ * <p>Abstract implementation for keyed limiters.  Unlike the other limiters we can not extend off 
+ * of each one, and just add extra functionality.  Instead they must extend these abstract classes.  
+ * The reason for that being that these types of limiters use the other limiters, rather than 
+ * extend functionality off each other.</p>
+ * 
+ * @param <T> Type of limiter stored internally
+ * @author jent - Mike Jensen
+ * @since 4.3.0
+ */
+abstract class AbstractKeyedLimiter<T extends ExecutorLimiter> {
+  protected static final int DEFAULT_LOCK_PARALISM = 32;
+  protected static final float CONCURRENT_HASH_MAP_LOAD_FACTOR = 0.75f;  // 0.75 is ConcurrentHashMap default
+  protected static final int CONCURRENT_HASH_MAP_MIN_SIZE = 8;
+  protected static final int CONCURRENT_HASH_MAP_MAX_INITIAL_SIZE = 64;
+  protected static final int CONCURRENT_HASH_MAP_MAX_CONCURRENCY_LEVEL = 32;
+  
+  protected final Executor executor;
+  protected final int maxConcurrency;
+  protected final String subPoolName;
+  protected final boolean addKeyToThreadName;
+  protected final StripedLock sLock;
+  protected final ConcurrentHashMap<Object, LimiterContainer> currentLimiters;
+  
+  protected AbstractKeyedLimiter(Executor executor, int maxConcurrency, 
+                                 String subPoolName, boolean addKeyToThreadName, 
+                                 int expectedTaskAdditionParallism) {
+    ArgumentVerifier.assertGreaterThanZero(maxConcurrency, "maxConcurrency");
+    ArgumentVerifier.assertNotNull(executor, "executor");
+
+    this.executor = executor;
+    this.maxConcurrency = maxConcurrency;
+    // make sure this is non-null so that it 'null' wont appear
+    this.subPoolName = StringUtils.nullToEmpty(subPoolName);
+    this.addKeyToThreadName = addKeyToThreadName;
+    this.sLock = new StripedLock(expectedTaskAdditionParallism);
+    int mapInitialSize = Math.min(sLock.getExpectedConcurrencyLevel(), 
+                                  CONCURRENT_HASH_MAP_MAX_INITIAL_SIZE);
+    if (mapInitialSize < CONCURRENT_HASH_MAP_MIN_SIZE) {
+      mapInitialSize = CONCURRENT_HASH_MAP_MIN_SIZE;
+    }
+    int mapConcurrencyLevel = Math.min(sLock.getExpectedConcurrencyLevel() / 2, 
+                                       CONCURRENT_HASH_MAP_MAX_CONCURRENCY_LEVEL);
+    if (mapConcurrencyLevel < 1) {
+      mapConcurrencyLevel = 1;
+    }
+    this.currentLimiters = new ConcurrentHashMap<Object, LimiterContainer>(mapInitialSize,  
+                                                                           CONCURRENT_HASH_MAP_LOAD_FACTOR, 
+                                                                           mapConcurrencyLevel);
+  }
+  
+  /**
+   * Check how many threads may run in parallel for a single unique key.
+   * 
+   * @return maximum concurrent tasks to be run
+   */
+  public int getMaxConcurrencyPerKey() {
+    return maxConcurrency;
+  }
+  
+  /**
+   * Check how many tasks are currently being limited, and not submitted yet for a given key.  
+   * This can be useful for knowing how backed up a specific key is.
+   * 
+   * @param taskKey Key which would be limited
+   * @return Quantity of tasks being held back inside the limiter, and thus still queued
+   */
+  public int getUnsubmittedTaskCount(Object taskKey) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    
+    LimiterContainer lc = currentLimiters.get(taskKey);
+    return lc == null ? 0 : lc.limiter.getUnsubmittedTaskCount();
+  }
+  
+  /**
+   * Get a map of all the keys and how many tasks are held back (queued) in each limiter per key.  
+   * This map is generated without locking.  Due to that, this may be inaccurate as task queue 
+   * sizes changed while iterating all key's limiters.
+   * 
+   * Because this requires an iteration of all limiters, if only a single limiters unsubmitted 
+   * count is needed, use {@link #getUnsubmittedTaskCount(Object)} as a cheaper alternative.
+   * 
+   * @return Map of task key's to their respective task queue size
+   */
+  public Map<Object, Integer> getUnsubmittedTaskCountMap() {
+    Map<Object, Integer> result = new HashMap<Object, Integer>();
+    for (Map.Entry<Object, LimiterContainer> e : currentLimiters.entrySet()) {
+      int taskCount = e.getValue().limiter.getUnsubmittedTaskCount();
+      if (taskCount > 0) {
+        result.put(e.getKey(), taskCount);
+      }
+    }
+    return result;
+  }
+  
+  /**
+   * Provide a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#execute(Runnable)}
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Task to be executed
+   */
+  public void execute(Object taskKey, Runnable task) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    ArgumentVerifier.assertNotNull(task, "task");
+    
+    getLimiterContainer(taskKey).execute(task);
+  }
+  
+  /**
+   * Submit a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Runnable)}
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Task to be executed
+   * @return Future to represent when the execution has occurred
+   */
+  public ListenableFuture<?> submit(Object taskKey, Runnable task) {
+    return submit(taskKey, task, null);
+  }
+  
+  /**
+   * Submit a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Runnable, Object)}
+   * 
+   * @param <TT> type of result returned from the future
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Runnable to be executed
+   * @param result Result to be returned from future when task completes
+   * @return Future to represent when the execution has occurred and provide the given result
+   */
+  public <TT> ListenableFuture<TT> submit(Object taskKey, Runnable task, TT result) {
+    return submit(taskKey, new RunnableCallableAdapter<TT>(task, result));
+  }
+  
+  /**
+   * Submit a callable to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Callable)}
+   * 
+   * @param <TT> type of result returned from the future
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Callable to be executed
+   * @return Future to represent when the execution has occurred and provide the result from the callable
+   */
+  public <TT> ListenableFuture<TT> submit(Object taskKey, Callable<TT> task) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    ArgumentVerifier.assertNotNull(task, "task");
+    
+    ListenableRunnableFuture<TT> rf = new ListenableFutureTask<TT>(false, task);
+    
+    getLimiterContainer(taskKey).execute(rf);
+    
+    return rf;
+  }
+  
+  /**
+   * Get the current limiter in a thread safe way.  If the limiter does not exist it will be 
+   * created in a thread safe way.  In addition the limiters handling task count will be 
+   * incremented in expectation for execution.  If not accessing for execution 
+   * {@link #currentLimiters} should just be accessed directly.
+   * 
+   * @param taskKey Key used to identify execution limiter
+   * @return Container with limiter and associated state data
+   */
+  protected LimiterContainer getLimiterContainer(Object taskKey) {
+    LimiterContainer lc;
+    Object lock = sLock.getLock(taskKey);
+    synchronized (lock) {
+      lc = currentLimiters.get(taskKey);
+      if (lc == null) {
+        lc = new LimiterContainer(taskKey, makeLimiter(subPoolName + 
+                                                         (addKeyToThreadName ? taskKey.toString() : "")));
+        currentLimiters.put(taskKey, lc);
+      }
+      // must increment while in lock to prevent early removal
+      lc.handlingTasks.incrementAndGet();
+    }
+    
+    return lc;
+  }
+  
+  /**
+   * Constructs a new limiter that is specific for the given type.
+   * 
+   * @param limiterThreadName Name for threads inside subpool
+   * @return A newly constructed limiter
+   */
+  protected abstract T makeLimiter(String limiterThreadName);
+
+  /**
+   * Returns an executor implementation where all tasks submitted on this executor will run on the 
+   * provided key.  Tasks executed on the returned scheduler will be limited by the key 
+   * submitted on this instance equally with ones provided through the returned instance.
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @return Executor which will only execute with reference to the provided key
+   */
+  public SubmitterExecutor getSubmitterExecutorForKey(final Object taskKey) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    
+    return new AbstractSubmitterExecutor() {
+      @Override
+      protected void doExecute(Runnable task) {
+        getLimiterContainer(taskKey).execute(task);
+      }
+    };
+  }
+  
+  /**
+   * <p>Small class to hold the limiter and state associated with the limiter.</p>
+   * 
+   * @author jent - Mike Jensen
+   * @since 4.3.0
+   */
+  protected class LimiterContainer {
+    public final Object taskKey;
+    public final T limiter;
+    public final AtomicInteger handlingTasks;
+    
+    public LimiterContainer(Object taskKey, T limiter) {
+      this.taskKey = taskKey;
+      this.limiter = limiter;
+      this.handlingTasks = new AtomicInteger(0);
+    }
+
+    public Runnable wrap(Runnable task) {
+      return new LimiterCleaner(task);
+    }
+    
+    public void execute(Runnable task) {
+      limiter.doExecute(wrap(task));
+    }
+    
+    /**
+     * <p>Small class to handle tracking as tasks finish.  Once the last task of a limiter finishes 
+     * the limiter is removed for GC.  This wraps the runnable to handle that cleanup if needed.</p>
+     * 
+     * @author jent - Mike Jensen
+     * @since 4.3.0
+     */
+    private class LimiterCleaner implements Runnable, RunnableContainer {
+      private final Runnable wrappedTask;
+      
+      protected LimiterCleaner(Runnable wrappedTask) {
+        this.wrappedTask = wrappedTask;
+      }
+      
+      @Override
+      public void run() {
+        try {
+          wrappedTask.run();
+        } finally {
+          if (handlingTasks.decrementAndGet() == 0) {
+            synchronized (sLock.getLock(taskKey)) {
+              // must verify removal in lock so that map gets are atomic with removals
+              if (handlingTasks.get() == 0) {
+                currentLimiters.remove(taskKey);
+              }
+            }
+          }
+        }
+      }
+
+      @Override
+      public Runnable getContainedRunnable() {
+        return wrappedTask;
+      }
+    }
+  }
+}

--- a/src/main/java/org/threadly/concurrent/limiter/AbstractKeyedSchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/AbstractKeyedSchedulerLimiter.java
@@ -1,0 +1,212 @@
+package org.threadly.concurrent.limiter;
+
+import java.util.concurrent.Callable;
+
+import org.threadly.concurrent.AbstractSubmitterScheduler;
+import org.threadly.concurrent.RunnableCallableAdapter;
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.util.ArgumentVerifier;
+
+/**
+ * <p>Abstract implementation for scheduled keyed limiters.  Unlike the other limiters we can not 
+ * extend off of each one, and just add extra functionality.  Instead they must extend these 
+ * abstract classes.  The reason for that being that these types of limiters use the other 
+ * limiters, rather than extend functionality off each other.</p>
+ * 
+ * <p>This adds scheduling functionality.  It must exist in an abstract form because of the need 
+ * to type the limiter type for specific functionality in the specific limiter type (casting is 
+ * ugly, which would be the alternative).</p>
+ * 
+ * @param <T> Type of limiter stored internally
+ * @author jent - Mike Jensen
+ * @since 4.3.0
+ */
+abstract class AbstractKeyedSchedulerLimiter<T extends SubmitterSchedulerLimiter> extends AbstractKeyedLimiter<T> {
+  protected final SubmitterScheduler scheduler;
+  
+  protected AbstractKeyedSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
+                                          String subPoolName, boolean addKeyToThreadName, 
+                                          int expectedTaskAdditionParallism) {
+    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, expectedTaskAdditionParallism);
+    
+    this.scheduler = scheduler;
+  }
+  
+  /**
+   * 
+   * Schedule a task with a given delay.  There is a slight increase in load when using 
+   * {@link #submitScheduled(Object, Runnable, long)} over 
+   * {@link #schedule(Object, Runnable, long)}.  So this should only be used when the future is 
+   * necessary.
+   * 
+   * The {@link ListenableFuture#get()} method will return {@code null} once the runnable has 
+   * completed.  
+   * 
+   * The key is used to identify this threads execution limit.  Tasks with matching keys will be 
+   * limited concurrent execution to the level returned by {@link #getMaxConcurrencyPerKey()}.
+   * 
+   * See also: {@link SubmitterScheduler#submitScheduled(Runnable, long)}
+   * 
+   * @param taskKey Key to use for identifying execution limit
+   * @param task runnable to execute
+   * @param delayInMs time in milliseconds to wait to execute task
+   * @return a future to know when the task has completed
+   */
+  public ListenableFuture<?> submitScheduled(Object taskKey, Runnable task, long delayInMs) {
+    return submitScheduled(taskKey, task, null, delayInMs);
+  }
+  
+  /**
+   * Schedule a task with a given delay.  The {@link ListenableFuture#get()} method will return 
+   * the provided result once the runnable has completed.  
+   * 
+   * The key is used to identify this threads execution limit.  Tasks with matching keys will be 
+   * limited concurrent execution to the level returned by {@link #getMaxConcurrencyPerKey()}.
+   * 
+   * See also: {@link SubmitterScheduler#submitScheduled(Runnable, Object, long)}
+   * 
+   * @param <TT> type of result returned from the future
+   * @param taskKey Key to use for identifying execution limit
+   * @param task runnable to execute
+   * @param result result to be returned from resulting future .get() when runnable completes
+   * @param delayInMs time in milliseconds to wait to execute task
+   * @return a future to know when the task has completed
+   */
+  public <TT> ListenableFuture<TT> submitScheduled(Object taskKey, Runnable task, TT result, long delayInMs) {
+    return submitScheduled(taskKey, new RunnableCallableAdapter<TT>(task, result), delayInMs);
+  }
+
+  /**
+   * Schedule a {@link Callable} with a given delay.  This is needed when a result needs to be 
+   * consumed from the callable.  
+   * 
+   * The key is used to identify this threads execution limit.  Tasks with matching keys will be 
+   * limited concurrent execution to the level returned by {@link #getMaxConcurrencyPerKey()}.
+   * 
+   * See also: {@link SubmitterScheduler#submitScheduled(Callable, long)}
+   * 
+   * @param <TT> type of result returned from the future
+   * @param taskKey Key to use for identifying execution limit
+   * @param task callable to be executed
+   * @param delayInMs time in milliseconds to wait to execute task
+   * @return a future to know when the task has completed and get the result of the callable
+   */
+  public <TT> ListenableFuture<TT> submitScheduled(Object taskKey, Callable<TT> task, long delayInMs) {
+    ArgumentVerifier.assertNotNull(task, "task");
+    
+    ListenableFutureTask<TT> ft = new ListenableFutureTask<TT>(false, task);
+    
+    schedule(taskKey, ft, delayInMs);
+    
+    return ft;
+  }
+
+  /**
+   * Schedule a one time task with a given delay.  
+   * 
+   * The key is used to identify this threads execution limit.  Tasks with matching keys will be 
+   * limited concurrent execution to the level returned by {@link #getMaxConcurrencyPerKey()}.
+   * 
+   * See also: {@link SubmitterScheduler#schedule(Runnable, long)}
+   * 
+   * @param taskKey Key to use for identifying execution limit
+   * @param task runnable to execute
+   * @param delayInMs time in milliseconds to wait to execute task
+   */
+  public void schedule(Object taskKey, Runnable task, long delayInMs) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    
+    LimiterContainer lc = getLimiterContainer(taskKey);
+    lc.limiter.doSchedule(lc.wrap(task), delayInMs);
+  }
+  
+  /**
+   * Schedule a fixed delay recurring task to run.  The recurring delay time will be from the 
+   * point where execution has finished.  So the execution frequency is the 
+   * {@code recurringDelay + runtime} for the provided task.  
+   * 
+   * Unlike {@link java.util.concurrent.ScheduledExecutorService} if the task throws an exception, 
+   * subsequent executions are NOT suppressed or prevented.  So if the task throws an exception on 
+   * every run, the task will continue to be executed at the provided recurring delay (possibly 
+   * throwing an exception on each execution).  
+   * 
+   * The key is used to identify this threads execution limit.  Tasks with matching keys will be 
+   * limited concurrent execution to the level returned by {@link #getMaxConcurrencyPerKey()}.
+   * 
+   * See also: {@link SubmitterScheduler#scheduleWithFixedDelay(Runnable, long, long)}
+   * 
+   * @param taskKey Key to use for identifying execution limit
+   * @param task runnable to be executed
+   * @param initialDelay delay in milliseconds until first run
+   * @param recurringDelay delay in milliseconds for running task after last finish
+   */
+  public void scheduleWithFixedDelay(Object taskKey, Runnable task, long initialDelay,
+                                     long recurringDelay) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    
+    LimiterContainer lc = getLimiterContainer(taskKey);
+    // we don't wrap the task here because it is recurring, this limiter can never be removed
+    lc.limiter.scheduleWithFixedDelay(task, initialDelay, recurringDelay);
+  }
+
+  /**
+   * Schedule a fixed rate recurring task to run.  The recurring delay will be the same, 
+   * regardless of how long task execution takes.  A given runnable will not run concurrently 
+   * (unless it is submitted to the scheduler multiple times).  Instead of execution takes longer 
+   * than the period, the next run will occur immediately (given thread availability in the pool).  
+   * 
+   * Unlike {@link java.util.concurrent.ScheduledExecutorService} if the task throws an exception, 
+   * subsequent executions are NOT suppressed or prevented.  So if the task throws an exception on 
+   * every run, the task will continue to be executed at the provided recurring delay (possibly 
+   * throwing an exception on each execution).  
+   * 
+   * The key is used to identify this threads execution limit.  Tasks with matching keys will be 
+   * limited concurrent execution to the level returned by {@link #getMaxConcurrencyPerKey()}.
+   * 
+   * See also: {@link SubmitterScheduler#scheduleAtFixedRate(Runnable, long, long)}
+   * 
+   * @param taskKey Key to use for identifying execution limit
+   * @param task runnable to be executed
+   * @param initialDelay delay in milliseconds until first run
+   * @param period amount of time in milliseconds between the start of recurring executions
+   */
+  public void scheduleAtFixedRate(Object taskKey, Runnable task, long initialDelay, long period) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    
+    LimiterContainer lc = getLimiterContainer(taskKey);
+    // we don't wrap the task here because it is recurring, this limiter can never be removed
+    lc.limiter.scheduleAtFixedRate(task, initialDelay, period);
+  }
+
+  /**
+   * Returns a scheduler implementation where all tasks submitted on this scheduler will run on 
+   * the provided key.  Tasks executed on the returned scheduler will be limited by the key 
+   * submitted on this instance equally with ones provided through the returned instance.
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @return scheduler which will only execute with reference to the provided key
+   */
+  public SubmitterScheduler getSubmitterSchedulerForKey(final Object taskKey) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    
+    return new AbstractSubmitterScheduler() {
+      @Override
+      public void scheduleWithFixedDelay(Runnable task, long initialDelay, long recurringDelay) {
+        AbstractKeyedSchedulerLimiter.this.scheduleWithFixedDelay(taskKey, task, 
+                                                                  initialDelay, recurringDelay);
+      }
+
+      @Override
+      public void scheduleAtFixedRate(Runnable task, long initialDelay, long period) {
+        AbstractKeyedSchedulerLimiter.this.scheduleAtFixedRate(taskKey, task, initialDelay, period);
+      }
+
+      @Override
+      protected void doSchedule(Runnable task, long delayInMs) {
+        AbstractKeyedSchedulerLimiter.this.schedule(taskKey, task, delayInMs);
+      }
+    };
+  }
+}

--- a/src/main/java/org/threadly/concurrent/limiter/KeyedExecutorLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/KeyedExecutorLimiter.java
@@ -1,0 +1,71 @@
+package org.threadly.concurrent.limiter;
+
+import java.util.concurrent.Executor;
+
+/**
+ * <p>This is a cross between the {@link org.threadly.concurrent.KeyDistributedExecutor} and an 
+ * {@link ExecutorLimiter}.  This is designed to limit concurrency for a given thread, but permit 
+ * more than one thread to run at a time for a given key.  If the desired effect is to have a 
+ * single thread per key, {@link org.threadly.concurrent.KeyDistributedExecutor} is a much better 
+ * option.</p>
+ * 
+ * <p>The easiest way to use this class would be to have it distribute out executors through 
+ * {@link #getSubmitterExecutorForKey(Object)}.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 4.3.0
+ */
+public class KeyedExecutorLimiter extends AbstractKeyedLimiter<ExecutorLimiter> {
+  /**
+   * Construct a new {@link KeyedExecutorLimiter} providing only the backing executor and the 
+   * maximum concurrency per unique key.  By default this will not rename threads for tasks 
+   * executing.
+   * 
+   * @param executor Executor to execute tasks on
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   */
+  public KeyedExecutorLimiter(Executor executor, int maxConcurrency) {
+    this(executor, maxConcurrency, null, false);
+  }
+
+  /**
+   * Construct a new {@link KeyedExecutorLimiter} providing the backing executor, the maximum 
+   * concurrency per unique key, and how keyed limiter threads should be named.
+   * 
+   * @param executor Executor to execute tasks on to
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
+   * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
+   */
+  public KeyedExecutorLimiter(Executor executor, int maxConcurrency, 
+                              String subPoolName, boolean addKeyToThreadName) {
+    this(executor, maxConcurrency, subPoolName, addKeyToThreadName, DEFAULT_LOCK_PARALISM);
+  }
+
+  /**
+   * Construct a new {@link KeyedExecutorLimiter} providing the backing executor, the maximum 
+   * concurrency per unique key, and how keyed limiter threads should be named.
+   * 
+   * @param executor Executor to execute tasks on to
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
+   * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
+   * @param expectedTaskAdditionParallism Expected concurrent task addition access, used for performance tuning
+   */
+  public KeyedExecutorLimiter(Executor executor, int maxConcurrency, 
+                              String subPoolName, boolean addKeyToThreadName, 
+                              int expectedTaskAdditionParallism) {
+    super(executor, maxConcurrency, subPoolName, addKeyToThreadName, expectedTaskAdditionParallism);
+  }
+  
+  @Override
+  protected ExecutorLimiter makeLimiter(String limiterThreadName) {
+    return new ExecutorLimiter(executor, maxConcurrency, limiterThreadName);
+  }
+  
+  /**********
+   * 
+   * NO IMPLEMENTATION SHOULD EXIST HERE, THIS SHOULD ALL BE IN {@link AbstractKeyedLimiter}
+   * 
+   **********/
+}

--- a/src/main/java/org/threadly/concurrent/limiter/KeyedSchedulerServiceLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/KeyedSchedulerServiceLimiter.java
@@ -1,0 +1,148 @@
+package org.threadly.concurrent.limiter;
+
+import java.util.concurrent.Callable;
+
+import org.threadly.concurrent.SchedulerService;
+
+/**
+ * <p>This is a cross between the {@link org.threadly.concurrent.KeyDistributedScheduler} and a 
+ * {@link SchedulerServiceLimiter}.  This is designed to limit concurrency for a given thread, 
+ * but permit more than one thread to run at a time for a given key.  If the desired effect is to 
+ * have a single thread per key, {@link org.threadly.concurrent.KeyDistributedScheduler} is a much 
+ * better option.</p>
+ * 
+ * <p>The easiest way to use this class would be to have it distribute out schedulers through 
+ * {@link #getSubmitterSchedulerForKey(Object)}.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 4.3.0
+ */
+public class KeyedSchedulerServiceLimiter extends AbstractKeyedSchedulerLimiter<SchedulerServiceLimiter> {
+  protected final SchedulerService scheduler;
+  
+  /**
+   * Construct a new {@link KeyedSchedulerServiceLimiter} providing only the backing scheduler 
+   * and the maximum concurrency per unique key.  By default this will not rename threads for 
+   * tasks executing.
+   * 
+   * @param scheduler Scheduler to execute and schedule tasks on
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   */
+  public KeyedSchedulerServiceLimiter(SchedulerService scheduler, int maxConcurrency) {
+    this(scheduler, maxConcurrency, null, false);
+  }
+
+  /**
+   * Construct a new {@link KeyedSchedulerServiceLimiter} providing the backing scheduler, the maximum 
+   * concurrency per unique key, and how keyed limiter threads should be named.
+   * 
+   * @param scheduler Scheduler to execute and schedule tasks on
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
+   * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
+   */
+  public KeyedSchedulerServiceLimiter(SchedulerService scheduler, int maxConcurrency, 
+                                      String subPoolName, boolean addKeyToThreadName) {
+    this(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, DEFAULT_LOCK_PARALISM);
+  }
+
+  /**
+   * Construct a new {@link KeyedSchedulerServiceLimiter} providing the backing scheduler, the 
+   * maximum concurrency per unique key, and how keyed limiter threads should be named.
+   * 
+   * @param scheduler Scheduler to execute and schedule tasks on
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
+   * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
+   * @param expectedTaskAdditionParallism Expected concurrent task addition access, used for performance tuning
+   */
+  public KeyedSchedulerServiceLimiter(SchedulerService scheduler, int maxConcurrency, 
+                                      String subPoolName, boolean addKeyToThreadName, 
+                                      int expectedTaskAdditionParallism) {
+    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, expectedTaskAdditionParallism);
+    
+    this.scheduler = scheduler;
+  }
+  
+  @Override
+  protected SchedulerServiceLimiter makeLimiter(String limiterThreadName) {
+    return new SchedulerServiceLimiter(scheduler, maxConcurrency, limiterThreadName);
+  }
+
+  /**
+   * Removes the runnable task from the execution queue.  It is possible for the runnable to still 
+   * run until this call has returned.
+   * 
+   * See also: {@link SchedulerService#remove(Runnable)}
+   * 
+   * @param task The original task provided to the executor
+   * @return {@code true} if the task was found and removed
+   */
+  public boolean remove(Runnable task) {
+    for (LimiterContainer limiter : currentLimiters.values()) {
+      if (limiter.limiter.remove(task)) {
+        limiter.handlingTasks.decrementAndGet();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Removes the runnable task from the execution queue.  It is possible for the runnable to still 
+   * run until this call has returned.
+   * 
+   * See also: {@link SchedulerService#remove(Callable)}
+   * 
+   * @param task The original task provided to the executor
+   * @return {@code true} if the task was found and removed
+   */
+  public boolean remove(Callable<?> task) {
+    for (LimiterContainer limiter : currentLimiters.values()) {
+      if (limiter.limiter.remove(task)) {
+        limiter.handlingTasks.decrementAndGet();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Call to check how many tasks are currently being executed in this scheduler.
+   * 
+   * See also: {@link SchedulerService#getCurrentRunningCount()}
+   * 
+   * @return current number of running tasks
+   */
+  public int getCurrentRunningCount() {
+    return scheduler.getCurrentRunningCount();
+  }
+
+  /**
+   * Returns how many tasks are either waiting to be executed, or are scheduled to be executed at 
+   * a future point.  Because this does not lock state can be modified during the calculation of 
+   * this result.  Ultimately resulting in an inaccurate number.
+   * 
+   * See also: {@link SchedulerService#getScheduledTaskCount()}
+   * 
+   * @return quantity of tasks waiting execution or scheduled to be executed later
+   */
+  public int getScheduledTaskCount() {
+    int result = 0;
+    for (LimiterContainer limiter : currentLimiters.values()) {
+      result += limiter.limiter.waitingTasks.size();
+    }
+    return result + scheduler.getScheduledTaskCount();
+  }
+
+  /**
+   * Function to check if the thread pool is currently accepting and handling tasks.
+   * 
+   * See also: {@link SchedulerService#isShutdown()}
+   * 
+   * @return {@code true} if thread pool is running
+   */
+  public boolean isShutdown() {
+    return scheduler.isShutdown();
+  }
+}

--- a/src/main/java/org/threadly/concurrent/limiter/KeyedSubmitterSchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/KeyedSubmitterSchedulerLimiter.java
@@ -1,0 +1,71 @@
+package org.threadly.concurrent.limiter;
+
+import org.threadly.concurrent.SubmitterScheduler;
+
+/**
+ * <p>This is a cross between the {@link org.threadly.concurrent.KeyDistributedScheduler} and a 
+ * {@link SubmitterSchedulerLimiter}.  This is designed to limit concurrency for a given thread, 
+ * but permit more than one thread to run at a time for a given key.  If the desired effect is to 
+ * have a single thread per key, {@link org.threadly.concurrent.KeyDistributedScheduler} is a much 
+ * better option.</p>
+ * 
+ * <p>The easiest way to use this class would be to have it distribute out schedulers through 
+ * {@link #getSubmitterSchedulerForKey(Object)}.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 4.3.0
+ */
+public class KeyedSubmitterSchedulerLimiter extends AbstractKeyedSchedulerLimiter<SubmitterSchedulerLimiter> {
+  /**
+   * Construct a new {@link KeyedSubmitterSchedulerLimiter} providing only the backing scheduler 
+   * and the maximum concurrency per unique key.  By default this will not rename threads for 
+   * tasks executing.
+   * 
+   * @param scheduler Scheduler to execute and schedule tasks on
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   */
+  public KeyedSubmitterSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency) {
+    this(scheduler, maxConcurrency, null, false);
+  }
+
+  /**
+   * Construct a new {@link KeyedSubmitterSchedulerLimiter} providing the backing scheduler, the maximum 
+   * concurrency per unique key, and how keyed limiter threads should be named.
+   * 
+   * @param scheduler Scheduler to execute and schedule tasks on
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
+   * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
+   */
+  public KeyedSubmitterSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
+                                        String subPoolName, boolean addKeyToThreadName) {
+    this(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, DEFAULT_LOCK_PARALISM);
+  }
+
+  /**
+   * Construct a new {@link KeyedSubmitterSchedulerLimiter} providing the backing scheduler, the 
+   * maximum concurrency per unique key, and how keyed limiter threads should be named.
+   * 
+   * @param scheduler Scheduler to execute and schedule tasks on
+   * @param maxConcurrency Maximum concurrency allowed per task key
+   * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
+   * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
+   * @param expectedTaskAdditionParallism Expected concurrent task addition access, used for performance tuning
+   */
+  public KeyedSubmitterSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
+                                        String subPoolName, boolean addKeyToThreadName, 
+                                        int expectedTaskAdditionParallism) {
+    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, expectedTaskAdditionParallism);
+  }
+  
+  @Override
+  protected SubmitterSchedulerLimiter makeLimiter(String limiterThreadName) {
+    return new SubmitterSchedulerLimiter(scheduler, maxConcurrency, limiterThreadName);
+  }
+  
+  /**********
+   * 
+   * NO IMPLEMENTATION SHOULD EXIST HERE, THIS SHOULD ALL BE IN {@link AbstractKeyedSchedulerLimiter}
+   * 
+   **********/
+}

--- a/src/test/java/org/threadly/concurrent/limiter/AbstractKeyedLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/AbstractKeyedLimiterTest.java
@@ -1,0 +1,73 @@
+package org.threadly.concurrent.limiter;
+
+import static org.junit.Assert.*;
+import static org.threadly.TestConstants.*;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.threadly.BlockingTestRunnable;
+import org.threadly.concurrent.DoNothingRunnable;
+import org.threadly.util.StringUtils;
+
+@SuppressWarnings("javadoc")
+public abstract class AbstractKeyedLimiterTest {
+  protected abstract AbstractKeyedLimiter<?> makeLimiter(int limit);
+  
+  @Test
+  public void getMaxConcurrencyPerKeyTest() {
+    assertEquals(1, makeLimiter(1).getMaxConcurrencyPerKey());
+    int val = 10;
+    assertEquals(val, makeLimiter(val).getMaxConcurrencyPerKey());
+  }
+  
+  @Test
+  public void getUnsubmittedTaskCountTest() {
+    AbstractKeyedLimiter<?> singleConcurrencyLimiter = makeLimiter(1);
+    String key = StringUtils.makeRandomString(5);
+    BlockingTestRunnable btr = new BlockingTestRunnable();
+    try {
+      assertEquals(0, singleConcurrencyLimiter.getUnsubmittedTaskCount(key));
+      singleConcurrencyLimiter.execute(key, btr);
+      btr.blockTillStarted();
+      // should not be queued any more
+      assertEquals(0, singleConcurrencyLimiter.getUnsubmittedTaskCount(key));
+      
+      for (int i = 1; i < TEST_QTY; i++) {
+        singleConcurrencyLimiter.submit(key, DoNothingRunnable.instance());
+        assertEquals(i, singleConcurrencyLimiter.getUnsubmittedTaskCount(key));
+      }
+    } finally {
+      btr.unblock();
+    }
+  }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void getUnsubmittedTaskCountNullFail() {
+    makeLimiter(1).getUnsubmittedTaskCount(null);
+  }
+  
+  @Test
+  public void getUnsubmittedTaskCountMapTest() {
+    AbstractKeyedLimiter<?> singleConcurrencyLimiter = makeLimiter(1);
+    String key = StringUtils.makeRandomString(5);
+    BlockingTestRunnable btr = new BlockingTestRunnable();
+    try {
+      assertTrue(singleConcurrencyLimiter.getUnsubmittedTaskCountMap().isEmpty());
+      singleConcurrencyLimiter.execute(key, btr);
+      btr.blockTillStarted();
+
+      // should not be queued any more
+      assertTrue(singleConcurrencyLimiter.getUnsubmittedTaskCountMap().isEmpty());
+      
+      for (int i = 1; i < TEST_QTY; i++) {
+        singleConcurrencyLimiter.submit(key, DoNothingRunnable.instance());
+        Map<?, ?> taskCountMap = singleConcurrencyLimiter.getUnsubmittedTaskCountMap();
+        assertEquals(1, taskCountMap.size());
+        assertEquals(i, taskCountMap.get(key));
+      }
+    } finally {
+      btr.unblock();
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/limiter/KeyedExecutorLimiterInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/KeyedExecutorLimiterInterfaceTest.java
@@ -1,0 +1,37 @@
+package org.threadly.concurrent.limiter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.SubmitterExecutor;
+import org.threadly.concurrent.SubmitterExecutorInterfaceTest;
+
+@SuppressWarnings("javadoc")
+public class KeyedExecutorLimiterInterfaceTest extends SubmitterExecutorInterfaceTest {
+  @Override
+  protected SubmitterExecutorFactory getSubmitterExecutorFactory() {
+    return new KeyedExecutorLimiterFactory();
+  }
+  
+  private static class KeyedExecutorLimiterFactory implements SubmitterExecutorFactory {
+    private final List<PriorityScheduler> schedulers = new ArrayList<PriorityScheduler>(2);
+    @Override
+    public SubmitterExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
+      PriorityScheduler ps = new PriorityScheduler(poolSize * 2);
+      if (prestartIfAvailable) {
+        ps.prestartAllThreads();
+      }
+      schedulers.add(ps);
+      
+      return new KeyedExecutorLimiter(ps, poolSize).getSubmitterExecutorForKey("foo");
+    }
+
+    @Override
+    public void shutdown() {
+      for (PriorityScheduler ps : schedulers) {
+        ps.shutdownNow();
+      }
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/limiter/KeyedExecutorLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/KeyedExecutorLimiterTest.java
@@ -1,0 +1,47 @@
+package org.threadly.concurrent.limiter;
+
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.SameThreadSubmitterExecutor;
+
+@SuppressWarnings("javadoc")
+public class KeyedExecutorLimiterTest extends AbstractKeyedLimiterTest {
+  protected PriorityScheduler scheduler;
+  
+  @Before
+  public void setup() {
+    scheduler = new PriorityScheduler(10);
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler.shutdownNow();
+    scheduler = null;
+  }
+
+  @Override
+  protected AbstractKeyedLimiter<?> makeLimiter(int limit) {
+    return new KeyedExecutorLimiter(scheduler, limit, null, true, 1);
+  }
+  
+  @Test
+  @SuppressWarnings("unused")
+  public void constructorFail() {
+    try {
+      new KeyedExecutorLimiter(null, 10);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      new KeyedExecutorLimiter(SameThreadSubmitterExecutor.instance(), 0);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/limiter/KeyedSchedulerServiceLimiterInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/KeyedSchedulerServiceLimiterInterfaceTest.java
@@ -1,0 +1,48 @@
+package org.threadly.concurrent.limiter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.SubmitterExecutor;
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.SubmitterSchedulerInterfaceTest;
+
+@SuppressWarnings("javadoc")
+public class KeyedSchedulerServiceLimiterInterfaceTest extends SubmitterSchedulerInterfaceTest {
+  @Override
+  protected SubmitterSchedulerFactory getSubmitterSchedulerFactory() {
+    return new KeyedSchedulerServiceLimiterFactory();
+  }
+  
+  private static class KeyedSchedulerServiceLimiterFactory implements SubmitterSchedulerFactory {
+    private final List<PriorityScheduler> schedulers = new ArrayList<PriorityScheduler>(2);
+    
+    @Override
+    public SubmitterExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
+      return makeSubmitterScheduler(poolSize, prestartIfAvailable);
+    }
+
+    @Override
+    public SubmitterScheduler makeSubmitterScheduler(int poolSize, boolean prestartIfAvailable) {
+      /* we must honor pool size of one due to how scheduled tasks are handled.  Since an extra 
+       * task is used for scheduled tasks, execution order may switch if there is more than one 
+       * thread.
+       */
+      PriorityScheduler ps = new PriorityScheduler(poolSize > 1 ? poolSize * 2 : 1);
+      if (prestartIfAvailable) {
+        ps.prestartAllThreads();
+      }
+      schedulers.add(ps);
+      
+      return new KeyedSchedulerServiceLimiter(ps, poolSize).getSubmitterSchedulerForKey("foo");
+    }
+
+    @Override
+    public void shutdown() {
+      for (PriorityScheduler ps : schedulers) {
+        ps.shutdownNow();
+      }
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/limiter/KeyedSchedulerServiceLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/KeyedSchedulerServiceLimiterTest.java
@@ -1,0 +1,159 @@
+package org.threadly.concurrent.limiter;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.BlockingTestRunnable;
+import org.threadly.concurrent.DoNothingRunnable;
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.SingleThreadScheduler;
+import org.threadly.concurrent.TestCallable;
+import org.threadly.test.concurrent.TestRunnable;
+import org.threadly.util.StringUtils;
+
+@SuppressWarnings("javadoc")
+public class KeyedSchedulerServiceLimiterTest extends AbstractKeyedLimiterTest {
+  protected PriorityScheduler scheduler;
+  
+  @Before
+  public void setup() {
+    scheduler = new PriorityScheduler(10);
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler.shutdownNow();
+    scheduler = null;
+  }
+
+  @Override
+  protected KeyedSchedulerServiceLimiter makeLimiter(int limit) {
+    return new KeyedSchedulerServiceLimiter(scheduler, limit, null, true, 1);
+  }
+  
+  @Test
+  @SuppressWarnings("unused")
+  public void constructorFail() {
+    try {
+      new KeyedSchedulerServiceLimiter(null, 10);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      new KeyedSchedulerServiceLimiter(scheduler, 0);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void removeRunnableTest() {
+    KeyedSchedulerServiceLimiter limiter = makeLimiter(1);
+    String key = StringUtils.makeRandomString(5);
+    
+    BlockingTestRunnable btr = new BlockingTestRunnable();
+    try {
+      assertFalse(limiter.remove(btr));
+      assertFalse(limiter.remove((Runnable)null));
+      
+      limiter.execute(key, btr);
+      
+      TestRunnable tr = new TestRunnable();
+      
+      assertFalse(limiter.remove(tr));
+
+      limiter.execute(key, tr);
+      assertTrue(limiter.remove(tr));
+      assertFalse(limiter.remove(tr));
+
+      limiter.submit(key, tr);
+      assertTrue(limiter.remove(tr));
+      assertFalse(limiter.remove(tr));
+    } finally {
+      btr.unblock();
+    }
+  }
+
+  @Test
+  public void removeCallableTest() {
+    KeyedSchedulerServiceLimiter limiter = makeLimiter(1);
+    String key = StringUtils.makeRandomString(5);
+    
+    BlockingTestRunnable btr = new BlockingTestRunnable();
+    try {
+      assertFalse(limiter.remove(btr));
+      assertFalse(limiter.remove((Runnable)null));
+      
+      limiter.execute(key, btr);
+      
+      TestCallable tc = new TestCallable();
+      
+      assertFalse(limiter.remove(tc));
+
+      limiter.submit(key, tc);
+      assertTrue(limiter.remove(tc));
+      assertFalse(limiter.remove(tc));
+    } finally {
+      btr.unblock();
+    }
+  }
+  
+  @Test
+  public void getCurrentRunningCountTest() {
+    KeyedSchedulerServiceLimiter limiter = makeLimiter(1);
+    String key = StringUtils.makeRandomString(5);
+    
+    assertEquals(0, limiter.getCurrentRunningCount());
+    
+    BlockingTestRunnable btr = new BlockingTestRunnable();
+    try {
+      limiter.execute(key, btr);
+      btr.blockTillStarted();
+      
+      assertEquals(1, limiter.getCurrentRunningCount());
+    } finally {
+      btr.unblock();
+    }
+  }
+  
+  @Test
+  public void getScheduledTaskCount() {
+    // must be single thread scheduler so we can block one on the shceduler
+    KeyedSchedulerServiceLimiter limiter = new KeyedSchedulerServiceLimiter(new SingleThreadScheduler(), 1);
+    String key = StringUtils.makeRandomString(5);
+    
+    BlockingTestRunnable btr = new BlockingTestRunnable();
+    try {
+      assertEquals(0, limiter.getScheduledTaskCount());
+      
+      limiter.execute(key, btr);
+      btr.blockTillStarted();
+      
+      limiter.execute(StringUtils.makeRandomString(2), DoNothingRunnable.instance());
+      // 1 blocked on scheduler due to different key
+      assertEquals(1, limiter.getScheduledTaskCount());
+      
+
+      limiter.execute(key, DoNothingRunnable.instance());
+      // 1 additional blocked in limiter now
+      assertEquals(2, limiter.getScheduledTaskCount());
+    } finally {
+      btr.unblock();
+    }
+  }
+  
+  @Test
+  public void isShutdownTest() {
+    KeyedSchedulerServiceLimiter limiter = makeLimiter(1);
+    
+    assertFalse(limiter.isShutdown());
+    
+    scheduler.shutdown();
+    
+    assertTrue(limiter.isShutdown());
+  }
+}

--- a/src/test/java/org/threadly/concurrent/limiter/KeyedSubmitterSchedulerLimiterInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/KeyedSubmitterSchedulerLimiterInterfaceTest.java
@@ -1,0 +1,48 @@
+package org.threadly.concurrent.limiter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.SubmitterExecutor;
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.SubmitterSchedulerInterfaceTest;
+
+@SuppressWarnings("javadoc")
+public class KeyedSubmitterSchedulerLimiterInterfaceTest  extends SubmitterSchedulerInterfaceTest {
+  @Override
+  protected SubmitterSchedulerFactory getSubmitterSchedulerFactory() {
+    return new KeyedSubmitterSchedulerLimiterFactory();
+  }
+  
+  private static class KeyedSubmitterSchedulerLimiterFactory implements SubmitterSchedulerFactory {
+    private final List<PriorityScheduler> schedulers = new ArrayList<PriorityScheduler>(2);
+    
+    @Override
+    public SubmitterExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
+      return makeSubmitterScheduler(poolSize, prestartIfAvailable);
+    }
+
+    @Override
+    public SubmitterScheduler makeSubmitterScheduler(int poolSize, boolean prestartIfAvailable) {
+      /* we must honor pool size of one due to how scheduled tasks are handled.  Since an extra 
+       * task is used for scheduled tasks, execution order may switch if there is more than one 
+       * thread.
+       */
+      PriorityScheduler ps = new PriorityScheduler(poolSize > 1 ? poolSize * 2 : 1);
+      if (prestartIfAvailable) {
+        ps.prestartAllThreads();
+      }
+      schedulers.add(ps);
+      
+      return new KeyedSubmitterSchedulerLimiter(ps, poolSize).getSubmitterSchedulerForKey("foo");
+    }
+
+    @Override
+    public void shutdown() {
+      for (PriorityScheduler ps : schedulers) {
+        ps.shutdownNow();
+      }
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/limiter/KeyedSubmitterSchedulerLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/KeyedSubmitterSchedulerLimiterTest.java
@@ -1,0 +1,46 @@
+package org.threadly.concurrent.limiter;
+
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.PriorityScheduler;
+
+@SuppressWarnings("javadoc")
+public class KeyedSubmitterSchedulerLimiterTest extends AbstractKeyedLimiterTest {
+  protected PriorityScheduler scheduler;
+  
+  @Before
+  public void setup() {
+    scheduler = new PriorityScheduler(10);
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler.shutdownNow();
+    scheduler = null;
+  }
+
+  @Override
+  protected AbstractKeyedLimiter<?> makeLimiter(int limit) {
+    return new KeyedSubmitterSchedulerLimiter(scheduler, limit, null, true, 1);
+  }
+  
+  @Test
+  @SuppressWarnings("unused")
+  public void constructorFail() {
+    try {
+      new KeyedSubmitterSchedulerLimiter(null, 10);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      new KeyedSubmitterSchedulerLimiter(scheduler, 0);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
These new limiters are a combination of the KeyDistributed* and the existing limiters within threadly.
Tasks are catagorized by a key, and within a given key concurrency is limited.  Unlike KeyDistributedExecutor this allows for higher levels of concurrency than one.
Under the hood we use the existing limiters, just tracking which ones are in use in a thread safe way, and cleaning them up once all tasks have finished for a given key.

@lwahlmeier This was the feature I talked about with you over the weekend.  I had it mostly complete then, but had not done any unit tests.  This should be almost good to go now.  I still need to do benchmarks (which I plan to do tonight), but after that unless you or others see any improvements we can go ahead and merge this (then release 4.3.0)...so give it a look, give me your thoughts, and I will let you know once we have benchmarking results.