### PR TITLE
Added wrappers for renaming at either a Runnable level, or pool level

### DIFF
--- a/src/main/java/org/threadly/concurrent/ThreadRenamingExecutor.java
+++ b/src/main/java/org/threadly/concurrent/ThreadRenamingExecutor.java
@@ -1,0 +1,37 @@
+package org.threadly.concurrent;
+
+import java.util.concurrent.Executor;
+
+/**
+ * <p>Class which wraps a {@link Executor} and wraps all supplied tasks in a 
+ * {@link ThreadRenamingRunnableWrapper}.  This allows you to make a pool where all tasks submitted 
+ * inside it have the threads named in an identifiable way.</p>
+ * 
+ * @author jent
+ * @since 4.3.0
+ */
+public class ThreadRenamingExecutor extends AbstractSubmitterExecutor {
+  protected final Executor executor;
+  protected final String threadName;
+  protected final boolean replace;
+  
+  /**
+   * Constructs a new {@link ThreadRenamingExecutor}, wrapping a supplied {@link Executor}.  If 
+   * {@code replace} is {@code false} the thread will be named such that 
+   * {@code threadName[originalThreadName]}.
+   * 
+   * @param executor Executor to wrap and send executions to
+   * @param threadName Thread name prefix, or replaced name
+   * @param replace If {@code true} the original name wont be included in the thread name
+   */
+  public ThreadRenamingExecutor(Executor executor, String threadName, boolean replace) {
+    this.executor = executor;
+    this.threadName = threadName;
+    this.replace = replace;
+  }
+
+  @Override
+  protected void doExecute(Runnable task) {
+    executor.execute(new ThreadRenamingRunnableWrapper(task, threadName, replace));
+  }
+}

--- a/src/main/java/org/threadly/concurrent/ThreadRenamingRunnableWrapper.java
+++ b/src/main/java/org/threadly/concurrent/ThreadRenamingRunnableWrapper.java
@@ -1,0 +1,54 @@
+package org.threadly.concurrent;
+
+import org.threadly.util.ArgumentVerifier;
+
+/**
+ * <p>A simple runnable wrapper which will rename the thread during execution, and set the name 
+ * back at the end of execution.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 4.3.0
+ */
+public class ThreadRenamingRunnableWrapper implements Runnable, RunnableContainer {
+  protected final Runnable runnable;
+  protected final String threadName;
+  protected final boolean replace;
+  
+  /**
+   * Constructs a new {@link ThreadRenamingRunnableWrapper}.  If {@code replace} is {@code false} 
+   * the thread will be named such that {@code threadName[originalThreadName]}.
+   * 
+   * @param runnable Runnable which should be executed
+   * @param threadName Thread name prefix, or replaced name
+   * @param replace If {@code true} the original name wont be included in the thread name
+   */
+  public ThreadRenamingRunnableWrapper(Runnable runnable, String threadName, boolean replace) {
+    ArgumentVerifier.assertNotNull(runnable, "runnable");
+    
+    this.runnable = runnable;
+    this.threadName = threadName;
+    this.replace = replace;
+  }
+
+  @Override
+  public void run() {
+    Thread t = Thread.currentThread();
+    String originalName = t.getName();
+    try {
+      if (replace) {
+        t.setName(threadName);
+      } else {
+        t.setName(threadName + '[' + originalName + ']');
+      }
+      
+      runnable.run();
+    } finally {
+      t.setName(originalName);
+    }
+  }
+
+  @Override
+  public Runnable getContainedRunnable() {
+    return runnable;
+  }
+}

--- a/src/main/java/org/threadly/concurrent/ThreadRenamingSchedulerService.java
+++ b/src/main/java/org/threadly/concurrent/ThreadRenamingSchedulerService.java
@@ -1,0 +1,56 @@
+package org.threadly.concurrent;
+
+import java.util.concurrent.Callable;
+
+/**
+ * <p>Class which wraps a {@link SchedulerService} and wraps all supplied tasks in a 
+ * {@link ThreadRenamingRunnableWrapper}.  This allows you to make a pool where all tasks submitted 
+ * inside it have the threads named in an identifiable way.</p>
+ * 
+ * @author jent
+ * @since 4.3.0
+ */
+public class ThreadRenamingSchedulerService extends ThreadRenamingSubmitterScheduler 
+                                            implements SchedulerService {
+  protected final SchedulerService scheduler;
+  
+  /**
+   * Constructs a new {@link ThreadRenamingSchedulerService}, wrapping a supplied 
+   * {@link SchedulerService}.  If /{@code replace} is {@code false} the thread will be named such 
+   * that {@code threadName[originalThreadName]}.
+   * 
+   * @param scheduler SchedulerService to wrap and send executions to
+   * @param threadName Thread name prefix, or replaced name
+   * @param replace If {@code true} the original name wont be included in the thread name
+   */
+  public ThreadRenamingSchedulerService(SchedulerService scheduler, String threadName, boolean replace) {
+    super(scheduler, threadName, replace);
+    
+    this.scheduler = scheduler;
+  }
+
+  @Override
+  public boolean remove(Runnable task) {
+    return scheduler.remove(task);
+  }
+
+  @Override
+  public boolean remove(Callable<?> task) {
+    return scheduler.remove(task);
+  }
+
+  @Override
+  public int getCurrentRunningCount() {
+    return scheduler.getCurrentRunningCount();
+  }
+
+  @Override
+  public int getScheduledTaskCount() {
+    return scheduler.getScheduledTaskCount();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return scheduler.isShutdown();
+  }
+}

--- a/src/main/java/org/threadly/concurrent/ThreadRenamingSubmitterScheduler.java
+++ b/src/main/java/org/threadly/concurrent/ThreadRenamingSubmitterScheduler.java
@@ -1,0 +1,47 @@
+package org.threadly.concurrent;
+
+/**
+ * <p>Class which wraps a {@link SubmitterScheduler} and wraps all supplied tasks in a 
+ * {@link ThreadRenamingRunnableWrapper}.  This allows you to make a pool where all tasks submitted 
+ * inside it have the threads named in an identifiable way.</p>
+ * 
+ * @author jent
+ * @since 4.3.0
+ */
+public class ThreadRenamingSubmitterScheduler extends AbstractSubmitterScheduler {
+  protected final SubmitterScheduler scheduler;
+  protected final String threadName;
+  protected final boolean replace;
+
+  /**
+   * Constructs a new {@link ThreadRenamingSubmitterScheduler}, wrapping a supplied 
+   * {@link SchedulerService}.  If /{@code replace} is {@code false} the thread will be named such 
+   * that {@code threadName[originalThreadName]}.
+   * 
+   * @param scheduler SubmitterScheduler to wrap and send executions to
+   * @param threadName Thread name prefix, or replaced name
+   * @param replace If {@code true} the original name wont be included in the thread name
+   */
+  public ThreadRenamingSubmitterScheduler(SubmitterScheduler scheduler, String threadName, boolean replace) {
+    this.scheduler = scheduler;
+    this.threadName = threadName;
+    this.replace = replace;
+  }
+
+  @Override
+  public void scheduleWithFixedDelay(Runnable task, long initialDelay, long recurringDelay) {
+    scheduler.scheduleWithFixedDelay(new ThreadRenamingRunnableWrapper(task, threadName, replace), 
+                                     initialDelay, recurringDelay);
+  }
+
+  @Override
+  public void scheduleAtFixedRate(Runnable task, long initialDelay, long period) {
+    scheduler.scheduleAtFixedRate(new ThreadRenamingRunnableWrapper(task, threadName, replace), 
+                                  initialDelay, period);
+  }
+
+  @Override
+  protected void doSchedule(Runnable task, long delayInMillis) {
+    scheduler.schedule(new ThreadRenamingRunnableWrapper(task, threadName, replace), delayInMillis);
+  }
+}

--- a/src/main/java/org/threadly/concurrent/limiter/ExecutorLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/ExecutorLimiter.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.threadly.concurrent.AbstractSubmitterExecutor;
 import org.threadly.concurrent.RunnableContainer;
 import org.threadly.concurrent.SubmitterExecutorInterface;
+import org.threadly.concurrent.ThreadRenamingExecutor;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.StringUtils;
 
@@ -32,7 +33,6 @@ public class ExecutorLimiter extends AbstractSubmitterExecutor
   protected final Executor executor;
   protected final Queue<LimiterRunnableWrapper> waitingTasks;
   protected final int maxConcurrency;
-  protected final String subPoolName;
   private final AtomicInteger currentlyRunning;
   
   /**
@@ -48,18 +48,24 @@ public class ExecutorLimiter extends AbstractSubmitterExecutor
   /**
    * Construct a new execution limiter that implements the {@link Executor} interface.
    * 
+   * @deprecated Rename threads using {@link ThreadRenamingExecutor} to rename executions from this limiter
+   * 
    * @param executor {@link Executor} to submit task executions to.
    * @param maxConcurrency maximum quantity of runnables to run in parallel
    * @param subPoolName name to describe threads while tasks running in pool ({@code null} to not change thread names)
    */
+  @Deprecated
   public ExecutorLimiter(Executor executor, int maxConcurrency, String subPoolName) {
     ArgumentVerifier.assertGreaterThanZero(maxConcurrency, "maxConcurrency");
     ArgumentVerifier.assertNotNull(executor, "executor");
     
-    this.executor = executor;
+    if (StringUtils.isNullOrEmpty(subPoolName)) {
+      this.executor = executor;
+    } else {
+      this.executor = new ThreadRenamingExecutor(executor, subPoolName, false);
+    }
     this.waitingTasks = new ConcurrentLinkedQueue<LimiterRunnableWrapper>();
     this.maxConcurrency = maxConcurrency;
-    this.subPoolName = StringUtils.emptyToNull(subPoolName);
     this.currentlyRunning = new AtomicInteger(0);
   }
   
@@ -164,17 +170,6 @@ public class ExecutorLimiter extends AbstractSubmitterExecutor
   }
   
   /**
-   * Constructs a formated name for a given thread for this sub pool.  This only makes sense to 
-   * call when subPoolName is not {@code null}.
-   * 
-   * @param originalThreadName name of thread before change
-   * @return a formated name to change the thread to.
-   */
-  protected String makeSubPoolThreadName(String originalThreadName) {
-    return subPoolName + "[" + originalThreadName + "]";
-  }
-  
-  /**
    * <p>Generic wrapper for runnables which are used within the limiters.  This wrapper ensures 
    * that {@link #handleTaskFinished()} will be called after the task completes.</p>
    * 
@@ -208,30 +203,15 @@ public class ExecutorLimiter extends AbstractSubmitterExecutor
     
     @Override
     public void run() {
-      Thread currentThread = null;
-      String originalThreadName = null;
-      if (subPoolName != null) {
-        currentThread = Thread.currentThread();
-        originalThreadName = currentThread.getName();
-        
-        currentThread.setName(makeSubPoolThreadName(originalThreadName));
-      }
-      
       try {
         runnable.run();
       } finally {
         try {
           doAfterRunTasks();
         } finally {
-          try {
-            currentlyRunning.decrementAndGet();
-            
-            consumeAvailable(); // allow any waiting tasks to run
-          } finally {
-            if (subPoolName != null) {
-              currentThread.setName(originalThreadName);
-            }
-          }
+          currentlyRunning.decrementAndGet();
+          
+          consumeAvailable(); // allow any waiting tasks to run
         }
       }
     }

--- a/src/main/java/org/threadly/concurrent/limiter/SchedulerServiceLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/SchedulerServiceLimiter.java
@@ -45,10 +45,14 @@ public class SchedulerServiceLimiter extends SimpleSchedulerLimiter
   /**
    * Constructs a new limiter that implements the {@link SchedulerService}.
    * 
+   * @deprecated Rename threads using {@link  org.threadly.concurrent.ThreadRenamingSchedulerService} 
+   *               to rename executions from this limiter
+   * 
    * @param scheduler {@link SchedulerService} implementation to submit task executions to.
    * @param maxConcurrency maximum quantity of runnables to run in parallel
    * @param subPoolName name to describe threads while tasks running in pool ({@code null} to not change thread names)
    */
+  @Deprecated
   public SchedulerServiceLimiter(SchedulerService scheduler, 
                                  int maxConcurrency, String subPoolName) {
     super(scheduler, maxConcurrency, subPoolName);

--- a/src/main/java/org/threadly/concurrent/limiter/SubmitterSchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/SubmitterSchedulerLimiter.java
@@ -43,10 +43,14 @@ public class SubmitterSchedulerLimiter extends ExecutorLimiter
   /**
    * Constructs a new limiter that implements the {@link SubmitterScheduler}.
    * 
+   * @deprecated Rename threads using {@link  org.threadly.concurrent.ThreadRenamingSubmitterScheduler} 
+   *               to rename executions from this limiter
+   * 
    * @param scheduler {@link SubmitterScheduler} implementation to submit task executions to.
    * @param maxConcurrency maximum quantity of runnables to run in parallel
    * @param subPoolName name to describe threads while tasks running in pool ({@code null} to not change thread names)
    */
+  @Deprecated
   public SubmitterSchedulerLimiter(SubmitterScheduler scheduler, 
                                    int maxConcurrency, String subPoolName) {
     super(scheduler, maxConcurrency, subPoolName);

--- a/src/test/java/org/threadly/concurrent/ThreadRenamingExecutorTest.java
+++ b/src/test/java/org/threadly/concurrent/ThreadRenamingExecutorTest.java
@@ -1,0 +1,34 @@
+package org.threadly.concurrent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("javadoc")
+public class ThreadRenamingExecutorTest extends SubmitterExecutorInterfaceTest {
+  @Override
+  protected SubmitterExecutorFactory getSubmitterExecutorFactory() {
+    return new ThreadRenamingPoolWrapperFactory();
+  }
+
+  private static class ThreadRenamingPoolWrapperFactory implements SubmitterExecutorFactory {
+    private final List<PriorityScheduler> schedulers = new ArrayList<PriorityScheduler>(2);
+    
+    @Override
+    public SubmitterExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
+      PriorityScheduler ps = new PriorityScheduler(poolSize);
+      if (prestartIfAvailable) {
+        ps.prestartAllThreads();
+      }
+      schedulers.add(ps);
+
+      return new ThreadRenamingExecutor(ps, "foo", false);
+    }
+
+    @Override
+    public void shutdown() {
+      for (PriorityScheduler ps : schedulers) {
+        ps.shutdownNow();
+      }
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/ThreadRenamingRunnableWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/ThreadRenamingRunnableWrapperTest.java
@@ -1,0 +1,56 @@
+package org.threadly.concurrent;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.threadly.test.concurrent.TestRunnable;
+import org.threadly.util.StringUtils;
+
+@SuppressWarnings("javadoc")
+public class ThreadRenamingRunnableWrapperTest {
+  @Test
+  public void renameReplaceAndResetTest() {
+    final String originalName = Thread.currentThread().getName();
+    final String newName = StringUtils.makeRandomString(5);
+    
+    TestRunnable tr = new TestRunnable() {
+      @Override
+      public void handleRunStart() {
+        assertEquals(newName, Thread.currentThread().getName());
+      }
+    };
+
+    assertEquals(originalName, Thread.currentThread().getName());
+    
+    new ThreadRenamingRunnableWrapper(tr, newName, true).run();
+    
+    assertTrue(tr.ranOnce());
+  }
+  
+  @Test
+  public void renamePrependAndResetTest() {
+    final String originalName = Thread.currentThread().getName();
+    final String newName = StringUtils.makeRandomString(5);
+    
+    TestRunnable tr = new TestRunnable() {
+      @Override
+      public void handleRunStart() {
+        assertTrue(Thread.currentThread().getName().startsWith(newName));
+        assertTrue(Thread.currentThread().getName().contains(originalName));
+      }
+    };
+
+    assertEquals(originalName, Thread.currentThread().getName());
+    
+    new ThreadRenamingRunnableWrapper(tr, newName, false).run();
+    
+    assertTrue(tr.ranOnce());
+  }
+  
+  @Test
+  public void getContainedRunnableTest() {
+    TestRunnable tr = new TestRunnable();
+    
+    assertTrue(tr == new ThreadRenamingRunnableWrapper(tr, "foo", false).getContainedRunnable());
+  }
+}

--- a/src/test/java/org/threadly/concurrent/ThreadRenamingSchedulerServiceTest.java
+++ b/src/test/java/org/threadly/concurrent/ThreadRenamingSchedulerServiceTest.java
@@ -1,0 +1,44 @@
+package org.threadly.concurrent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("javadoc")
+public class ThreadRenamingSchedulerServiceTest extends SchedulerServiceInterfaceTest {
+  @Override
+  protected SchedulerServiceFactory getSchedulerServiceFactory() {
+    return new ThreadRenamingPoolWrapperFactory();
+  }
+
+  private static class ThreadRenamingPoolWrapperFactory implements SchedulerServiceFactory {
+    private final List<PriorityScheduler> schedulers = new ArrayList<PriorityScheduler>(2);
+
+    @Override
+    public SubmitterExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
+      return makeSubmitterScheduler(poolSize, prestartIfAvailable);
+    }
+    
+    @Override
+    public SubmitterScheduler makeSubmitterScheduler(int poolSize, boolean prestartIfAvailable) {
+      return makeSchedulerService(poolSize, prestartIfAvailable);
+    }
+
+    @Override
+    public SchedulerService makeSchedulerService(int poolSize, boolean prestartIfAvailable) {
+      PriorityScheduler ps = new PriorityScheduler(poolSize);
+      if (prestartIfAvailable) {
+        ps.prestartAllThreads();
+      }
+      schedulers.add(ps);
+
+      return new ThreadRenamingSchedulerService(ps, "foo", false);
+    }
+
+    @Override
+    public void shutdown() {
+      for (PriorityScheduler ps : schedulers) {
+        ps.shutdownNow();
+      }
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/ThreadRenamingSubmitterSchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/ThreadRenamingSubmitterSchedulerTest.java
@@ -1,0 +1,39 @@
+package org.threadly.concurrent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("javadoc")
+public class ThreadRenamingSubmitterSchedulerTest extends SubmitterSchedulerInterfaceTest {
+  @Override
+  protected SubmitterSchedulerFactory getSubmitterSchedulerFactory() {
+    return new ThreadRenamingPoolWrapperFactory();
+  }
+  
+  private static class ThreadRenamingPoolWrapperFactory implements SubmitterSchedulerFactory {
+    private final List<PriorityScheduler> schedulers = new ArrayList<PriorityScheduler>(2);
+
+    @Override
+    public SubmitterExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
+      return makeSubmitterScheduler(poolSize, prestartIfAvailable);
+    }
+    
+    @Override
+    public SubmitterScheduler makeSubmitterScheduler(int poolSize, boolean prestartIfAvailable) {
+      PriorityScheduler ps = new PriorityScheduler(poolSize);
+      if (prestartIfAvailable) {
+        ps.prestartAllThreads();
+      }
+      schedulers.add(ps);
+      
+      return new ThreadRenamingSubmitterScheduler(ps, "foo", false);
+    }
+
+    @Override
+    public void shutdown() {
+      for (PriorityScheduler ps : schedulers) {
+        ps.shutdownNow();
+      }
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/limiter/ExecutorLimiterNamedTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/ExecutorLimiterNamedTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 @SuppressWarnings("javadoc")
 public class ExecutorLimiterNamedTest extends ExecutorLimiterTest {
   @Override
+  @SuppressWarnings("deprecation")
   protected ExecutorLimiter getLimiter(int parallelCount) {
     return new ExecutorLimiter(scheduler, parallelCount, "TestSubPool");
   }

--- a/src/test/java/org/threadly/concurrent/limiter/ExecutorLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/ExecutorLimiterTest.java
@@ -100,9 +100,10 @@ public class ExecutorLimiterTest extends SubmitterExecutorInterfaceTest {
   
   @Test
   public void constructorEmptySubPoolNameTest() {
+    @SuppressWarnings("deprecation")
     ExecutorLimiter limiter = new ExecutorLimiter(scheduler, 1, "");
     
-    assertNull(limiter.subPoolName);
+    assertTrue(limiter.executor == scheduler);
   }
   
   @Test
@@ -224,6 +225,7 @@ public class ExecutorLimiterTest extends SubmitterExecutorInterfaceTest {
     }
     
     @Override
+    @SuppressWarnings("deprecation")
     public ExecutorLimiter makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
       PriorityScheduler executor = new StrictPriorityScheduler(poolSize);
       if (prestartIfAvailable) {

--- a/src/test/java/org/threadly/concurrent/limiter/SchedulerServiceLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/SchedulerServiceLimiterTest.java
@@ -138,6 +138,7 @@ public class SchedulerServiceLimiterTest extends SimpleSchedulerLimiterTest {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public SchedulerService makeSchedulerService(int poolSize, boolean prestartIfAvailable) {
       PriorityScheduler executor = new StrictPriorityScheduler(poolSize);
       if (prestartIfAvailable) {

--- a/src/test/java/org/threadly/concurrent/limiter/SubmitterSchedulerLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/limiter/SubmitterSchedulerLimiterTest.java
@@ -67,6 +67,7 @@ public class SubmitterSchedulerLimiterTest extends ExecutorLimiterTest {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public SubmitterScheduler makeSubmitterScheduler(int poolSize, boolean prestartIfAvailable) {
       PriorityScheduler executor = new StrictPriorityScheduler(poolSize);
       if (prestartIfAvailable) {


### PR DESCRIPTION
This resolves #170, adding the ability to in a more generic way rename tasks submitted from a specific executor/scheduler reference.
This is slightly different style from other threadly stuff, instead of having a top level class per executor/scheduler type, we have a single class "ThreadRenamingPoolWrapper" which has three wrap functions, returning the wrapper for the right type of scheduler you provided.

@lwahlmeier I have been on a bit of a roll tonight.  This will be the last one for 4.3.0 for sure.  We need to decide what we want to do on this one first before we can merge the one I submitted earlier tonight.

The implementation is super simple, the biggest thing I want feedback on is the API.  Do you think we should make those pool wrappers top level classes (ThreadRenamingExecutorWrapper, ThreadRenamingSubmitterSchedulerWrapper, ThreadRenamingSchedulerServiceWrapper)?  Or do you like having one class which determines the right types for all of them?

If so do you think we should make this pattern happen throughout the library?  Ie instead of ExecutorLimiter, SubmitterSchedulerLimiter, SchedulerServiceLimiter we have "PoolExecutionLimiter" with a "wrap" function for each type just like we do here?

I want to remain consistent, so tell me what you think.  I like both for different reasons.  I feel like class per type separates the code concerns nicely, and keeps the classes clean.

I feel like a single class that just has an overloaded function that is type specific makes it easier to use (possibly easier to find in the javadocs too?).

Let me know what you think we want to do going forward, and with this PR.