### PR TITLE
Listener helpers use Pair list instead of Map

### DIFF
--- a/src/main/java/org/threadly/util/Pair.java
+++ b/src/main/java/org/threadly/util/Pair.java
@@ -22,6 +22,7 @@ public class Pair<L, R> {
    * iterates over a source collection and collects all non-null left references into a new list 
    * that can be manipulated or referenced.
    *  
+   * @param <T> Type of object held as pair's left reference
    * @param source Source collection of pairs
    * @return New list that contains non-null left references
    */
@@ -40,6 +41,7 @@ public class Pair<L, R> {
    * iterates over a source collection and collects all non-null right references into a new list 
    * that can be manipulated or referenced.
    *  
+   * @param <T> Type of object held as pair's right reference
    * @param source Source collection of pairs
    * @return New list that contains non-null right references
    */
@@ -85,7 +87,7 @@ public class Pair<L, R> {
    */
   public static boolean containsRight(Iterable<? extends Pair<?, ?>> search, Object value) {
     for (Pair<?, ?> p : search) {
-      if (p.left == null) {
+      if (p.right == null) {
         if (value == null) {
           return true;
         }
@@ -95,6 +97,58 @@ public class Pair<L, R> {
     }
     
     return false;
+  }
+  
+  /**
+   * Get the right side of a pair by searching for a matching left side.  This iterates over the 
+   * provided source, and once the first pair with a left that matches (via 
+   * {@link Object#equals(Object)}), the right side is returned.  If no match is found, 
+   * {@code null} will be returned.  Although the implementer must be aware that since nulls can 
+   * be kept kept inside pairs, that does not strictly indicate a match failure.
+   * 
+   * @param <T> Type of object held as pair's right reference
+   * @param search Iteratable to search through looking for a match
+   * @param left Object to be looking searching for as a left reference
+   * @return Corresponding right reference or {@code null} if none is found
+   */
+  public static <T> T getRightFromLeft(Iterable<? extends Pair<?, T>> search, Object left) {
+    for (Pair<?, T> p : search) {
+      if (p.left == null) {
+        if (left == null) {
+          return p.right;
+        }
+      } else if (p.left.equals(left)) {
+        return p.right;
+      }
+    }
+    
+    return null;
+  }
+  
+  /**
+   * Get the left side of a pair by searching for a matching right side.  This iterates over the 
+   * provided source, and once the first pair with a right that matches (via 
+   * {@link Object#equals(Object)}), the left side is returned.  If no match is found, 
+   * {@code null} will be returned.  Although the implementer must be aware that since nulls can 
+   * be kept kept inside pairs, that does not strictly indicate a match failure.
+   * 
+   * @param <T> Type of object held as pair's left reference
+   * @param search Iteratable to search through looking for a match
+   * @param right Object to be looking searching for as a left reference
+   * @return Corresponding left reference or {@code null} if none is found
+   */
+  public static <T> T getLeftFromRight(Iterable<? extends Pair<T, ?>> search, Object right) {
+    for (Pair<T, ?> p : search) {
+      if (p.right == null) {
+        if (right == null) {
+          return p.left;
+        }
+      } else if (p.right.equals(right)) {
+        return p.left;
+      }
+    }
+    
+    return null;
   }
   
   // not final so extending classes can mutate

--- a/src/main/java/org/threadly/util/Pair.java
+++ b/src/main/java/org/threadly/util/Pair.java
@@ -1,5 +1,9 @@
 package org.threadly.util;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 /**
  * <p>A simple tuple implementation (every library needs one, right?).  This is designed to be a 
  * minimal and light weight pair holder.</p>
@@ -12,6 +16,42 @@ package org.threadly.util;
 public class Pair<L, R> {
   private static final short LEFT_PRIME = 13;
   private static final short RIGHT_PRIME = 31;
+  
+  /**
+   * Collect all the non-null left references into a new List.  A simple implementation which 
+   * iterates over a source collection and collects all non-null left references into a new list 
+   * that can be manipulated or referenced.
+   *  
+   * @param source Source collection of pairs
+   * @return New list that contains non-null left references
+   */
+  public static <T> List<T> collectLeft(Collection<? extends Pair<T, ?>> source) {
+    List<T> result = new ArrayList<T>(source.size());
+    for (Pair<T, ?> p : source) {
+      if (p.left != null) {
+        result.add(p.left);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Collect all the non-null right references into a new List.  A simple implementation which 
+   * iterates over a source collection and collects all non-null right references into a new list 
+   * that can be manipulated or referenced.
+   *  
+   * @param source Source collection of pairs
+   * @return New list that contains non-null right references
+   */
+  public static <T> List<T> collectRight(Collection<? extends Pair<?, T>> source) {
+    List<T> result = new ArrayList<T>(source.size());
+    for (Pair<?, T> p : source) {
+      if (p.right != null) {
+        result.add(p.right);
+      }
+    }
+    return result;
+  }
   
   /**
    * Simple search to see if a collection of pairs contains a given left value.  It is assumed 

--- a/src/test/java/org/threadly/concurrent/event/ListenerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/event/ListenerHelperTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Executor;
 import org.junit.Test;
 import org.threadly.concurrent.SameThreadSubmitterExecutor;
 import org.threadly.util.ExceptionUtils;
+import org.threadly.util.Pair;
 import org.threadly.util.StringUtils;
 import org.threadly.util.TestExceptionHandler;
 
@@ -61,7 +62,7 @@ public class ListenerHelperTest {
     ch.addListener(ti);
     
     assertEquals(1, ch.registeredListenerCount());
-    assertTrue(ch.listeners.containsKey(ti));
+    assertTrue(Pair.containsLeft(ch.listeners, ti));
   }
   
   @Test
@@ -72,7 +73,7 @@ public class ListenerHelperTest {
     ch.addListener(ti, executor);
 
     assertEquals(1, ch.registeredListenerCount());
-    assertTrue(ch.listeners.get(ti) == executor);
+    assertTrue(Pair.getRightFromLeft(ch.listeners, ti) == executor);
   }
   
   @Test

--- a/src/test/java/org/threadly/util/ClockTest.java
+++ b/src/test/java/org/threadly/util/ClockTest.java
@@ -21,9 +21,30 @@ public class ClockTest {
   }
   
   @Test
+  @SuppressWarnings("deprecation")
   public void systemNanoTimeTest() {
     long baseTime = System.nanoTime();
     assertTrue(Clock.systemNanoTime() >= baseTime);
+  }
+  
+  @Test
+  public void accurateNanoTimeTest() {
+    long baseTime = System.nanoTime();
+    assertTrue(Clock.accurateNanoTime() >= baseTime);
+  }
+  
+  @Test
+  public void lastKnownNanoTimeTest() {
+    // verify clock is not updating
+    long before = Clock.lastKnownNanoTime();
+    
+    TestUtils.blockTillClockAdvances();
+    
+    // update clock
+    long newTime = -1;
+    assertTrue((newTime = Clock.accurateNanoTime()) > before);
+    // verify we get the new time again
+    assertEquals(newTime, Clock.lastKnownNanoTime());
   }
   
   @Test
@@ -111,7 +132,7 @@ public class ClockTest {
     long newTime = -1;
     assertTrue((newTime = Clock.accurateTimeMillis()) > before);
     // verify we get the new time again
-    assertTrue(newTime <= Clock.lastKnownTimeMillis());
+    assertEquals(newTime, Clock.lastKnownTimeMillis());
   }
   
   @Test

--- a/src/test/java/org/threadly/util/PairTest.java
+++ b/src/test/java/org/threadly/util/PairTest.java
@@ -15,6 +15,40 @@ public class PairTest {
   }
   
   @Test
+  public void collectLeftTest() {
+    List<String> expectedResult = new ArrayList<String>(TEST_QTY);
+    List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>(TEST_QTY * 2);
+    for (int i = 0; i < TEST_QTY; i++) {
+      String str = StringUtils.makeRandomString(10);
+      expectedResult.add(str);
+      pairs.add(makePair(str, StringUtils.makeRandomString(5)));
+      pairs.add(makePair(null, StringUtils.makeRandomString(5)));
+    }
+    
+    List<String> result = Pair.collectLeft(pairs);
+    
+    assertEquals(TEST_QTY, result.size());
+    assertTrue(expectedResult.equals(result));
+  }
+  
+  @Test
+  public void collectRightTest() {
+    List<String> expectedResult = new ArrayList<String>(TEST_QTY);
+    List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>(TEST_QTY * 2);
+    for (int i = 0; i < TEST_QTY; i++) {
+      String str = StringUtils.makeRandomString(10);
+      expectedResult.add(str);
+      pairs.add(makePair(StringUtils.makeRandomString(5), str));
+      pairs.add(makePair(StringUtils.makeRandomString(5), null));
+    }
+    
+    List<String> result = Pair.collectRight(pairs);
+    
+    assertEquals(TEST_QTY, result.size());
+    assertTrue(expectedResult.equals(result));
+  }
+  
+  @Test
   public void containsLeftTest() {
     String searchStr = StringUtils.makeRandomString(10);
     String rightStr = StringUtils.makeRandomString(20);

--- a/src/test/java/org/threadly/util/PairTest.java
+++ b/src/test/java/org/threadly/util/PairTest.java
@@ -50,9 +50,17 @@ public class PairTest {
   
   @Test
   public void containsLeftTest() {
-    String searchStr = StringUtils.makeRandomString(10);
+    containsLeftTest(StringUtils.makeRandomString(10));
+  }
+  
+  @Test
+  public void containsLeftNullTest() {
+    containsLeftTest(null);
+  }
+  
+  private void containsLeftTest(String searchStr) {
     String rightStr = StringUtils.makeRandomString(20);
-    List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>(TEST_QTY);
+    List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>(TEST_QTY + 1);
     for (int i = 0; i < TEST_QTY; i++) {
       if (i == TEST_QTY / 2) {
         pairs.add(makePair(searchStr, rightStr));
@@ -66,9 +74,17 @@ public class PairTest {
   
   @Test
   public void containsRightTest() {
-    String searchStr = StringUtils.makeRandomString(10);
+    containsRightTest(StringUtils.makeRandomString(10));
+  }
+  
+  @Test
+  public void containsRightNullTest() {
+    containsRightTest(StringUtils.makeRandomString(10));
+  }
+  
+  private void containsRightTest(String searchStr) {
     String leftStr = StringUtils.makeRandomString(20);
-    List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>(TEST_QTY);
+    List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>(TEST_QTY + 1);
     for (int i = 0; i < TEST_QTY; i++) {
       if (i == TEST_QTY / 2) {
         pairs.add(makePair(leftStr, searchStr));
@@ -78,6 +94,52 @@ public class PairTest {
     
     assertFalse(Pair.containsRight(pairs, leftStr));
     assertTrue(Pair.containsRight(pairs, searchStr));
+  }
+  
+  @Test
+  public void getRightFromLeftTest() {
+    getRightFromLeftTest(StringUtils.makeRandomString(10));
+  }
+  
+  @Test
+  public void getRightFromLeftNullTest() {
+    getRightFromLeftTest(null);
+  }
+  
+  private void getRightFromLeftTest(String searchStr) {
+    String rightStr = StringUtils.makeRandomString(20);
+    List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>(TEST_QTY + 1);
+    for (int i = 0; i < TEST_QTY; i++) {
+      if (i == TEST_QTY / 2) {
+        pairs.add(makePair(searchStr, rightStr));
+      }
+      pairs.add(makePair(StringUtils.makeRandomString(5), StringUtils.makeRandomString(5)));
+    }
+    
+    assertTrue(Pair.getRightFromLeft(pairs, searchStr) == rightStr);
+  }
+  
+  @Test
+  public void getLeftFromRightTest() {
+    getLeftFromRightTest(StringUtils.makeRandomString(10));
+  }
+  
+  @Test
+  public void getLeftFromRightNullTest() {
+    getLeftFromRightTest(null);
+  }
+  
+  private void getLeftFromRightTest(String searchStr) {
+    String leftStr = StringUtils.makeRandomString(20);
+    List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>(TEST_QTY + 1);
+    for (int i = 0; i < TEST_QTY; i++) {
+      if (i == TEST_QTY / 2) {
+        pairs.add(makePair(leftStr, searchStr));
+      }
+      pairs.add(makePair(StringUtils.makeRandomString(5), StringUtils.makeRandomString(5)));
+    }
+    
+    assertTrue(Pair.getLeftFromRight(pairs, searchStr) == leftStr);
   }
   
   @Test


### PR DESCRIPTION
This is from #177.  As you can see there are a few commits here because I needed to expand the functionality of Pair slightly to make this easier/cleaner to implement.

To answer some likely questions you might have in this implementation:

* The memory usage is lower than HashMap
* There is about a 40% speed improvement in listener addition
* I am using an ArrayList, a deque would not make sense for this.  A HashSet just uses a HashMap behind the scenes, so would offer no improvements.
* The ArrayList is constructed with a default size of 2.  This is under the assumption that there is usually few listeners.  Making it cheap to construct, but in cases where there is lots of listeners there will be lots of array copies as that size is grown.  I think this is a reasonable expectations.

Let me know if you have other thoughts or questions.  Otherwise if it looks good to you, go ahead and merge it @lwahlmeier 