### PR TITLE
Add "Promise" as a short hand to "ListenableFuture"

### DIFF
--- a/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
@@ -9,9 +9,9 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 
 import org.threadly.concurrent.collections.ConcurrentArrayList;
-import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.ListenableFutureTask;
 import org.threadly.concurrent.future.ListenableRunnableFuture;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.Clock;
 import org.threadly.util.ExceptionUtils;
@@ -101,17 +101,17 @@ public abstract class AbstractPriorityScheduler extends AbstractSubmitterSchedul
   }
 
   @Override
-  public ListenableFuture<?> submit(Runnable task, TaskPriority priority) {
+  public Promise<?> submit(Runnable task, TaskPriority priority) {
     return submitScheduled(task, null, 0, priority);
   }
   
   @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result, TaskPriority priority) {
+  public <T> Promise<T> submit(Runnable task, T result, TaskPriority priority) {
     return submitScheduled(task, result, 0, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task, TaskPriority priority) {
+  public <T> Promise<T> submit(Callable<T> task, TaskPriority priority) {
     return submitScheduled(task, 0, priority);
   }
 
@@ -127,20 +127,18 @@ public abstract class AbstractPriorityScheduler extends AbstractSubmitterSchedul
   }
 
   @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs, 
-                                             TaskPriority priority) {
+  public Promise<?> submitScheduled(Runnable task, long delayInMs, TaskPriority priority) {
     return submitScheduled(task, null, delayInMs, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, 
-                                                 long delayInMs, TaskPriority priority) {
+  public <T> Promise<T> submitScheduled(Runnable task, T result, 
+                                        long delayInMs, TaskPriority priority) {
     return submitScheduled(new RunnableCallableAdapter<T>(task, result), delayInMs, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs, 
-                                                 TaskPriority priority) {
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs, TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(delayInMs, "delayInMs");
     if (priority == null) {

--- a/src/main/java/org/threadly/concurrent/AbstractSubmitterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/AbstractSubmitterExecutor.java
@@ -2,8 +2,8 @@ package org.threadly.concurrent;
 
 import java.util.concurrent.Callable;
 
-import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.util.ArgumentVerifier;
 
 /**
@@ -37,17 +37,17 @@ public abstract class AbstractSubmitterExecutor implements SubmitterExecutorInte
   }
 
   @Override
-  public ListenableFuture<?> submit(Runnable task) {
+  public Promise<?> submit(Runnable task) {
     return submit(task, null);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result) {
+  public <T> Promise<T> submit(Runnable task, T result) {
     return submit(new RunnableCallableAdapter<T>(task, result));
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task) {
+  public <T> Promise<T> submit(Callable<T> task) {
     ArgumentVerifier.assertNotNull(task, "task");
     
     ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task);

--- a/src/main/java/org/threadly/concurrent/AbstractSubmitterScheduler.java
+++ b/src/main/java/org/threadly/concurrent/AbstractSubmitterScheduler.java
@@ -2,8 +2,8 @@ package org.threadly.concurrent;
 
 import java.util.concurrent.Callable;
 
-import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.util.ArgumentVerifier;
 
 /**
@@ -44,17 +44,17 @@ public abstract class AbstractSubmitterScheduler extends AbstractSubmitterExecut
   }
 
   @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs) {
+  public Promise<?> submitScheduled(Runnable task, long delayInMs) {
     return submitScheduled(task, null, delayInMs);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs) {
     return submitScheduled(new RunnableCallableAdapter<T>(task, result), delayInMs);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs) {
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(delayInMs, "delayInMs");
     

--- a/src/main/java/org/threadly/concurrent/KeyDistributedExecutor.java
+++ b/src/main/java/org/threadly/concurrent/KeyDistributedExecutor.java
@@ -10,9 +10,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.ListenableFutureTask;
 import org.threadly.concurrent.future.ListenableRunnableFuture;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.concurrent.lock.StripedLock;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.ExceptionUtils;
@@ -407,7 +407,7 @@ public class KeyDistributedExecutor {
    * @return Future to represent when the execution has occurred
    */
   @Deprecated
-  public ListenableFuture<?> submitTask(Object threadKey, Runnable task) {
+  public Promise<?> submitTask(Object threadKey, Runnable task) {
     return submit(threadKey, task);
   }
   
@@ -418,7 +418,7 @@ public class KeyDistributedExecutor {
    * @param task Task to be executed
    * @return Future to represent when the execution has occurred
    */
-  public ListenableFuture<?> submit(Object threadKey, Runnable task) {
+  public Promise<?> submit(Object threadKey, Runnable task) {
     return submitTask(threadKey, task, null);
   }
   
@@ -434,7 +434,7 @@ public class KeyDistributedExecutor {
    * @return Future to represent when the execution has occurred and provide the given result
    */
   @Deprecated
-  public <T> ListenableFuture<T> submitTask(Object threadKey, Runnable task, T result) {
+  public <T> Promise<T> submitTask(Object threadKey, Runnable task, T result) {
     return submit(threadKey, task, result);
   }
   
@@ -447,7 +447,7 @@ public class KeyDistributedExecutor {
    * @param result Result to be returned from future when task completes
    * @return Future to represent when the execution has occurred and provide the given result
    */
-  public <T> ListenableFuture<T> submit(Object threadKey, Runnable task, T result) {
+  public <T> Promise<T> submit(Object threadKey, Runnable task, T result) {
     return submit(threadKey, new RunnableCallableAdapter<T>(task, result));
   }
   
@@ -462,7 +462,7 @@ public class KeyDistributedExecutor {
    * @return Future to represent when the execution has occurred and provide the result from the callable
    */
   @Deprecated
-  public <T> ListenableFuture<T> submitTask(Object threadKey, Callable<T> task) {
+  public <T> Promise<T> submitTask(Object threadKey, Callable<T> task) {
     return submit(threadKey, task);
   }
   
@@ -474,7 +474,7 @@ public class KeyDistributedExecutor {
    * @param task Callable to be executed
    * @return Future to represent when the execution has occurred and provide the result from the callable
    */
-  public <T> ListenableFuture<T> submit(Object threadKey, Callable<T> task) {
+  public <T> Promise<T> submit(Object threadKey, Callable<T> task) {
     ArgumentVerifier.assertNotNull(threadKey, "threadKey");
     ArgumentVerifier.assertNotNull(task, "task");
     
@@ -663,17 +663,17 @@ public class KeyDistributedExecutor {
     }
 
     @Override
-    public ListenableFuture<?> submit(Runnable task) {
+    public Promise<?> submit(Runnable task) {
       return KeyDistributedExecutor.this.submit(threadKey, task);
     }
 
     @Override
-    public <T> ListenableFuture<T> submit(Runnable task, T result) {
+    public <T> Promise<T> submit(Runnable task, T result) {
       return KeyDistributedExecutor.this.submit(threadKey, task, result);
     }
 
     @Override
-    public <T> ListenableFuture<T> submit(Callable<T> task) {
+    public <T> Promise<T> submit(Callable<T> task) {
       return KeyDistributedExecutor.this.submit(threadKey, task);
     }
   }

--- a/src/main/java/org/threadly/concurrent/KeyDistributedScheduler.java
+++ b/src/main/java/org/threadly/concurrent/KeyDistributedScheduler.java
@@ -2,9 +2,9 @@ package org.threadly.concurrent;
 
 import java.util.concurrent.Callable;
 
-import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.ListenableFutureTask;
 import org.threadly.concurrent.future.ListenableRunnableFuture;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.concurrent.lock.StripedLock;
 import org.threadly.util.ArgumentVerifier;
 
@@ -251,7 +251,7 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * {@link #scheduleTask(Object, Runnable, long)}.  So this should only be used when the future 
    * is necessary.
    * 
-   * The {@link ListenableFuture#get()} method will return {@code null} once the runnable has completed.
+   * The {@link Promise#get()} method will return {@code null} once the runnable has completed.
    * 
    * @deprecated Use {@link #submitScheduled(Object, Runnable, long)} as a directed replacement
    * 
@@ -261,7 +261,7 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * @return a future to know when the task has completed
    */
   @Deprecated
-  public ListenableFuture<?> submitScheduledTask(Object threadKey, Runnable task, long delayInMs) {
+  public Promise<?> submitScheduledTask(Object threadKey, Runnable task, long delayInMs) {
     return submitScheduled(threadKey, task, delayInMs);
   }
 
@@ -271,19 +271,19 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * {@link #scheduleTask(Object, Runnable, long)}.  So this should only be used when the future 
    * is necessary.
    * 
-   * The {@link ListenableFuture#get()} method will return {@code null} once the runnable has completed.
+   * The {@link Promise#get()} method will return {@code null} once the runnable has completed.
    * 
    * @param threadKey object key where {@code equals()} will be used to determine execution thread
    * @param task runnable to execute
    * @param delayInMs time in milliseconds to wait to execute task
    * @return a future to know when the task has completed
    */
-  public ListenableFuture<?> submitScheduled(Object threadKey, Runnable task, long delayInMs) {
+  public Promise<?> submitScheduled(Object threadKey, Runnable task, long delayInMs) {
     return submitScheduledTask(threadKey, task, null, delayInMs);
   }
 
   /**
-   * Schedule a task with a given delay.  The future {@link ListenableFuture#get()} method will 
+   * Schedule a task with a given delay.  The future {@link Promise#get()} method will 
    * return null once the runnable has completed.
    * 
    * @deprecated Use {@link #submitScheduled(Object, Runnable, Object, long)} as a direct replacement
@@ -291,29 +291,29 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * @param <T> type of result returned from the future
    * @param threadKey object key where {@code equals()} will be used to determine execution thread
    * @param task runnable to execute
-   * @param result result to be returned from resulting {@link ListenableFuture#get()} when runnable completes
+   * @param result result to be returned from resulting {@link Promise#get()} when runnable completes
    * @param delayInMs time in milliseconds to wait to execute task
    * @return a future to know when the task has completed
    */
   @Deprecated
-  public <T> ListenableFuture<T> submitScheduledTask(Object threadKey, Runnable task, 
-                                                     T result, long delayInMs) {
+  public <T> Promise<T> submitScheduledTask(Object threadKey, Runnable task, 
+                                            T result, long delayInMs) {
     return submitScheduled(threadKey, task, result, delayInMs);
   }
 
   /**
-   * Schedule a task with a given delay.  The future {@link ListenableFuture#get()} method will 
+   * Schedule a task with a given delay.  The future {@link Promise#get()} method will 
    * return null once the runnable has completed.
    * 
    * @param <T> type of result returned from the future
    * @param threadKey object key where {@code equals()} will be used to determine execution thread
    * @param task runnable to execute
-   * @param result result to be returned from resulting {@link ListenableFuture#get()} when runnable completes
+   * @param result result to be returned from resulting {@link Promise#get()} when runnable completes
    * @param delayInMs time in milliseconds to wait to execute task
    * @return a future to know when the task has completed
    */
-  public <T> ListenableFuture<T> submitScheduled(Object threadKey, Runnable task, 
-                                                 T result, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Object threadKey, Runnable task, 
+                                        T result, long delayInMs) {
     return submitScheduled(threadKey, new RunnableCallableAdapter<T>(task, result), delayInMs);
   }
 
@@ -330,8 +330,7 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * @return a future to know when the task has completed and get the result of the callable
    */
   @Deprecated
-  public <T> ListenableFuture<T> submitScheduledTask(Object threadKey, 
-                                                     Callable<T> task, long delayInMs) {
+  public <T> Promise<T> submitScheduledTask(Object threadKey, Callable<T> task, long delayInMs) {
     return submitScheduled(threadKey, task, delayInMs);
   }
 
@@ -345,8 +344,7 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * @param delayInMs time in milliseconds to wait to execute task
    * @return a future to know when the task has completed and get the result of the callable
    */
-  public <T> ListenableFuture<T> submitScheduled(Object threadKey, 
-                                                 Callable<T> task,  long delayInMs) {
+  public <T> Promise<T> submitScheduled(Object threadKey, Callable<T> task,  long delayInMs) {
     ArgumentVerifier.assertNotNull(threadKey, "threadKey");
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(delayInMs, "delayInMs");
@@ -519,17 +517,17 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
     }
 
     @Override
-    public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs) {
+    public Promise<?> submitScheduled(Runnable task, long delayInMs) {
       return submitScheduled(task, null, delayInMs);
     }
 
     @Override
-    public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs) {
+    public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs) {
       return KeyDistributedScheduler.this.submitScheduled(threadKey, task, result, delayInMs);
     }
 
     @Override
-    public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
+    public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs) {
       return KeyDistributedScheduler.this.submitScheduled(threadKey, task, delayInMs);
     }
 

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerDefaultPriorityWrapper.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerDefaultPriorityWrapper.java
@@ -2,7 +2,7 @@ package org.threadly.concurrent;
 
 import java.util.concurrent.Callable;
 
-import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.util.ArgumentVerifier;
 
 /**
@@ -45,32 +45,32 @@ public class PrioritySchedulerDefaultPriorityWrapper implements PrioritySchedule
   }
 
   @Override
-  public ListenableFuture<?> submit(Runnable task) {
+  public Promise<?> submit(Runnable task) {
     return scheduler.submit(task, defaultPriority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result) {
+  public <T> Promise<T> submit(Runnable task, T result) {
     return scheduler.submit(task, result, defaultPriority);
   }
 
   @Override
-  public ListenableFuture<?> submit(Runnable task, TaskPriority priority) {
+  public Promise<?> submit(Runnable task, TaskPriority priority) {
     return scheduler.submit(task, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result, TaskPriority priority) {
+  public <T> Promise<T> submit(Runnable task, T result, TaskPriority priority) {
     return scheduler.submit(task, result, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task) {
+  public <T> Promise<T> submit(Callable<T> task) {
     return scheduler.submit(task, defaultPriority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task, TaskPriority priority) {
+  public <T> Promise<T> submit(Callable<T> task, TaskPriority priority) {
     return scheduler.submit(task, priority);
   }
   
@@ -85,35 +85,33 @@ public class PrioritySchedulerDefaultPriorityWrapper implements PrioritySchedule
   }
 
   @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs) {
+  public Promise<?> submitScheduled(Runnable task, long delayInMs) {
     return scheduler.submitScheduled(task, delayInMs, defaultPriority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs) {
     return scheduler.submitScheduled(task, result, delayInMs, defaultPriority);
   }
 
   @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs,
-                                             TaskPriority priority) {
+  public Promise<?> submitScheduled(Runnable task, long delayInMs, TaskPriority priority) {
     return scheduler.submitScheduled(task, delayInMs, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs,
-                                                 TaskPriority priority) {
+  public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs,
+                                        TaskPriority priority) {
     return scheduler.submitScheduled(task, result, delayInMs, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs) {
     return scheduler.submitScheduled(task, delayInMs, defaultPriority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs,
-                                                 TaskPriority priority) {
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs, TaskPriority priority) {
     return scheduler.submitScheduled(task, delayInMs, priority);
   }
 

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerService.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerService.java
@@ -2,7 +2,7 @@ package org.threadly.concurrent;
 
 import java.util.concurrent.Callable;
 
-import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.Promise;
 
 /**
  * <p>This interface represents schedulers which can not only execute and schedule tasks, but run 
@@ -26,21 +26,21 @@ public interface PrioritySchedulerService extends SchedulerServiceInterface {
    * in load when using submit over execute.  So this should only be used when the future is 
    * necessary.
    * 
-   * The {@link ListenableFuture#get()} method will return {@code null} once the runnable has 
+   * The {@link Promise#get()} method will return {@code null} once the runnable has 
    * completed.
    * 
    * @param task runnable to be executed
    * @param priority priority for task to get available thread to run on
    * @return a future to know when the task has completed
    */
-  public ListenableFuture<?> submit(Runnable task, TaskPriority priority);
+  public Promise<?> submit(Runnable task, TaskPriority priority);
   
   /**
    * Submit a task to run as soon as possible for the given priority.  There is a slight increase 
    * in load when using submit over execute.  So this should only be used when the future is 
    * necessary.
    * 
-   * The {@link ListenableFuture#get()} method will return the provided result once the runnable has 
+   * The {@link Promise#get()} method will return the provided result once the runnable has 
    * completed.
    * 
    * @param <T> type of result returned from the future
@@ -49,7 +49,7 @@ public interface PrioritySchedulerService extends SchedulerServiceInterface {
    * @param priority priority for task to get available thread to run on
    * @return a future to know when the task has completed
    */
-  public <T> ListenableFuture<T> submit(Runnable task, T result, TaskPriority priority);
+  public <T> Promise<T> submit(Runnable task, T result, TaskPriority priority);
 
   /**
    * Submit a {@link Callable} to run as soon as possible for the given priority.  This is needed 
@@ -60,7 +60,7 @@ public interface PrioritySchedulerService extends SchedulerServiceInterface {
    * @param priority priority for task to get available thread to run on
    * @return a future to know when the task has completed and get the result of the callable
    */
-  public <T> ListenableFuture<T> submit(Callable<T> task, TaskPriority priority);
+  public <T> Promise<T> submit(Callable<T> task, TaskPriority priority);
   
   /**
    * Schedule a task with a given delay and a specified priority.
@@ -77,19 +77,19 @@ public interface PrioritySchedulerService extends SchedulerServiceInterface {
    * {@link #schedule(Runnable, long, TaskPriority)}.  So this should only be used when the 
    * future is necessary.
    * 
-   * The {@link ListenableFuture#get()} method will return null once the runnable has completed.
+   * The {@link Promise#get()} method will return null once the runnable has completed.
    * 
    * @param task runnable to execute
    * @param delayInMs time in milliseconds to wait to execute task
    * @param priority priority for task to get available thread to run on
    * @return a future to know when the task has completed
    */
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs, TaskPriority priority);
+  public Promise<?> submitScheduled(Runnable task, long delayInMs, TaskPriority priority);
   
   /**
    * Schedule a task with a given delay and a specified priority.  
    * 
-   * The {@link ListenableFuture#get()} method will return the provided result once the runnable 
+   * The {@link Promise#get()} method will return the provided result once the runnable 
    * has completed.
    * 
    * @param <T> type of result returned from the future
@@ -99,8 +99,8 @@ public interface PrioritySchedulerService extends SchedulerServiceInterface {
    * @param priority priority for task to get available thread to run on
    * @return a future to know when the task has completed
    */
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, 
-                                                 long delayInMs, TaskPriority priority);
+  public <T> Promise<T> submitScheduled(Runnable task, T result, 
+                                        long delayInMs, TaskPriority priority);
   
   /**
    * Schedule a {@link Callable} with a given delay.  This is needed when a result needs to be 
@@ -112,8 +112,7 @@ public interface PrioritySchedulerService extends SchedulerServiceInterface {
    * @param priority priority for task to get available thread to run on
    * @return a future to know when the task has completed and get the result of the callable
    */
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs, 
-                                                 TaskPriority priority);
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs, TaskPriority priority);
 
   /**
    * Schedule a fixed delay recurring task to run.  The recurring delay time will be from the 

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerStatisticTracker.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerStatisticTracker.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.threadly.concurrent.collections.ConcurrentArrayList;
-import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.Clock;
 
@@ -194,17 +194,17 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler {
   }
   
   @Override
-  public ListenableFuture<?> submit(Runnable task) {
+  public Promise<?> submit(Runnable task) {
     return submitScheduled(task, null, 0, defaultPriority);
   }
   
   @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result) {
+  public <T> Promise<T> submit(Runnable task, T result) {
     return submitScheduled(task, result, 0, defaultPriority);
   }
   
   @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task) {
+  public <T> Promise<T> submit(Callable<T> task) {
     return submitScheduled(task, 0, defaultPriority);
   }
 
@@ -214,17 +214,17 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler {
   }
 
   @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs) {
+  public Promise<?> submitScheduled(Runnable task, long delayInMs) {
     return submitScheduled(task, null, delayInMs, defaultPriority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs) {
     return submitScheduled(task, result, delayInMs, defaultPriority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs) {
     return submitScheduled(task, delayInMs, defaultPriority);
   }
 
@@ -244,20 +244,18 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler {
   }
 
   @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs,
-                                             TaskPriority priority) {
+  public Promise<?> submitScheduled(Runnable task, long delayInMs, TaskPriority priority) {
     return submitScheduled(task, null, delayInMs, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs,
-                                                 TaskPriority priority) {
+  public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs,
+                                        TaskPriority priority) {
     return submitScheduled(new RunnableCallableAdapter<T>(task, result), delayInMs, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs,
-                                                 TaskPriority priority) {
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs, TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
     
     return super.submitScheduled(wrap(task, priority, false), delayInMs, priority);

--- a/src/main/java/org/threadly/concurrent/SameThreadSubmitterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/SameThreadSubmitterExecutor.java
@@ -3,7 +3,7 @@ package org.threadly.concurrent;
 import java.util.concurrent.Callable;
 
 import org.threadly.concurrent.future.FutureUtils;
-import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.ExceptionUtils;
 
@@ -14,7 +14,7 @@ import org.threadly.util.ExceptionUtils;
  * {@link ExceptionUtils#handleException(Throwable)} to In the case of just 
  * {@link #execute(Runnable)} thrown exceptions will be provided to 
  * {@link ExceptionUtils#handleException(Throwable)} to be handled.  Otherwise thrown exceptions 
- * will be represented by their returned {@link ListenableFuture}.</p>
+ * will be represented by their returned {@link Promise}.</p>
  * 
  * @author jent - Mike Jensen
  * @since 1.2.0
@@ -45,12 +45,12 @@ public class SameThreadSubmitterExecutor implements SubmitterExecutorInterface {
   }
 
   @Override
-  public ListenableFuture<?> submit(Runnable task) {
+  public Promise<?> submit(Runnable task) {
     return submit(task, null);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result) {
+  public <T> Promise<T> submit(Runnable task, T result) {
     ArgumentVerifier.assertNotNull(task, "task");
     
     try {
@@ -63,7 +63,7 @@ public class SameThreadSubmitterExecutor implements SubmitterExecutorInterface {
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task) {
+  public <T> Promise<T> submit(Callable<T> task) {
     ArgumentVerifier.assertNotNull(task, "task");
     
     try {

--- a/src/main/java/org/threadly/concurrent/SubmitterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/SubmitterExecutor.java
@@ -3,7 +3,7 @@ package org.threadly.concurrent;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 
-import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.Promise;
 
 /**
  * <p>A thread pool for executing tasks with provided futures.  This executor submits 
@@ -18,16 +18,16 @@ public interface SubmitterExecutor extends Executor {
    * {@link #submit(Runnable)} over {@link #execute(Runnable)}.  So this should only be used when 
    * the returned future is necessary.  
    * 
-   * The {@link ListenableFuture#get()} method will return {@code null} once the runnable has 
+   * The {@link Promise#get()} method will return {@code null} once the runnable has 
    * completed.
    * 
    * @param task runnable to be executed
    * @return a future to know when the task has completed
    */
-  public ListenableFuture<?> submit(Runnable task);
+  public Promise<?> submit(Runnable task);
   
   /**
-   * Submit a task to run as soon as possible.  The {@link ListenableFuture#get()} method will 
+   * Submit a task to run as soon as possible.  The {@link Promise#get()} method will 
    * return the provided result once the runnable has completed.
    * 
    * @param <T> type of result for future
@@ -35,7 +35,7 @@ public interface SubmitterExecutor extends Executor {
    * @param result result to be returned from resulting future .get() when runnable completes
    * @return a future to know when the task has completed
    */
-  public <T> ListenableFuture<T> submit(Runnable task, T result);
+  public <T> Promise<T> submit(Runnable task, T result);
 
   /**
    * Submit a {@link Callable} to run as soon as possible.  This is needed when a result needs to 
@@ -45,5 +45,5 @@ public interface SubmitterExecutor extends Executor {
    * @param task callable to be executed
    * @return a future to know when the task has completed and get the result of the callable
    */
-  public <T> ListenableFuture<T> submit(Callable<T> task);
+  public <T> Promise<T> submit(Callable<T> task);
 }

--- a/src/main/java/org/threadly/concurrent/SubmitterScheduler.java
+++ b/src/main/java/org/threadly/concurrent/SubmitterScheduler.java
@@ -2,7 +2,7 @@ package org.threadly.concurrent;
 
 import java.util.concurrent.Callable;
 
-import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.Promise;
 
 /**
  * <p>A thread pool for scheduling tasks with provided futures.  This scheduler submits 
@@ -63,17 +63,17 @@ public interface SubmitterScheduler extends SimpleSchedulerInterface,
    * {@link #submitScheduled(Runnable, long)} over {@link #schedule(Runnable, long)}.  So this 
    * should only be used when the future is necessary.
    * 
-   * The {@link ListenableFuture#get()} method will return {@code null} once the runnable has 
+   * The {@link Promise#get()} method will return {@code null} once the runnable has 
    * completed.
    * 
    * @param task runnable to execute
    * @param delayInMs time in milliseconds to wait to execute task
    * @return a future to know when the task has completed
    */
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs);
+  public Promise<?> submitScheduled(Runnable task, long delayInMs);
   
   /**
-   * Schedule a task with a given delay.  The {@link ListenableFuture#get()} method will return 
+   * Schedule a task with a given delay.  The {@link Promise#get()} method will return 
    * the provided result once the runnable has completed.
    * 
    * @param <T> type of result returned from the future
@@ -82,7 +82,7 @@ public interface SubmitterScheduler extends SimpleSchedulerInterface,
    * @param delayInMs time in milliseconds to wait to execute task
    * @return a future to know when the task has completed
    */
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs);
+  public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs);
   
   /**
    * Schedule a {@link Callable} with a given delay.  This is needed when a result needs to be 
@@ -93,5 +93,5 @@ public interface SubmitterScheduler extends SimpleSchedulerInterface,
    * @param delayInMs time in milliseconds to wait to execute task
    * @return a future to know when the task has completed and get the result of the callable
    */
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs);
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs);
 }

--- a/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Executor;
  * @param <T> The result object type returned by this future
  */
 abstract class AbstractImmediateListenableFuture<T> extends AbstractNoncancelableListenableFuture<T>
-                                                    implements ListenableFuture<T> {
+                                                    implements Promise<T> {
   @Override
   public boolean isDone() {
     return true;

--- a/src/main/java/org/threadly/concurrent/future/FutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureUtils.java
@@ -260,8 +260,8 @@ public class FutureUtils {
    * @param result Result to provide returned future once all futures complete
    * @return ListenableFuture which will be done once all futures provided are done
    */
-  public static <T> ListenableFuture<T> makeCompleteFuture(Iterable<? extends ListenableFuture<?>> futures, 
-                                                           final T result) {
+  public static <T> Promise<T> makeCompleteFuture(Iterable<? extends ListenableFuture<?>> futures, 
+                                                  final T result) {
     final EmptyFutureCollection efc = new EmptyFutureCollection(futures);
     final SettableListenableFuture<T> resultFuture = new CancelDelegateSettableListenableFuture<T>(efc);
     efc.addCallback(new FutureCallback<Object>() {
@@ -298,7 +298,7 @@ public class FutureUtils {
    * @param futures Structure of futures to iterate over
    * @return ListenableFuture which will be done once all futures provided are done
    */
-  public static <T> ListenableFuture<List<ListenableFuture<? extends T>>> 
+  public static <T> Promise<List<ListenableFuture<? extends T>>> 
       makeCompleteListFuture(Iterable<? extends ListenableFuture<? extends T>> futures) {
     return new AllFutureCollection<T>(futures);
   }
@@ -319,7 +319,7 @@ public class FutureUtils {
    * @param futures Structure of futures to iterate over
    * @return ListenableFuture which will be done once all futures provided are done
    */
-  public static <T> ListenableFuture<List<ListenableFuture<? extends T>>> 
+  public static <T> Promise<List<ListenableFuture<? extends T>>> 
       makeSuccessListFuture(Iterable<? extends ListenableFuture<? extends T>> futures) {
     return new SuccessFutureCollection<T>(futures);
   }
@@ -340,7 +340,7 @@ public class FutureUtils {
    * @param futures Structure of futures to iterate over
    * @return ListenableFuture which will be done once all futures provided are done
    */
-  public static <T> ListenableFuture<List<ListenableFuture<? extends T>>> 
+  public static <T> Promise<List<ListenableFuture<? extends T>>> 
       makeFailureListFuture(Iterable<? extends ListenableFuture<? extends T>> futures) {
     return new FailureFutureCollection<T>(futures);
   }
@@ -366,7 +366,7 @@ public class FutureUtils {
    * @param ignoreFailedFutures {@code true} to ignore any future failures
    * @return A {@link ListenableFuture} which will provide a list of the results from the provided futures
    */
-  public static <T> ListenableFuture<List<T>> 
+  public static <T> Promise<List<T>> 
       makeResultListFuture(Iterable<? extends ListenableFuture<? extends T>> futures, 
                            final boolean ignoreFailedFutures) {
     if (futures == null) {
@@ -440,9 +440,9 @@ public class FutureUtils {
    * @return Already satisfied future
    */
   @SuppressWarnings("unchecked")
-  public static <T> ListenableFuture<T> immediateResultFuture(T result) {
+  public static <T> Promise<T> immediateResultFuture(T result) {
     if (result == null) {
-      return (ListenableFuture<T>)ImmediateResultListenableFuture.NULL_RESULT;
+      return (Promise<T>)ImmediateResultListenableFuture.NULL_RESULT;
     } else {
       return new ImmediateResultListenableFuture<T>(result);
     }
@@ -459,7 +459,7 @@ public class FutureUtils {
    * @param failure to provide as cause for ExecutionException thrown from .get() call
    * @return Already satisfied future
    */
-  public static <T> ListenableFuture<T> immediateFailureFuture(Throwable failure) {
+  public static <T> Promise<T> immediateFailureFuture(Throwable failure) {
     return new ImmediateFailureListenableFuture<T>(failure);
   }
   

--- a/src/main/java/org/threadly/concurrent/future/ListenableRunnableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableRunnableFuture.java
@@ -14,6 +14,6 @@ import java.util.concurrent.RunnableFuture;
  * @since 1.0.0
  * @param <T> The result object type returned by this future
  */
-public interface ListenableRunnableFuture<T> extends ListenableFuture<T>, RunnableFuture<T> {
+public interface ListenableRunnableFuture<T> extends Promise<T>, RunnableFuture<T> {
   // nothing added here
 }

--- a/src/main/java/org/threadly/concurrent/future/Promise.java
+++ b/src/main/java/org/threadly/concurrent/future/Promise.java
@@ -1,0 +1,13 @@
+package org.threadly.concurrent.future;
+
+/**
+ * <p>Extending interface from {@link ListenableFuture}.  This offers nothing unique but does 
+ * allow for less typing.  Please see {@link ListenableFuture} documentation.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @param <T> The result object type returned by this future
+ * @since 4.4.0
+ */
+public interface Promise<T> extends ListenableFuture<T> {
+  // nothing added here
+}

--- a/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
@@ -18,7 +18,7 @@ import org.threadly.util.Clock;
  * @since 1.2.0
  * @param <T> The result object type returned by this future
  */
-public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureCallback<T> {
+public class SettableListenableFuture<T> implements Promise<T>, FutureCallback<T> {
   protected final RunnableListenerHelper listenerHelper;
   protected final Object resultLock;
   protected final boolean throwIfAlreadyComplete;

--- a/src/main/java/org/threadly/concurrent/limiter/PrioritySchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/PrioritySchedulerLimiter.java
@@ -5,8 +5,8 @@ import java.util.concurrent.Callable;
 import org.threadly.concurrent.PrioritySchedulerInterface;
 import org.threadly.concurrent.PrioritySchedulerService;
 import org.threadly.concurrent.TaskPriority;
-import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.Clock;
 
@@ -72,31 +72,28 @@ public class PrioritySchedulerLimiter extends SchedulerServiceLimiter
   }
 
   @Override
-  public ListenableFuture<?> submit(Runnable task, TaskPriority priority) {
+  public Promise<?> submit(Runnable task, TaskPriority priority) {
     return submitScheduled(task, null, 0, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result, 
-                                        TaskPriority priority) {
+  public <T> Promise<T> submit(Runnable task, T result, TaskPriority priority) {
     return submitScheduled(task, result, 0, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task, 
-                                        TaskPriority priority) {
+  public <T> Promise<T> submit(Callable<T> task, TaskPriority priority) {
     return submitScheduled(task, 0, priority);
   }
 
   @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs, 
-                                             TaskPriority priority) {
+  public Promise<?> submitScheduled(Runnable task, long delayInMs, TaskPriority priority) {
     return submitScheduled(task, null, delayInMs, priority);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs, 
-                                                 TaskPriority priority) {
+  public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs, 
+                                        TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
     if (priority == null) {
       priority = scheduler.getDefaultPriority();
@@ -110,8 +107,7 @@ public class PrioritySchedulerLimiter extends SchedulerServiceLimiter
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs, 
-                                                 TaskPriority priority) {
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs, TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
     if (priority == null) {
       priority = scheduler.getDefaultPriority();
@@ -125,8 +121,7 @@ public class PrioritySchedulerLimiter extends SchedulerServiceLimiter
   }
 
   @Override
-  public void schedule(Runnable task, long delayInMs, 
-                       TaskPriority priority) {
+  public void schedule(Runnable task, long delayInMs, TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(delayInMs, "delayInMs");
     if (priority == null) {

--- a/src/main/java/org/threadly/concurrent/limiter/SubmitterSchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/SubmitterSchedulerLimiter.java
@@ -5,8 +5,8 @@ import java.util.concurrent.Callable;
 import org.threadly.concurrent.RunnableCallableAdapter;
 import org.threadly.concurrent.RunnableContainer;
 import org.threadly.concurrent.SubmitterScheduler;
-import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.concurrent.future.Promise;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.Clock;
 
@@ -59,17 +59,17 @@ public class SubmitterSchedulerLimiter extends ExecutorLimiter
   }
 
   @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs) {
+  public Promise<?> submitScheduled(Runnable task, long delayInMs) {
     return submitScheduled(task, null, delayInMs);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs) {
     return submitScheduled(new RunnableCallableAdapter<T>(task, result), delayInMs);
   }
 
   @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
+  public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs) {
     ArgumentVerifier.assertNotNull(task, "task");
     
     ListenableFutureTask<T> ft = new ListenableFutureTask<T>(false, task);

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerDefaultPriorityWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerDefaultPriorityWrapperTest.java
@@ -8,7 +8,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.threadly.concurrent.future.FutureUtils;
-import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.Promise;
 
 @SuppressWarnings("javadoc")
 public class PrioritySchedulerDefaultPriorityWrapperTest {
@@ -255,19 +255,19 @@ public class PrioritySchedulerDefaultPriorityWrapperTest {
     }
 
     @Override
-    public ListenableFuture<?> submit(Runnable task, TaskPriority priority) {
+    public Promise<?> submit(Runnable task, TaskPriority priority) {
       submitRunnableCalled = true;
       return FutureUtils.immediateFailureFuture(new UnsupportedOperationException());
     }
 
     @Override
-    public <T> ListenableFuture<T> submit(Runnable task, T result, TaskPriority priority) {
+    public <T> Promise<T> submit(Runnable task, T result, TaskPriority priority) {
       submitRunnableResultCalled = true;
       return FutureUtils.immediateFailureFuture(new UnsupportedOperationException());
     }
 
     @Override
-    public <T> ListenableFuture<T> submit(Callable<T> task, TaskPriority priority) {
+    public <T> Promise<T> submit(Callable<T> task, TaskPriority priority) {
       submitCallableCalled = true;
       return FutureUtils.immediateFailureFuture(new UnsupportedOperationException());
     }
@@ -278,21 +278,21 @@ public class PrioritySchedulerDefaultPriorityWrapperTest {
     }
 
     @Override
-    public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs, TaskPriority priority) {
+    public Promise<?> submitScheduled(Runnable task, long delayInMs, TaskPriority priority) {
       submitScheduledRunnableCalled = true;
       return FutureUtils.immediateFailureFuture(new UnsupportedOperationException());
     }
 
     @Override
-    public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs,
-                                                   TaskPriority priority) {
+    public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs,
+                                          TaskPriority priority) {
       submitScheduledRunnableResultCalled = true;
       return FutureUtils.immediateFailureFuture(new UnsupportedOperationException());
     }
 
     @Override
-    public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs,
-                                                   TaskPriority priority) {
+    public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs,
+                                          TaskPriority priority) {
       submitScheduledCallableCalled = true;
       return FutureUtils.immediateFailureFuture(new UnsupportedOperationException());
     }
@@ -343,17 +343,17 @@ public class PrioritySchedulerDefaultPriorityWrapperTest {
     
     // NO OPERATIONS WITHOUT PRIORITY SHOULD BE CALLED
     @Override
-    public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs) {
+    public Promise<?> submitScheduled(Runnable task, long delayInMs) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs) {
+    public <T> Promise<T> submitScheduled(Runnable task, T result, long delayInMs) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
+    public <T> Promise<T> submitScheduled(Callable<T> task, long delayInMs) {
       throw new UnsupportedOperationException();
     }
 
@@ -378,17 +378,17 @@ public class PrioritySchedulerDefaultPriorityWrapperTest {
     }
 
     @Override
-    public ListenableFuture<?> submit(Runnable task) {
+    public Promise<?> submit(Runnable task) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public <T> ListenableFuture<T> submit(Runnable task, T result) {
+    public <T> Promise<T> submit(Runnable task, T result) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public <T> ListenableFuture<T> submit(Callable<T> task) {
+    public <T> Promise<T> submit(Callable<T> task) {
       throw new UnsupportedOperationException();
     }
   }


### PR DESCRIPTION
This comes from #180, with a goal to have less typing in this very frequently used structure.
I am a little nervous to completely remove ListenableFuture.  While I understand threadly has long names that is to make it easy to navigate the project through javadocs.
This is an attempt to provide both options, but I am unsure if it fits very cleanly.  Here we create a new interface "Promise" which just extends "ListenableFuture".  We now return "Promise" as an alternative, but if your setting it into a ListenableFuture it should work just as good.  We are not deprecating ListenableFuture, just giving a short hand version.

If we do like this, some outstanding questions are:
* What should we do about the interface "ListenableRunnableFuture"?  Should we have an extending "RunnablePromise" to keep things consistent?
* Should we rename "ListenableFutureTask" into "PromiseTask" to keep things shorter and consistent?

@lwahlmeier I appreciate your feedback here.  I know your not a particular fan of the verbosity, but do you think this keeps things easy to navigate from the javadocs?  And do feel it's worth this added complexity?  If you do like this, what do you think about the two questions above?