### PR TITLE
PriorityScheduler: remove the queue manager thread

### DIFF
--- a/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
@@ -182,7 +182,8 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
     try {
       while ((nextTask = getNextReadyTask()) != null && ! tickCanceled) {
         // call will remove task from queue, or reposition as necessary
-        if (nextTask.canExecute()) {
+        // we can cheat with the execution reference since task de-queue is single threaded
+        if (nextTask.canExecute(nextTask.getExecuteReference())) {
           try {
             nextTask.runTask();
           } catch (Throwable t) {
@@ -543,10 +544,7 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
         if (! canceled) {
           updateNextRunTime();
           // now that nextRunTime has been set, resort the queue
-          queueSet.reschedule(this);
-          
-          // only set executing to false AFTER rescheduled
-          executing = false;
+          queueSet.reschedule(this);  // this will set executing to false atomically with the resort
         }
       }
     }

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerServiceWrapper.java
@@ -93,7 +93,7 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     task = new ThrowableHandlingRecurringRunnable(scheduler, task);
     
     ListenableRunnableFuture<Void> taskFuture = new ListenableFutureTask<Void>(true, task);
-    QueueSet queueSet = pScheduler.taskConsumer.getQueueSet(pScheduler.getDefaultPriority());
+    QueueSet queueSet = pScheduler.taskQueueManager.getQueueSet(pScheduler.getDefaultPriority());
     RecurringDelayTaskWrapper rdtw = 
         new RecurringDelayTaskWrapper(taskFuture, queueSet,
                                       Clock.accurateForwardProgressingMillis() + initialDelay, delayInMs);
@@ -110,7 +110,7 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     task = new ThrowableHandlingRecurringRunnable(pScheduler, task);
     
     ListenableRunnableFuture<Void> taskFuture = new ListenableFutureTask<Void>(true, task);
-    QueueSet queueSet = pScheduler.taskConsumer.getQueueSet(pScheduler.getDefaultPriority());
+    QueueSet queueSet = pScheduler.taskQueueManager.getQueueSet(pScheduler.getDefaultPriority());
     RecurringRateTaskWrapper rrtw = 
         new RecurringRateTaskWrapper(taskFuture, queueSet,
                                      Clock.accurateForwardProgressingMillis() + initialDelay, periodInMillis);

--- a/src/main/java/org/threadly/util/Pair.java
+++ b/src/main/java/org/threadly/util/Pair.java
@@ -17,6 +17,8 @@ public class Pair<L, R> {
   private static final short LEFT_PRIME = 13;
   private static final short RIGHT_PRIME = 31;
   
+  // TODO - in threadly 5.0.0 make an easy way to apply a functional to either left or right
+  
   /**
    * Collect all the non-null left references into a new List.  A simple implementation which 
    * iterates over a source collection and collects all non-null left references into a new list 

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest.java
@@ -1,13 +1,19 @@
 package org.threadly.concurrent;
 
 import org.junit.Before;
+import org.threadly.concurrent.PriorityScheduler.QueueManager;
 import org.threadly.concurrent.PrioritySchedulerStatisticTracker.StatisticWorkerPool;
 import org.threadly.concurrent.PrioritySchedulerStatisticTracker.StatsManager;
 
 @SuppressWarnings("javadoc")
 public class PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest extends PrioritySchedulerWorkerPoolTest {
+  @Override
   @Before
   public void setup() {
     workerPool = new StatisticWorkerPool(new ConfigurableThreadFactory(), 1, new StatsManager());
+    qm = new QueueManager(workerPool, 1000);
+    
+    // set the queue manager, but then make sure we kill the worker
+    workerPool.start(qm);
   }
 }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerTaskWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerTaskWrapperTest.java
@@ -61,7 +61,12 @@ public class PrioritySchedulerTaskWrapperTest {
     }
 
     @Override
-    public boolean canExecute() {
+    public short getExecuteReference() {
+      return 0;
+    }
+
+    @Override
+    public boolean canExecute(short executionReference) {
       canExecuteCalled = true;
       return true;
     }

--- a/src/test/java/org/threadly/concurrent/StrictPriorityScheduler.java
+++ b/src/test/java/org/threadly/concurrent/StrictPriorityScheduler.java
@@ -88,8 +88,7 @@ public class StrictPriorityScheduler extends PriorityScheduler {
    */
   public StrictPriorityScheduler(int poolSize, TaskPriority defaultPriority, 
                                  long maxWaitForLowPriorityInMs, ThreadFactory threadFactory) {
-    super(new StrictWorkerPool(threadFactory, poolSize), 
-          maxWaitForLowPriorityInMs, defaultPriority);
+    super(new WorkerPool(threadFactory, poolSize), maxWaitForLowPriorityInMs, defaultPriority);
   }
   
   private static void verifyOneTimeTaskQueueSet(QueueSet queueSet, OneTimeTaskWrapper task) {
@@ -126,101 +125,5 @@ public class StrictPriorityScheduler extends PriorityScheduler {
     }
     
     super.addToScheduleQueue(queueSet, task);
-  }
-  
-  protected static class StrictWorkerPool extends WorkerPool {
-    protected StrictWorkerPool(ThreadFactory threadFactory, int poolSize) {
-      super(threadFactory, poolSize);
-    }
-
-    private void verifyWorkersLock() {
-      if (! Thread.holdsLock(workersLock)) {
-        throw new IllegalStateException("Workers lock must be held before calling");
-      }
-    }
-
-    @Override
-    protected Worker makeNewWorker() {
-      verifyWorkersLock();
-      
-      return new StrictWorkerWrapper(this, threadFactory, super.makeNewWorker());
-    }
-  }
-  
-  /**
-   * <p>This is a hack...I did not want to extract worker into an interface, so we extend the 
-   * class and just override all implemented functions.  We can then defer to the provided 
-   * deligate for any operations needed.  This is because, 1, I did not want to add an interface, 
-   * and 2, I did not want to change the visibility of {@code currentPoolSize}</p>
-   * 
-   * <p>I know this is ugly, but since it is only used in test code, I don't mind it.  I would 
-   * NEVER do this in the main code base (I am only doing this to keep the main code base small and 
-   * clean).</p>
-   * 
-   * @author jent - Mike Jensen
-   */
-  protected static class StrictWorkerWrapper extends Worker {
-    private final Worker deligateWorker;
-    
-    private StrictWorkerWrapper(WorkerPool workerPool, ThreadFactory threadFactory, 
-                                Worker deligateWorker) {
-      super(workerPool, threadFactory);
-      
-      this.deligateWorker = deligateWorker;
-    }
-
-    @Override
-    public void start() {
-      deligateWorker.start();
-    }
-    
-    @Override
-    public boolean startIfNotStarted() {
-      return deligateWorker.startIfNotStarted();
-    }
-    
-    @Override
-    public void stop() {
-      deligateWorker.stop();
-    }
-    
-    @Override
-    public boolean stopIfRunning() {
-      return deligateWorker.stopIfRunning();
-    }
-
-    @Override
-    protected void startupService() {
-      // overriding above functions should mean this is never called
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void shutdownService() {
-      // overriding above functions should mean this is never called
-      throw new UnsupportedOperationException();
-    }
-    
-    @Override
-    public void run() {
-      // overriding above functions should mean this is never called
-      throw new UnsupportedOperationException();
-    }
-    
-    @Override
-    public boolean isRunning() {
-      return deligateWorker.isRunning();
-    }
-    
-    @Override
-    public void nextTask(TaskWrapper task) {
-      if (! deligateWorker.isRunning()) {
-        throw new IllegalStateException();
-      } else if (deligateWorker.nextTask != null) {
-        throw new IllegalStateException();
-      }
-      
-      deligateWorker.nextTask(task);
-    }
   }
 }

--- a/src/test/java/org/threadly/concurrent/SubmitterExecutorInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/SubmitterExecutorInterfaceTest.java
@@ -43,7 +43,7 @@ public abstract class SubmitterExecutorInterfaceTest {
   public void executeTest() {
     SubmitterExecutorFactory factory = getSubmitterExecutorFactory();
     try {
-      SubmitterExecutor executor = factory.makeSubmitterExecutor(TEST_QTY, false);
+      SubmitterExecutor executor = factory.makeSubmitterExecutor(2, false);
       
       List<TestRunnable> runnables = executeTestRunnables(executor, 0);
       

--- a/src/test/java/org/threadly/util/debug/ProfilerTest.java
+++ b/src/test/java/org/threadly/util/debug/ProfilerTest.java
@@ -146,13 +146,11 @@ public class ProfilerTest {
   public void startWitExecutorTest() {
     PrioritySchedulerStatisticTracker e = new PrioritySchedulerStatisticTracker(1);
     try {
-      assertEquals(0, e.getCurrentPoolSize());
       assertEquals(0, e.getCurrentRunningCount());
       
       profiler.start(e);
       
       assertTrue(profiler.isRunning());
-      assertEquals(1, e.getCurrentPoolSize());
       assertEquals(1, e.getCurrentRunningCount());
     } finally {
       profiler.stop();


### PR DESCRIPTION
This is a large change that is really the sum of months of work.
This removes the queue manager thread.  Workers never move into an idle structure.  Instead each worker tries to aggressively take tasks.  A lot more similar to how java.util's schedulers work, but with quite a few complexities due to how threadly works.
This provides a massive performance improvement.  But also still has some problems I am yet to figure out solutions for (documented as TODO).

Because of the complexity and the risk of this change I will describe things in-line (sorry for the spam to all the watchers of the project).

Don't merge this until we know we are all okay with everything.