### PR TITLE
Profiler: Deprecate constructing with a file to dump to

### DIFF
--- a/src/main/java/org/threadly/util/debug/Profiler.java
+++ b/src/main/java/org/threadly/util/debug/Profiler.java
@@ -79,8 +79,12 @@ public class Profiler {
    * 
    * This uses a default poll interval of 100 milliseconds.
    * 
+   * @deprecated Dumping to a file on stop will no longer be supported, 
+   *               instead just invoke {@link #dump(OutputStream)} after stopping
+   *               
    * @param outputFile file to dump results to on stop (or {@code null} to not dump on stop)
    */
+  @Deprecated
   public Profiler(File outputFile) {
     this(outputFile, DEFAULT_POLL_INTERVAL_IN_MILLIS);
   }
@@ -101,9 +105,13 @@ public class Profiler {
    * 
    * If the output file is {@code null}, this will behave the same as the empty constructor.
    * 
+   * @deprecated Dumping to a file on stop will no longer be supported, 
+   *               instead just invoke {@link #dump(OutputStream)} after stopping
+   * 
    * @param outputFile file to dump results to on stop (or {@code null} to not dump on stop)
    * @param pollIntervalInMs frequency to check running threads
    */
+  @Deprecated
   public Profiler(File outputFile, int pollIntervalInMs) {
     this(outputFile, new ProfileStorage(pollIntervalInMs));
   }
@@ -349,6 +357,7 @@ public class Profiler {
             it.next().setResult(result);
           }
         }
+        // TODO - remove logic in 5.0.0 after deprecation removal
         if (outputFile != null) {
           try {
             OutputStream out = new FileOutputStream(outputFile);

--- a/src/test/java/org/threadly/util/debug/ProfilerTest.java
+++ b/src/test/java/org/threadly/util/debug/ProfilerTest.java
@@ -48,6 +48,7 @@ public class ProfilerTest {
   }
   
   @Test
+  @SuppressWarnings("deprecation")
   public void constructorTest() {
     int testPollInterval = Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS * 10;
     File dumpFile = new File("foo");


### PR DESCRIPTION
This deprecates for removal in 5.0.0 where Profiler can be constructed with a file to dump to on shutdown.
Instead dump with a FileOutputStream should be manually invoked after stopping the scheduler.

@lwahlmeier Let me know your thoughts on this.  I am thinking of removing it only because I have never personally found it useful.  Removing this makes the API seem a bit more cleaner and easier to understand, and would remove a tiny amount of logic.

But it's not causing problems, so if you or anyone else think there is any (even minimal) value in this, let me know.