### PR TITLE
UnfairExecutor initial implementation

### DIFF
--- a/src/main/java/org/threadly/concurrent/UnfairExecutor.java
+++ b/src/main/java/org/threadly/concurrent/UnfairExecutor.java
@@ -1,0 +1,236 @@
+package org.threadly.concurrent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+
+import org.threadly.util.ArgumentVerifier;
+import org.threadly.util.Clock;
+
+/**
+ * <p>A very high performance {@link SubmitterExecutor} implementation.  Though to get those 
+ * performance gains, some guarantees are reduced.  Most prominently is execution order, this 
+ * scheduler does not ensure that tasks are executed in the order they are submitted, but rather 
+ * tasks are consumed however is fastest.</p>
+ * 
+ * <p>This executor has an execution queue per thread.  That way each thread has a many producer, 
+ * one consumer safety guarantees.  Vs normal pools which have to deal with a many to many thread 
+ * safety issue.  Determining the thread queue may be based on a variety of information, some 
+ * examples are the {@link Object#hashCode()} of the provided task, the current time, or other 
+ * weak choices to try and distribute work evenly.</p>
+ * 
+ * <p>In this it is obviously possible for one long running task to block other tasks needing to 
+ * run (even if other threads are idle).  Because of that tasks should be equally sized, having 
+ * large tasks mixed in with small ones will make this more problematic.  We also recommend having 
+ * thread counts which are prime numbers for a more even hash distribution.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 4.5.0
+ */
+public class UnfairExecutor extends AbstractSubmitterExecutor {
+  private final SingleThreadScheduler[] schedulers;
+  private volatile boolean  allThreadsStarted;  // only transitions to true once
+  
+  /**
+   * Constructs a new {@link UnfairExecutor} with a provided thread count.  This defaults to using 
+   * daemon threads.
+   * 
+   * @param threadCount Number of threads, recommended to be a prime number
+   */
+  public UnfairExecutor(int threadCount) {
+    this(threadCount, true);
+  }
+
+  /**
+   * Constructs a new {@link UnfairExecutor} with a provided thread count.
+   * 
+   * @param threadCount Number of threads, recommended to be a prime number
+   * @param useDaemonThreads {@code true} if created threads should be daemon
+   */
+  public UnfairExecutor(int threadCount, boolean useDaemonThreads) {
+    this(threadCount, new ConfigurableThreadFactory(UnfairExecutor.class.getSimpleName() + "-", true, 
+                                                    useDaemonThreads, Thread.NORM_PRIORITY, null, null));
+  }
+
+  /**
+   * Constructs a new {@link UnfairExecutor} with a provided thread count and factory.
+   * 
+   * @param threadCount Number of threads, recommended to be a prime number
+   * @param threadFactory thread factory for producing new threads within executor
+   */
+  public UnfairExecutor(int threadCount, ThreadFactory threadFactory) {
+    ArgumentVerifier.assertGreaterThanZero(threadCount, "threadCount");
+    
+    schedulers = new SingleThreadScheduler[threadCount];
+    for (int i = 0; i < threadCount; i++) {
+      schedulers[i] = new SingleThreadScheduler(threadFactory);
+    }
+    allThreadsStarted = false;
+  }
+  
+  @Override
+  protected void doExecute(Runnable task) {
+    long seed = Math.abs(task.hashCode() ^ Clock.lastKnownTimeNanos());
+    SingleThreadScheduler scheduler1 = schedulers[(int)(seed % schedulers.length)];
+    NoThreadScheduler nts1 = scheduler1.sManager.scheduler;
+    if (nts1.getActiveTaskCount() == 0) {
+      scheduler1.execute(task);
+    } else {
+      SingleThreadScheduler scheduler2 = schedulers[(int)((seed + 1) % schedulers.length)];
+      NoThreadScheduler nts2 = scheduler2.sManager.scheduler;
+      if (nts1.highPriorityQueueSet.executeQueue.size() < nts2.highPriorityQueueSet.executeQueue.size()) {
+        scheduler1.execute(task);
+      } else {
+        scheduler2.execute(task);
+      }
+    }
+  }
+  
+  /**
+   * Getter for the currently set max thread pool size.
+   * 
+   * @return current max pool size
+   */
+  public int getMaxPoolSize() {
+    return schedulers.length;
+  }
+
+  /**
+   * Getter for the current quantity of threads running in this pool (either active or idle).  
+   * This is different than the size returned from {@link #getMaxPoolSize()} in that we 
+   * lazily create threads.  This represents the amount of threads needed to be created so far, 
+   * where {@link #getMaxPoolSize()} represents the amount of threads the pool may grow to.  
+   * 
+   * Unlike other pools, this call may have O(n threads) to calculate the result.
+   * 
+   * @return current thread count
+   */
+  public int getCurrentPoolSize() {
+    if (allThreadsStarted && ! isShutdown()) {
+      // shortcut to avoid looping over all threads
+      return schedulers.length;
+    }
+    
+    int result = 0;
+    for (SingleThreadScheduler sts : schedulers) {
+      if (sts.sManager.execThread.isAlive()) {
+        result++;
+      }
+    }
+    if (result == schedulers.length) {
+      allThreadsStarted = true;
+    }
+    return result;
+  }
+  
+  /**
+   * Ensures all threads have been started, it will create threads till the thread count matches 
+   * the set pool size (checked via {@link #getMaxPoolSize()}).  These new threads will remain 
+   * idle till there is tasks ready to execute.
+   */
+  public void prestartAllThreads() {
+    if (allThreadsStarted) {
+      // shortcut to avoid looping over all threads
+      return;
+    }
+    
+    for (SingleThreadScheduler sts : schedulers) {
+      if (! sts.sManager.execThread.isAlive()) {
+        // easiest way to start it up
+        try {
+          sts.execute(DoNothingRunnable.instance());
+        } catch (RejectedExecutionException e) {
+          // shutting down
+          return;
+        }
+      }
+    }
+    
+    allThreadsStarted = true;
+  }
+
+  /**
+   * Function to check if the thread pool is currently accepting and handling tasks.
+   * 
+   * @return {@code true} if thread pool is running
+   */
+  public boolean isShutdown() {
+    return schedulers[0].isShutdown();
+  }
+
+  /**
+   * Stops any new tasks from being submitted to the pool.  But allows all tasks which are 
+   * submitted to execute, or scheduled (and have elapsed their delay time) to run.  If recurring 
+   * tasks are present they will also be unable to reschedule.  This call will not block to wait 
+   * for the shutdown of the scheduler to finish.  If {@code shutdown()} or 
+   * {@link #shutdownNow()} has already been called, this will have no effect.  
+   * 
+   * If you wish to not want to run any queued tasks you should use {@link #shutdownNow()}.
+   */
+  public void shutdown() {
+    synchronized (schedulers) {
+      if (isShutdown()) {
+        return;
+      }
+      
+      for (SingleThreadScheduler sts : schedulers) {
+        sts.shutdown();
+      }
+    }
+  }
+
+  /**
+   * Stops any new tasks from being submitted to the pool.  If any tasks are waiting for execution 
+   * they will be prevented from being run.  If a task is currently running it will be allowed to 
+   * finish (though this call will not block waiting for it to finish).
+   * 
+   * @return returns a list of runnables which were waiting in the queue to be run at time of shutdown
+   */
+  public List<Runnable> shutdownNow() {
+    synchronized (schedulers) {
+      if (isShutdown()) {
+        return Collections.emptyList();
+      }
+      
+      List<Runnable> result = new ArrayList<Runnable>();
+      for (SingleThreadScheduler sts : schedulers) {
+        result.addAll(sts.shutdownNow());
+      }
+      return result;
+    }
+  }
+
+  /**
+   * Block until the thread pool has shutdown and all threads have been stopped.  If neither 
+   * {@link #shutdown()} or {@link #shutdownNow()} is invoked, then this will block forever.
+   * 
+   * @throws InterruptedException Thrown if blocking thread is interrupted waiting for shutdown
+   */
+  public void awaitTermination() throws InterruptedException {
+    for (SingleThreadScheduler sts : schedulers) {
+      sts.awaitTermination();
+    }
+  }
+
+  /**
+   * Block until the thread pool has shutdown and all threads have been stopped.  If neither 
+   * {@link #shutdown()} or {@link #shutdownNow()} is invoked, then this will block until the 
+   * timeout is reached.
+   * 
+   * @param timeoutMillis time to block and wait for thread pool to shutdown
+   * @return {@code true} if the pool has shutdown, false if timeout was reached
+   * @throws InterruptedException Thrown if blocking thread is interrupted waiting for shutdown
+   */
+  public boolean awaitTermination(long timeoutMillis) throws InterruptedException {
+    long startTime = Clock.accurateForwardProgressingMillis();
+    for (SingleThreadScheduler sts : schedulers) {
+      long remainingWait = timeoutMillis - (Clock.lastKnownForwardProgressingMillis() - startTime);
+      if (remainingWait <= 0 || ! sts.awaitTermination(remainingWait)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/test/java/org/threadly/concurrent/UnfairExecutorTest.java
+++ b/src/test/java/org/threadly/concurrent/UnfairExecutorTest.java
@@ -1,0 +1,187 @@
+package org.threadly.concurrent;
+
+import static org.junit.Assert.*;
+import static org.threadly.TestConstants.*;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.junit.Test;
+import org.threadly.BlockingTestRunnable;
+import org.threadly.test.concurrent.TestRunnable;
+import org.threadly.util.Clock;
+
+@SuppressWarnings("javadoc")
+public class UnfairExecutorTest extends SubmitterExecutorInterfaceTest {
+  @Override
+  protected SubmitterExecutorFactory getSubmitterExecutorFactory() {
+    return new UnfairExecutorFactory();
+  }
+  
+  @Test
+  @Override
+  public void executeInOrderTest() {
+    // ignored, this test makes no sense for this executor
+  }
+  
+  @Test
+  public void getMaxPoolSizeTest() {
+    UnfairExecutor ue = new UnfairExecutor(TEST_QTY);
+    assertEquals(TEST_QTY, ue.getMaxPoolSize());
+  }
+  
+  @Test
+  public void getCurrentPoolSizeTest() {
+    UnfairExecutor ue = new UnfairExecutor(TEST_QTY);
+    try {
+      assertEquals(0, ue.getCurrentPoolSize());
+      
+      TestRunnable tr = new TestRunnable();
+      ue.execute(tr);
+      tr.blockTillStarted();
+      assertEquals(1, ue.getCurrentPoolSize());
+      
+      ue.prestartAllThreads();
+      assertEquals(TEST_QTY, ue.getCurrentPoolSize());
+    } finally {
+      ue.shutdownNow();
+    }
+  }
+  
+  @Test
+  public void isShutdownTest() {
+    UnfairExecutor ue = new UnfairExecutor(1);
+    assertFalse(ue.isShutdown());
+
+    executeTestRunnables(ue, 0);
+    ue.shutdown();
+    assertTrue(ue.isShutdown());
+    
+    ue = new UnfairExecutor(1);
+    ue.shutdownNow();
+    assertTrue(ue.isShutdown());
+  }
+  
+  @Test
+  public void shutdownTest() {
+    UnfairExecutor ue = new UnfairExecutor(1);
+    /* adding a run time to have greater chances that runnable 
+     * will be waiting to execute after shutdown call.
+     */
+    TestRunnable lastRunnable = executeTestRunnables(ue, 5).get(TEST_QTY - 1);
+    
+    ue.shutdown();
+    
+    // runnable should finish
+    lastRunnable.blockTillFinished();
+  }
+  
+  @Test
+  public void shutdownNowTest() {
+    UnfairExecutor ue = new UnfairExecutor(1);
+    
+    // execute one runnable which will not complete
+    BlockingTestRunnable btr = new BlockingTestRunnable();
+    ue.execute(btr);
+
+    try {
+      List<TestRunnable> expectedRunnables = executeTestRunnables(ue, 0);
+      
+      btr.blockTillStarted();
+      
+      List<Runnable> canceledRunnables = ue.shutdownNow();
+      // unblock now so that others can run (if the unit test fails)
+      btr.unblock();
+      
+      assertNotNull(canceledRunnables);
+      assertTrue(canceledRunnables.containsAll(expectedRunnables));
+      assertTrue(expectedRunnables.containsAll(canceledRunnables));
+      
+      Iterator<TestRunnable> it = expectedRunnables.iterator();
+      while (it.hasNext()) {
+        assertEquals(0, it.next().getRunCount());
+      }
+    } finally {
+      btr.unblock();
+    }
+  }
+  
+  @Test
+  public void awaitTerminationTest() throws InterruptedException {
+    UnfairExecutor ue = new UnfairExecutor(1);
+    /* adding a run time to have greater chances that runnable 
+     * will be waiting to execute after shutdown call.
+     */
+    TestRunnable lastRunnable = executeTestRunnables(ue, 5).get(TEST_QTY - 1);
+    
+    ue.shutdown();
+    ue.awaitTermination();
+    
+    // runnable should already be done
+    assertTrue(lastRunnable.ranOnce());
+  }
+  
+  @Test
+  public void awaitTerminationWithTimeoutTest() throws InterruptedException {
+    UnfairExecutor ue = new UnfairExecutor(1);
+    /* adding a run time to have greater chances that runnable 
+     * will be waiting to execute after shutdown call.
+     */
+    TestRunnable lastRunnable = executeTestRunnables(ue, 5).get(TEST_QTY - 1);
+
+    ue.shutdown();
+    assertTrue(ue.awaitTermination(1000 * 10));
+    
+    // runnable should already be done
+    assertTrue(lastRunnable.ranOnce());
+  }
+  
+  @Test
+  public void awaitTerminationWithTimeoutExpireTest() throws InterruptedException {
+    UnfairExecutor ue = new UnfairExecutor(1);
+    executeTestRunnables(ue, 1000 * 10);
+    
+    long start = Clock.accurateForwardProgressingMillis();
+    ue.shutdown();
+    assertFalse(ue.awaitTermination(DELAY_TIME));
+
+    assertTrue(Clock.accurateForwardProgressingMillis() - start >= (DELAY_TIME - ALLOWED_VARIANCE));
+  }
+  
+  @Test (expected = RejectedExecutionException.class)
+  public void shutdownExecutionFail() {
+    UnfairExecutor ue = new UnfairExecutor(1);
+    ue.shutdown();
+    
+    ue.execute(new TestRunnable());
+  }
+  
+  @Test (expected = RejectedExecutionException.class)
+  public void shutdownNowExecutionFail() {
+    UnfairExecutor ue = new UnfairExecutor(1);
+    ue.shutdownNow();
+    
+    ue.execute(new TestRunnable());
+  }
+
+  private static class UnfairExecutorFactory implements SubmitterExecutorFactory {
+    private List<UnfairExecutor> executors = new ArrayList<UnfairExecutor>(1);
+    
+    @Override
+    public UnfairExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
+      UnfairExecutor result = new UnfairExecutor(poolSize);
+      executors.add(result);
+      
+      return result;
+    }
+
+    @Override
+    public void shutdown() {
+      for (UnfairExecutor ue : executors) {
+        ue.shutdownNow();
+      }
+    }
+  }
+}


### PR DESCRIPTION
This resolves #194 by providing an executor with superior performance, but reduced garuntees.

It attempts to hash out tasks to individual thread queues.  Using the time, and the runnables hash code to determine what two schedulers to check.  It then adds the task to the scheduler with the least queued on it (of the two).
The two scheduler comparision is because submitting the same task multime times while Clock's nano times is not updating, can result in a scheduler bias.  By comparing two schedulers that bias will at least be slightly distributed without incuring more checking burden.
As currently impelemted this provides around a 200% to 400% improvement compared to java.util.concurrent.ThreadPoolExecutor.

It seems that KeyDistrubtedExecutor may have a better improvement (being 400% to 600%), but it has several issues:
* The additional queue mechanism in KDE makes "shutdownNow" hard to implement.  Tasks in queue would need to finish, or we would need to really hack it apart.
* While it works, the code is somewhat awkward.  We end up using an "Integer" as our key, being the value of what thread index we have, and use PriorityScheduler to deal with the parking/unparking of threads.
* It makes it very difficult (not resonable without larger changes) to do balancing between queues...even though our balancing right now is basic, it's at least _something_.

Possible reasons KDE may be better: I _suspect_ that it's better due to use of LockSupport in PriorityScheduler for sleeping/waking, compare to Object.wait/notify in NoThreadScheduler's Blocking tick.  It may also be that the queuing inside KeyDistributedExecutor is a better fit (though I tried to replicate this queuing design and had little luck gaining the performance back).
If the reason is LockSupport, we could consider doing that in NTS.  The only reason I have not been using it is to mitigate the damage if some idiot calls tick from multiple threads.  Using LockSupport would make that an even more dangerous position (but no one technically should be doing it anyways).

@lwahlmeier give it a look.  Let me know your thoughts.  Biggest things I want feedback:
* Do you think scheduler balancing is reasonable?  Or is an AtomicInteger needed?
* Do you think it is worth the performance hit for the things I described above?
* There is a chunk of waste by reusing these classes...for example each STS has 6 queues (schedule + execute for all three priorities).  But we are only using one.  Does it make sense to redo this with a new executor type?
* Anything you see to possibly improve in general