### PR TITLE
PriorityScheduler: Fix shutdown and pool size decrease race condition

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.6.1
+version = 4.6.2
 org.gradle.daemon = false

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.threadly</groupId>
   <artifactId>threadly</artifactId>
-  <version>4.6.0</version>
+  <version>4.6.2</version>
   <packaging>jar</packaging>
 
   <name>Threadly</name>


### PR DESCRIPTION
This was a regresion from 4.4.0 when we changed how we poll tasks in `PriorityScheduler`.

A very small race condition existed that was thankfully reported to me.  In workerIdle we have two while loops, the inner loop is used as a minor optimization to avoid re-checking the pool logic that rarely changes.  We use this loop for the double check strategy when parking a thread, so that we can park more efficiently.  This introduced the following condition:

Worker thread A is done with a task, it has not queued yet, but already has seen the pool is still running
Thread B issues a shutdown, when it checks if there is a parked thread to wake up, it does NOT see thread A yet
Thread A finds no tasks, and then parks (possibly forever).

There were two possible solutions I saw to this problem:
1) We remove the inner loop optimization.  If we went to the top loop on every try, we would have seen the pool state transitioned before parking.  Or if we already parked then the shutdown would have been for sure able to unpark us.
2) We find another way to indicate when a worker thread needs to re-check the pool state.

In this commit I choose option 2, but it was not an easy decision.  While #1 makes things simpler, and #2 adds additional complexity, it was hard to give up any performance gains in favor of option #1 (even if they are super minor).

In this commit we actually do remove the pool state checking from the task polling loop.  Instead it is checked at the start of workerIdle, then never checked again.  This means that the only way for us to get a thread to exit the task polling loop is to give it a task.

When the pool state changes (ie shutdown or size decreased), we ensure that we are able to get the threads out of the polling loop by adding a task that will continue to keep adding itself until the state has been achieved (ie pool size has reached desired levels, or in the case of shutdown until all threads are shutdown).

I don't particularly like this complexity, as we have to be sure the task keeps re-adding itself (otherwise we can't be sure all threads have been removed from this loop).  But from a performance side, we have reduced the checking of this state which rarely changes even more than ever before (though you could argue that when these states do change it is now more expensive).

@lwahlmeier and @blendmaster I would like your opinion.  I don't take adding complexity in this area lightly, and I am sure this is easier for me to reason about since I originally wrote it.  For contrast if we were to take the simpler road we would remove this while loop:
https://github.com/threadly/threadly/blob/master/src/main/java/org/threadly/concurrent/PriorityScheduler.java#L729-L730

In which case this logic is what would end up being hit much more frequently:
https://github.com/threadly/threadly/blob/master/src/main/java/org/threadly/concurrent/PriorityScheduler.java#L718-L727