### PR TITLE
Allow interceptors to accept an lambda

### DIFF
--- a/src/main/java/org/threadly/concurrent/wrapper/interceptor/ExecutorTaskInterceptor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/interceptor/ExecutorTaskInterceptor.java
@@ -2,6 +2,7 @@ package org.threadly.concurrent.wrapper.interceptor;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 
 import org.threadly.concurrent.SubmitterExecutor;
 import org.threadly.concurrent.future.ListenableFuture;
@@ -10,10 +11,11 @@ import org.threadly.util.ArgumentVerifier;
 
 /**
  * <p>Class to wrap {@link Executor} pool so that tasks can be intercepted and either wrapped, or 
- * modified, before being submitted to the pool.  This abstract class needs to have 
- * {@link #wrapTask(Runnable)} overridden to provide the task which should be submitted to the 
- * {@link Executor}.  Please see the javadocs of {@link #wrapTask(Runnable)} for more details 
- * about ways a task can be modified or wrapped.</p>
+ * modified, before being submitted to the pool. This class can be passed a lamba in the 
+ * constructor, or you can extend this class and override the function {@link #wrapTask(Runnable)}
+ * to provide the task which should be submitted to the {@link Executor}.  Please see the javadocs
+ * of {@link #wrapTask(Runnable)} for more details about ways a task can be modified or wrapped.
+ * </p>
  * 
  * <p>Other variants of task wrappers: {@link SubmitterSchedulerTaskInterceptor}, 
  * {@link SchedulerServiceTaskInterceptor}, {@link PrioritySchedulerTaskInterceptor}.</p>
@@ -21,20 +23,41 @@ import org.threadly.util.ArgumentVerifier;
  * @author jent - Mike Jensen
  * @since 4.6.0
  */
-public abstract class ExecutorTaskInterceptor implements SubmitterExecutor {
+public class ExecutorTaskInterceptor implements SubmitterExecutor {
   protected final Executor parentExecutor;
+  protected final Function<Runnable, Runnable> taskManipulator;
   
+  /**
+   * When using this constructor, {@link #wrapTask(Runnable)} must be overridden to handle the 
+   * task manipulation before the task is submitted to the provided {@link Executor}.  Please see 
+   * the javadocs of {@link #wrapTask(Runnable)} for more details about ways a task can be 
+   * modified or wrapped.
+   * 
+   * @param parentExecutor An instance of {@link Executor} to wrap
+   */
   protected ExecutorTaskInterceptor(Executor parentExecutor) {
+    this(parentExecutor, null);
+  }
+  
+  /**
+   * Constructs a wrapper for {@link Executor} pool so that tasks can be intercepted and modified,
+   * before being submitted to the pool.
+   * 
+   * @param parentExecutor An instance of {@link Executor} to wrap
+   * @param taskManipulator A lambda to manipulate a {@link Runnable} that was submitted for execution
+   */
+  public ExecutorTaskInterceptor(Executor parentExecutor, Function<Runnable, Runnable> taskManipulator) {
     ArgumentVerifier.assertNotNull(parentExecutor, "parentExecutor");
     
+    this.taskManipulator = taskManipulator;
     this.parentExecutor = parentExecutor;
   }
   
   /**
    * Implementation to modify a provided task.  The provided runnable will be the one submitted to 
    * the Executor, unless a {@link Callable} was submitted, in which case a 
-   * {@link ListenableFutureTask} will be provided.  In the last condition the original callable 
-   * can be retrieved by invoking {@link ListenableFutureTask#getContainedCallable()}.  The returned 
+   * {@link ListenableFutureTask} will be provided. In the last condition the original callable 
+   * can be retrieved by invoking {@link ListenableFutureTask#getContainedCallable()}. The returned 
    * task can not be null, but could be either the original task, a modified task, a wrapper to the 
    * provided task, or if no action is desired 
    * {@link org.threadly.concurrent.DoNothingRunnable#instance()} may be provided.  However caution 
@@ -44,12 +67,12 @@ public abstract class ExecutorTaskInterceptor implements SubmitterExecutor {
    * execute/return the provided task, then you should be careful to ensure 
    * {@link ListenableFutureTask#cancel(boolean)} is invoked.
    * 
-   * Public visibility for javadoc visibility.   
-   * 
    * @param task A runnable that was submitted for execution
    * @return A non-null task that will be provided to the parent executor
    */
-  public abstract Runnable wrapTask(Runnable task);
+  public Runnable wrapTask(Runnable task) {
+    return this.taskManipulator.apply(task);
+  }
 
   @Override
   public void execute(Runnable task) {

--- a/src/main/java/org/threadly/concurrent/wrapper/interceptor/PrioritySchedulerTaskInterceptor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/interceptor/PrioritySchedulerTaskInterceptor.java
@@ -1,6 +1,7 @@
 package org.threadly.concurrent.wrapper.interceptor;
 
 import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
 
 import org.threadly.concurrent.PrioritySchedulerService;
 import org.threadly.concurrent.TaskPriority;
@@ -10,10 +11,12 @@ import org.threadly.util.ArgumentVerifier;
 
 /**
  * <p>Class to wrap {@link PrioritySchedulerService} pool so that tasks can be intercepted and either 
- * wrapped, or modified, before being submitted to the pool.  This abstract class needs to have 
- * {@link #wrapTask(Runnable, boolean)} overridden to provide the task which should be submitted to the 
- * {@link PrioritySchedulerService}.  Please see the javadocs of {@link #wrapTask(Runnable, boolean)} for 
- * more details about ways a task can be modified or wrapped.</p>
+ * wrapped, or modified, before being submitted to the pool.  This class can be passed a lambda to
+ * {@link #PrioritySchedulerTaskInterceptor(PrioritySchedulerService, BiFunction)}}, or 
+ * {@link #wrapTask(Runnable, boolean)} can be overridden to provide the task which should be submitted 
+ * to the {@link PrioritySchedulerService}.  Please see the javadocs of 
+ * {@link #wrapTask(Runnable, boolean)} for more details about ways a task can be modified or 
+ * wrapped.</p>
  * 
  * <p>Other variants of task wrappers: {@link ExecutorTaskInterceptor}, 
  * {@link SubmitterSchedulerTaskInterceptor}, {@link PrioritySchedulerTaskInterceptor}.</p>
@@ -21,12 +24,33 @@ import org.threadly.util.ArgumentVerifier;
  * @author jent - Mike Jensen
  * @since 4.6.0
  */
-public abstract class PrioritySchedulerTaskInterceptor extends SchedulerServiceTaskInterceptor 
-                                                       implements PrioritySchedulerService {
+public class PrioritySchedulerTaskInterceptor extends SchedulerServiceTaskInterceptor 
+                                              implements PrioritySchedulerService {
   protected final PrioritySchedulerService parentScheduler;
-  
+
+  /**
+   * When using this constructor, {@link #wrapTask(Runnable, boolean)} must be overridden to 
+   * handle the task manipulation before the task is submitted to the provided 
+   * {@link PrioritySchedulerService}.  Please see the javadocs of 
+   * {@link #wrapTask(Runnable, boolean)} for more details about ways a task can be modified or 
+   * wrapped.
+   * 
+   * @param parentExecutor An instance of {@link Executor} to wrap
+   */
   protected PrioritySchedulerTaskInterceptor(PrioritySchedulerService parentScheduler) {
-    super(parentScheduler);
+    this(parentScheduler, null);
+  }
+  
+  /**
+   * Constructs a wrapper for {@link PrioritySchedulerService} pool so that tasks can be intercepted 
+   * and modified, before being submitted to the pool.
+   * 
+   * @param parentScheduler An instance of {@link PrioritySchedulerService} to wrap
+   * @param taskManipulator A lambda to manipulate a {@link Runnable} that was submitted for execution
+   */
+  public PrioritySchedulerTaskInterceptor(PrioritySchedulerService parentScheduler,
+                                          BiFunction<Runnable, Boolean, Runnable> taskManipulator) {
+    super(parentScheduler, taskManipulator);
     
     this.parentScheduler = parentScheduler;
   }

--- a/src/main/java/org/threadly/concurrent/wrapper/interceptor/SchedulerServiceTaskInterceptor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/interceptor/SchedulerServiceTaskInterceptor.java
@@ -1,15 +1,17 @@
 package org.threadly.concurrent.wrapper.interceptor;
 
 import java.util.concurrent.Callable;
-
+import java.util.function.BiFunction;
 import org.threadly.concurrent.SchedulerService;
 
 /**
  * <p>Class to wrap {@link SchedulerService} pool so that tasks can be intercepted and either 
- * wrapped, or modified, before being submitted to the pool.  This abstract class needs to have 
- * {@link #wrapTask(Runnable, boolean)} overridden to provide the task which should be submitted to 
- * the {@link SchedulerService}.  Please see the javadocs of {@link #wrapTask(Runnable, boolean)} 
- * for more details about ways a task can be modified or wrapped.</p>
+ * wrapped, or modified, before being submitted to the pool.  This class can be passed a lambda to
+ * {@link #SchedulerServiceTaskInterceptor(SchedulerService, BiFunction)}}, or 
+ * {@link #wrapTask(Runnable, boolean)} can be overridden to provide the task which should be 
+ * submitted to the {@link SchedulerService}.  Please see the javadocs of 
+ * {@link #wrapTask(Runnable, boolean)} for more details about ways a task can be modified or 
+ * wrapped.</p>
  * 
  * <p>Other variants of task wrappers: {@link ExecutorTaskInterceptor}, 
  * {@link SubmitterSchedulerTaskInterceptor}, {@link PrioritySchedulerTaskInterceptor}.</p>
@@ -17,12 +19,32 @@ import org.threadly.concurrent.SchedulerService;
  * @author jent - Mike Jensen
  * @since 4.6.0
  */
-public abstract class SchedulerServiceTaskInterceptor extends SubmitterSchedulerTaskInterceptor 
-                                                      implements SchedulerService {
+public class SchedulerServiceTaskInterceptor extends SubmitterSchedulerTaskInterceptor 
+                                             implements SchedulerService {
   protected final SchedulerService parentScheduler;
-  
+
+  /**
+   * When using this constructor, {@link #wrapTask(Runnable, boolean)} must be overridden to 
+   * handle the task manipulation before the task is submitted to the provided 
+   * {@link SchedulerService}.  Please see the javadocs of {@link #wrapTask(Runnable, boolean)} 
+   * for more details about ways a task can be modified or wrapped.
+   * 
+   * @param parentExecutor An instance of {@link Executor} to wrap
+   */
   protected SchedulerServiceTaskInterceptor(SchedulerService parentScheduler) {
-    super(parentScheduler);
+    this(parentScheduler, null);
+  }
+  
+  /**
+   * Constructs a wrapper for {@link SchedulerService} pool so that tasks can be intercepted and modified,
+   * before being submitted to the pool.
+   * 
+   * @param parentScheduler An instance of {@link SchedulerService} to wrap
+   * @param taskManipulator A lambda to manipulate a {@link Runnable} that was submitted for execution
+   */
+  public SchedulerServiceTaskInterceptor(SchedulerService parentScheduler, 
+                                         BiFunction<Runnable, Boolean, Runnable> taskManipulator) {
+    super(parentScheduler, taskManipulator);
     
     this.parentScheduler = parentScheduler;
   }

--- a/src/test/java/org/threadly/concurrent/wrapper/interceptor/ExecutorTaskInterceptorTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/interceptor/ExecutorTaskInterceptorTest.java
@@ -62,6 +62,23 @@ public class ExecutorTaskInterceptorTest {
   }
   
   @Test
+  public void interceptSubmitRunnableLambdaTest() {
+    List<Runnable> interceptedTasks = new ArrayList<Runnable>(1);
+    
+    ExecutorTaskInterceptor executorInterceptorLambda = new ExecutorTaskInterceptor(scheduler, (r1) -> { 
+      interceptedTasks.add(r1);
+      
+      return DoNothingRunnable.instance();
+    });
+    executorInterceptorLambda.execute(tr);
+    
+    assertEquals(1, interceptedTasks.size());
+    assertTrue(tr == interceptedTasks.get(0));
+    assertEquals(1, scheduler.tick());  // replaced task should run
+    assertEquals(0, tr.getRunCount());  // should have been replaced and not run
+  }
+  
+  @Test
   public void interceptSubmitRunnableWithResultTest() throws InterruptedException, ExecutionException {
     Object result = new Object();
     ListenableFuture<?> f = executorInterceptor.submit(tr, result);

--- a/src/test/java/org/threadly/concurrent/wrapper/interceptor/PrioritySchedulerTaskInterceptorTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/interceptor/PrioritySchedulerTaskInterceptorTest.java
@@ -31,6 +31,12 @@ public class PrioritySchedulerTaskInterceptorTest extends SchedulerServiceTaskIn
     priorityInterceptor = new TestPrioritySchedulerInterceptor(scheduler);
     executorInterceptor = submitterSchedulerInterceptor = priorityInterceptor;
     testInterceptor = (TestInterceptor)executorInterceptor;
+    interceptedTasks = new ArrayList<Runnable>(1);
+    submitSchedulerTaskInterceptorLamba = new PrioritySchedulerTaskInterceptor(scheduler, (r1, b1) -> { 
+      interceptedTasks.add(r1);
+      
+      return DoNothingRunnable.instance();
+    });  
     tr = new TestRunnable();
   }
   

--- a/src/test/java/org/threadly/concurrent/wrapper/interceptor/SchedulerServiceTaskInterceptorTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/interceptor/SchedulerServiceTaskInterceptorTest.java
@@ -18,6 +18,12 @@ public class SchedulerServiceTaskInterceptorTest extends SubmitterSchedulerTaskI
     submitterSchedulerInterceptor = new TestSchedulerServiceInterceptor(scheduler);
     executorInterceptor = submitterSchedulerInterceptor;
     testInterceptor = (TestInterceptor)executorInterceptor;
+    interceptedTasks = new ArrayList<Runnable>(1);
+    submitSchedulerTaskInterceptorLamba = new SchedulerServiceTaskInterceptor(scheduler, (r1, b1) -> { 
+      interceptedTasks.add(r1);
+      
+      return DoNothingRunnable.instance();
+    });  
     tr = new TestRunnable();
   }
 

--- a/src/test/java/org/threadly/concurrent/wrapper/interceptor/SubmitterSchedulerTaskInterceptorTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/interceptor/SubmitterSchedulerTaskInterceptorTest.java
@@ -21,6 +21,8 @@ import org.threadly.test.concurrent.TestableScheduler;
 @SuppressWarnings("javadoc")
 public class SubmitterSchedulerTaskInterceptorTest extends ExecutorTaskInterceptorTest {
   protected SubmitterSchedulerTaskInterceptor submitterSchedulerInterceptor;
+  protected SubmitterSchedulerTaskInterceptor submitSchedulerTaskInterceptorLamba;
+  protected List<Runnable> interceptedTasks;
   
   @Before
   @Override
@@ -29,6 +31,12 @@ public class SubmitterSchedulerTaskInterceptorTest extends ExecutorTaskIntercept
     submitterSchedulerInterceptor = new TestSubmitterSchedulerInterceptor(scheduler);
     executorInterceptor = submitterSchedulerInterceptor;
     testInterceptor = (TestInterceptor)executorInterceptor;
+    interceptedTasks = new ArrayList<Runnable>(1);
+    submitSchedulerTaskInterceptorLamba = new SubmitterSchedulerTaskInterceptor(scheduler, (r1, b1) -> { 
+      interceptedTasks.add(r1);
+      
+      return DoNothingRunnable.instance();
+    });
     tr = new TestRunnable();
   }
   
@@ -45,6 +53,16 @@ public class SubmitterSchedulerTaskInterceptorTest extends ExecutorTaskIntercept
 
     assertEquals(1, testInterceptor.getInterceptedTasks().size());
     assertTrue(tr == testInterceptor.getInterceptedTasks().get(0));
+    assertEquals(1, scheduler.advance(DELAY_TIME));  // replaced task should run
+    assertEquals(0, tr.getRunCount());  // should have been replaced and not run
+  }
+  
+  @Test
+  public void interceptScheduleLambdaTest() {
+    submitSchedulerTaskInterceptorLamba.schedule(tr, DELAY_TIME);
+    
+    assertEquals(1, interceptedTasks.size());
+    assertTrue(tr == interceptedTasks.get(0));
     assertEquals(1, scheduler.advance(DELAY_TIME));  // replaced task should run
     assertEquals(0, tr.getRunCount());  // should have been replaced and not run
   }


### PR DESCRIPTION
Changed abstract interceptor class to allow submission of a lambda as task modifier.
Classes can still be extended and wrapTask overridden and to handle task interception.

Already did a PR with feedback on @jentfoo 's fork