### PR TITLE
Added 'KeyedRateLimiterExecutor'

### DIFF
--- a/src/main/java/org/threadly/concurrent/wrapper/KeyDistributedExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/KeyDistributedExecutor.java
@@ -138,6 +138,11 @@ public class KeyDistributedExecutor {
    * This constructor does not attempt to have an accurate queue size for the 
    * {@link #getTaskQueueSize(Object)} call (thus preferring high performance).
    * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
+   * 
    * @param expectedParallism level of expected quantity of threads adding tasks in parallel
    * @param executor A multi-threaded executor to distribute tasks to.  Ideally has as many 
    *                 possible threads as keys that will be used in parallel.
@@ -152,6 +157,11 @@ public class KeyDistributedExecutor {
    * This constructor allows you to specify if you want accurate queue sizes to be tracked for 
    * given thread keys.  There is a performance hit associated with this, so this should only be 
    * enabled if {@link #getTaskQueueSize(Object)} calls will be used.
+   * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * 
    * @param expectedParallism level of expected quantity of threads adding tasks in parallel
    * @param executor A multi-threaded executor to distribute tasks to.  Ideally has as many 
@@ -175,6 +185,11 @@ public class KeyDistributedExecutor {
    * This constructor does not attempt to have an accurate queue size for the 
    * {@link #getTaskQueueSize(Object)} call (thus preferring high performance).
    * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
+   * 
    * @param expectedParallism level of expected quantity of threads adding tasks in parallel
    * @param executor A multi-threaded executor to distribute tasks to.  Ideally has as many 
    *                 possible threads as keys that will be used in parallel.
@@ -196,6 +211,11 @@ public class KeyDistributedExecutor {
    * This also allows you to specify if you want accurate queue sizes to be tracked for given 
    * thread keys.  There is a performance hit associated with this, so this should only be enabled 
    * if {@link #getTaskQueueSize(Object)} calls will be used.
+   * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * 
    * @param expectedParallism level of expected quantity of threads adding tasks in parallel
    * @param executor A multi-threaded executor to distribute tasks to.  Ideally has as many 

--- a/src/main/java/org/threadly/concurrent/wrapper/KeyDistributedScheduler.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/KeyDistributedScheduler.java
@@ -109,6 +109,11 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * This constructor does not attempt to have an accurate queue size for the 
    * {@link #getTaskQueueSize(Object)} call (thus preferring high performance).
    * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
+   * 
    * @param expectedParallism level of expected quantity of threads adding tasks in parallel
    * @param scheduler A multi-threaded scheduler to distribute tasks to.  Ideally has as many 
    *                  possible threads as keys that will be used in parallel.
@@ -123,6 +128,11 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * This constructor allows you to specify if you want accurate queue sizes to be tracked for 
    * given thread keys.  There is a performance hit associated with this, so this should only be 
    * enabled if {@link #getTaskQueueSize(Object)} calls will be used.
+   * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * 
    * @param expectedParallism level of expected quantity of threads adding tasks in parallel
    * @param scheduler A multi-threaded scheduler to distribute tasks to.  Ideally has as many 
@@ -146,6 +156,11 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * This constructor does not attempt to have an accurate queue size for the 
    * {@link #getTaskQueueSize(Object)} call (thus preferring high performance).
    * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
+   * 
    * @param expectedParallism level of expected quantity of threads adding tasks in parallel
    * @param scheduler A multi-threaded scheduler to distribute tasks to.  Ideally has as many 
    *                  possible threads as keys that will be used in parallel.
@@ -168,6 +183,11 @@ public class KeyDistributedScheduler extends KeyDistributedExecutor {
    * This also allows you to specify if you want accurate queue sizes to be tracked for given 
    * thread keys.  There is a performance hit associated with this, so this should only be enabled 
    * if {@link #getTaskQueueSize(Object)} calls will be used.
+   * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * 
    * @param expectedParallism level of expected quantity of threads adding tasks in parallel
    * @param scheduler A multi-threaded scheduler to distribute tasks to.  Ideally has as many 

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/AbstractKeyedLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/AbstractKeyedLimiter.java
@@ -33,6 +33,7 @@ abstract class AbstractKeyedLimiter<T extends ExecutorLimiter> {
   protected static final float CONCURRENT_HASH_MAP_LOAD_FACTOR = 0.75f;  // 0.75 is ConcurrentHashMap default
   protected static final short CONCURRENT_HASH_MAP_MIN_SIZE = 8;
   protected static final short CONCURRENT_HASH_MAP_MAX_INITIAL_SIZE = 64;
+  protected static final short CONCURRENT_HASH_MAP_MIN_CONCURRENCY_LEVEL = 4;
   protected static final short CONCURRENT_HASH_MAP_MAX_CONCURRENCY_LEVEL = 32;
   
   protected final Executor executor;
@@ -59,8 +60,9 @@ abstract class AbstractKeyedLimiter<T extends ExecutorLimiter> {
     if (mapInitialSize < CONCURRENT_HASH_MAP_MIN_SIZE) {
       mapInitialSize = CONCURRENT_HASH_MAP_MIN_SIZE;
     }
-    int mapConcurrencyLevel = Math.min(sLock.getExpectedConcurrencyLevel() / 2, 
-                                       CONCURRENT_HASH_MAP_MAX_CONCURRENCY_LEVEL);
+    int mapConcurrencyLevel = Math.max(CONCURRENT_HASH_MAP_MIN_CONCURRENCY_LEVEL, 
+                                       Math.min(sLock.getExpectedConcurrencyLevel() / 2, 
+                                                CONCURRENT_HASH_MAP_MAX_CONCURRENCY_LEVEL));
     if (mapConcurrencyLevel < 1) {
       mapConcurrencyLevel = 1;
     }

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedExecutorLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedExecutorLimiter.java
@@ -49,16 +49,21 @@ public class KeyedExecutorLimiter extends AbstractKeyedLimiter<ExecutorLimiter> 
    * Construct a new {@link KeyedExecutorLimiter} providing the backing executor, the maximum 
    * concurrency per unique key, and how keyed limiter threads should be named.
    * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
+   * 
    * @param executor Executor to execute tasks on to
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
-   * @param expectedTaskAdditionParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
    */
   public KeyedExecutorLimiter(Executor executor, int maxConcurrency, 
                               String subPoolName, boolean addKeyToThreadName, 
-                              int expectedTaskAdditionParallism) {
-    super(executor, maxConcurrency, subPoolName, addKeyToThreadName, expectedTaskAdditionParallism);
+                              int expectedParallism) {
+    super(executor, maxConcurrency, subPoolName, addKeyToThreadName, expectedParallism);
   }
   
   @Override

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutor.java
@@ -1,0 +1,393 @@
+package org.threadly.concurrent.wrapper.limiter;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import org.threadly.concurrent.AbstractSubmitterExecutor;
+import org.threadly.concurrent.DoNothingRunnable;
+import org.threadly.concurrent.PrioritySchedulerService;
+import org.threadly.concurrent.RunnableCallableAdapter;
+import org.threadly.concurrent.SubmitterExecutor;
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.TaskPriority;
+import org.threadly.concurrent.future.ImmediateResultListenableFuture;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.ListenableFutureTask;
+import org.threadly.concurrent.future.ListenableRunnableFuture;
+import org.threadly.concurrent.lock.StripedLock;
+import org.threadly.concurrent.wrapper.PrioritySchedulerDefaultPriorityWrapper;
+import org.threadly.concurrent.wrapper.traceability.ThreadRenamingSubmitterSchedulerWrapper;
+import org.threadly.util.ArgumentVerifier;
+import org.threadly.util.StringUtils;
+
+/**
+ * <p>Similar to {@link RateLimiterExecutor} except that the rate is applied on a per key basis.  
+ * Tasks submitted to this executor must all be associated to a key.  The key is compared by using 
+ * {@link Object#hashCode()} and {@link Object#equals(Object)}.  For any given key, a rate is 
+ * applied, but keys which don't match with the above checks will not impact each other.</p>
+ * 
+ * <p>Because different keys don't interact, this is not capable of providing a global rate limit 
+ * (unless the key quantity is known and restricted).</p>
+ * 
+ * <p>This differs from {@link KeyedExecutorLimiter} in that while that limits concurrency, this 
+ * limits by rate (thus there may be periods where nothing is execution, or if executions are long 
+ * things may run concurrently).  Please see {@link RateLimiterExecutor} for more details about how 
+ * rate is limited.</p>
+ * 
+ * @author jent - Mike Jensen
+ * @since 4.7.0
+ */
+public class KeyedRateLimiterExecutor {
+  protected static final short DEFAULT_LOCK_PARALISM = 32;
+  protected static final float CONCURRENT_HASH_MAP_LOAD_FACTOR = 0.75f;  // 0.75 is ConcurrentHashMap default
+  protected static final short CONCURRENT_HASH_MAP_MIN_SIZE = 8;
+  protected static final short CONCURRENT_HASH_MAP_MAX_INITIAL_SIZE = 64;
+  protected static final short CONCURRENT_HASH_MAP_MIN_CONCURRENCY_LEVEL = 4;
+  protected static final short CONCURRENT_HASH_MAP_MAX_CONCURRENCY_LEVEL = 32;
+  
+  protected final SubmitterScheduler scheduler;
+  protected final SubmitterScheduler limiterCheckerScheduler;
+  protected final double permitsPerSecond;
+  protected final String subPoolName;
+  protected final boolean addKeyToThreadName;
+  protected final StripedLock sLock;
+  protected final ConcurrentHashMap<Object, RateLimiterExecutor> currentLimiters;
+  
+  /**
+   * Constructs a new key rate limiting executor.  Using sensible default options.
+   * 
+   * @param scheduler Scheduler to defer executions to
+   * @param permitsPerSecond how many permits should be allowed per second per key
+   */
+  public KeyedRateLimiterExecutor(SubmitterScheduler scheduler, double permitsPerSecond) {
+    this(scheduler, permitsPerSecond, "", false, DEFAULT_LOCK_PARALISM);
+  }
+  
+  /**
+   * Constructs a new key rate limiting executor.  Allowing the specification of thread naming 
+   * behavior.  Providing null or empty for the {@code subPoolName} and {@code false} for appending 
+   * the key to the thread name will result in no thread name adjustments occurring.
+   * 
+   * @param scheduler Scheduler to defer executions to
+   * @param permitsPerSecond how many permits should be allowed per second per key
+   * @param subPoolName Prefix to give threads while executing tasks submitted through this limiter
+   * @param addKeyToThreadName {@code true} to append the task's key to the thread name
+   */
+  public KeyedRateLimiterExecutor(SubmitterScheduler scheduler, double permitsPerSecond, 
+                                  String subPoolName, boolean addKeyToThreadName) {
+    this(scheduler, permitsPerSecond, subPoolName, addKeyToThreadName, DEFAULT_LOCK_PARALISM);
+  }
+  
+  /**
+   * Constructs a new key rate limiting executor.  This constructor allows you to set both the 
+   * thread naming behavior as well as the level of parallelism expected for task submission.
+   * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
+   * 
+   * @param scheduler Scheduler to defer executions to
+   * @param permitsPerSecond how many permits should be allowed per second per key
+   * @param subPoolName Prefix to give threads while executing tasks submitted through this limiter
+   * @param addKeyToThreadName {@code true} to append the task's key to the thread name
+   * @param expectedParallism Expected level of task submission parallelism
+   */
+  public KeyedRateLimiterExecutor(SubmitterScheduler scheduler, double permitsPerSecond, 
+                                  String subPoolName, boolean addKeyToThreadName, 
+                                  int expectedParallism) {
+    ArgumentVerifier.assertNotNull(scheduler, "scheduler");
+    ArgumentVerifier.assertGreaterThanZero(permitsPerSecond, "permitsPerSecond");
+
+    this.scheduler = scheduler;
+    if (scheduler instanceof PrioritySchedulerService) {
+      limiterCheckerScheduler = 
+          new PrioritySchedulerDefaultPriorityWrapper((PrioritySchedulerService)scheduler, 
+                                                      TaskPriority.Low);
+    } else {
+      limiterCheckerScheduler = scheduler;
+    }
+    this.permitsPerSecond = permitsPerSecond;
+    // make sure this is non-null so that it 'null' wont appear
+    this.subPoolName = StringUtils.nullToEmpty(subPoolName);
+    this.addKeyToThreadName = addKeyToThreadName;
+    this.sLock = new StripedLock(expectedParallism);
+    int mapInitialSize = Math.min(sLock.getExpectedConcurrencyLevel(), 
+                                  CONCURRENT_HASH_MAP_MAX_INITIAL_SIZE);
+    if (mapInitialSize < CONCURRENT_HASH_MAP_MIN_SIZE) {
+      mapInitialSize = CONCURRENT_HASH_MAP_MIN_SIZE;
+    }
+    int mapConcurrencyLevel = Math.max(CONCURRENT_HASH_MAP_MIN_CONCURRENCY_LEVEL, 
+                                       Math.min(sLock.getExpectedConcurrencyLevel() / 2, 
+                                                CONCURRENT_HASH_MAP_MAX_CONCURRENCY_LEVEL));
+    if (mapConcurrencyLevel < 1) {
+      mapConcurrencyLevel = 1;
+    }
+    this.currentLimiters = new ConcurrentHashMap<Object, RateLimiterExecutor>(mapInitialSize,  
+                                                                              CONCURRENT_HASH_MAP_LOAD_FACTOR, 
+                                                                              mapConcurrencyLevel);
+  }
+  
+  /**
+   * This call will check how far out we have already scheduled tasks to be run.  Because it is 
+   * the applications responsibility to not provide tasks too fast for the limiter to run them, 
+   * this can give an idea of how backed up tasks provided through this limiter actually are.
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @return minimum delay in milliseconds for the next task to be provided
+   */
+  public int getMinimumDelay(Object taskKey) {
+    RateLimiterExecutor rle = currentLimiters.get(taskKey);
+    if (rle == null) {
+      return 0;
+    } else {
+      return rle.getMinimumDelay();
+    }
+  }
+  
+  /**
+   * In order to help assist with avoiding to schedule too much on the scheduler at any given 
+   * time, this call returns a future that will block until the delay for the next task falls 
+   * below the maximum delay provided into this call.  If you want to ensure that the next task 
+   * will execute immediately, you should provide a zero to this function.  If more tasks are 
+   * added to the limiter after this call, it will NOT impact when this future will unblock.  So 
+   * this future is assuming that nothing else is added to the limiter after requested.
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param maximumDelay maximum delay in milliseconds until returned Future should unblock
+   * @return Future that will unblock {@code get()} calls once delay has been reduced below the provided maximum
+   */
+  public ListenableFuture<?> getFutureTillDelay(Object taskKey, long maximumDelay) {
+    int currentMinimumDelay = getMinimumDelay(taskKey);
+    if (currentMinimumDelay == 0) {
+      return ImmediateResultListenableFuture.NULL_RESULT;
+    } else {
+      ListenableFutureTask<?> lft = new ListenableFutureTask<Void>(false, DoNothingRunnable.instance());
+      
+      long futureDelay;
+      if (maximumDelay > 0 && currentMinimumDelay > maximumDelay) {
+        futureDelay = maximumDelay;
+      } else {
+        futureDelay = currentMinimumDelay;
+      }
+      
+      scheduler.schedule(lft, futureDelay);
+      
+      return lft;
+    }
+  }
+  
+  /**
+   * Provide a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#execute(Runnable)}
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Task to be executed
+   */
+  public void execute(Object taskKey, Runnable task) {
+    execute(1, taskKey, task);
+  }
+  
+  /**
+   * Provide a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#execute(Runnable)}
+   * 
+   * @param permits resource permits for this task
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Task to be executed
+   */
+  public void execute(double permits, Object taskKey, Runnable task) {
+    ArgumentVerifier.assertNotNegative(permits, "permits");
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    ArgumentVerifier.assertNotNull(task, "task");
+    
+    doExecute(permits, taskKey, task);
+  }
+  
+  /**
+   * Submit a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Runnable)}
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Task to be executed
+   * @return Future to represent when the execution has occurred
+   */
+  public ListenableFuture<?> submit(Object taskKey, Runnable task) {
+    return submit(1, taskKey, task);
+  }
+  
+  /**
+   * Submit a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Runnable)}
+   * 
+   * @param permits resource permits for this task
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Task to be executed
+   * @return Future to represent when the execution has occurred
+   */
+  public ListenableFuture<?> submit(double permits, Object taskKey, Runnable task) {
+    return submit(permits, taskKey, task, null);
+  }
+  
+  /**
+   * Submit a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Runnable, Object)}
+   * 
+   * @param <T> type of result returned from the future
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Runnable to be executed
+   * @param result Result to be returned from future when task completes
+   * @return Future to represent when the execution has occurred and provide the given result
+   */
+  public <T> ListenableFuture<T> submit(Object taskKey, Runnable task, T result) {
+    return submit(1, taskKey, task, result);
+  }
+  
+  /**
+   * Submit a task to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Runnable, Object)}
+   * 
+   * @param <T> type of result returned from the future
+   * @param permits resource permits for this task
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Runnable to be executed
+   * @param result Result to be returned from future when task completes
+   * @return Future to represent when the execution has occurred and provide the given result
+   */
+  public <T> ListenableFuture<T> submit(double permits, Object taskKey, Runnable task, T result) {
+    return submit(permits, taskKey, new RunnableCallableAdapter<T>(task, result));
+  }
+  
+  /**
+   * Submit a callable to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Callable)}
+   * 
+   * @param <T> type of result returned from the future
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Callable to be executed
+   * @return Future to represent when the execution has occurred and provide the result from the callable
+   */
+  public <T> ListenableFuture<T> submit(Object taskKey, Callable<T> task) {
+    return submit(1, taskKey, task);
+  }
+  
+  /**
+   * Submit a callable to be run with a given thread key.
+   * 
+   * See also: {@link SubmitterExecutor#submit(Callable)}
+   * 
+   * @param <T> type of result returned from the future
+   * @param permits resource permits for this task
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @param task Callable to be executed
+   * @return Future to represent when the execution has occurred and provide the result from the callable
+   */
+  public <T> ListenableFuture<T> submit(double permits, Object taskKey, Callable<T> task) {
+    ArgumentVerifier.assertNotNegative(permits, "permits");
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    ArgumentVerifier.assertNotNull(task, "task");
+    
+    ListenableRunnableFuture<T> rf = new ListenableFutureTask<T>(false, task);
+    
+    doExecute(permits, taskKey, rf);
+    
+    return rf;
+  }
+  
+  protected void doExecute(double permits, Object taskKey, Runnable task) {
+    RateLimiterExecutor rle;
+    Object lock = sLock.getLock(taskKey);
+    synchronized (lock) {
+      rle = currentLimiters.get(taskKey);
+      if (rle == null) {
+        String keyedPoolName = subPoolName + (addKeyToThreadName ? taskKey.toString() : "");
+        SubmitterScheduler threadNamedScheduler;
+        if (StringUtils.isNullOrEmpty(keyedPoolName)) {
+          threadNamedScheduler = scheduler;
+        } else {
+          threadNamedScheduler = 
+              new ThreadRenamingSubmitterSchedulerWrapper(scheduler, keyedPoolName, false);
+        }
+        rle = new RateLimiterExecutor(threadNamedScheduler, permitsPerSecond);
+
+        currentLimiters.put(taskKey, rle);
+        // schedule task to check for removal later, should only be one task per limiter
+        limiterCheckerScheduler.schedule(new LimiterChecker(taskKey, rle), 1000);
+      }
+      
+      // must execute while in lock to prevent early removal
+      rle.execute(permits, task);
+    }
+  }
+
+  /**
+   * Returns an executor implementation where all tasks submitted on this executor will run on the 
+   * provided key.  Tasks executed on the returned scheduler will be limited by the key 
+   * submitted on this instance equally with ones provided through the returned instance.
+   * 
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @return Executor which will only execute with reference to the provided key
+   */
+  public SubmitterExecutor getSubmitterExecutorForKey(Object taskKey) {
+    return getSubmitterExecutorForKey(1, taskKey);
+  }
+
+  /**
+   * Returns an executor implementation where all tasks submitted on this executor will run on the 
+   * provided key.  Tasks executed on the returned scheduler will be limited by the key 
+   * submitted on this instance equally with ones provided through the returned instance.
+   * 
+   * @param permits resource permits for all tasks submitted on the returned executor
+   * @param taskKey object key where {@code equals()} will be used to determine execution thread
+   * @return Executor which will only execute with reference to the provided key
+   */
+  public SubmitterExecutor getSubmitterExecutorForKey(final double permits, final Object taskKey) {
+    ArgumentVerifier.assertNotNull(taskKey, "taskKey");
+    
+    return new AbstractSubmitterExecutor() {
+      @Override
+      protected void doExecute(Runnable task) {
+        KeyedRateLimiterExecutor.this.doExecute(permits, taskKey, task);
+      }
+    };
+  }
+  
+  /**
+   * <p>Task which checks to see if a limiter has become idle.  If so it removes the limiter in a 
+   * thread safe way.  If the limiter is still active then it will schedule itself to check again 
+   * later.</p>
+   * 
+   * @author jent - Mike Jensen
+   * @since 4.7.0
+   */
+  protected class LimiterChecker implements Runnable {
+    public final Object taskKey;
+    public final RateLimiterExecutor limiter;
+    
+    public LimiterChecker(Object taskKey, RateLimiterExecutor limiter) {
+      this.taskKey = taskKey;
+      this.limiter = limiter;
+    }
+
+    @Override
+    public void run() {
+      int minimumDelay;
+      synchronized (sLock.getLock(taskKey)) {
+        minimumDelay = limiter.getMinimumDelay();
+        if (minimumDelay == 0) {
+          currentLimiters.remove(taskKey);
+          return;
+        }
+      }
+      
+      // did not return above, so reschedule our check
+      limiterCheckerScheduler.schedule(this, minimumDelay + 100); // add a little to encourage object reuse
+    }
+  }
+}

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedSchedulerServiceLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedSchedulerServiceLimiter.java
@@ -52,16 +52,21 @@ public class KeyedSchedulerServiceLimiter extends AbstractKeyedSchedulerLimiter<
    * Construct a new {@link KeyedSchedulerServiceLimiter} providing the backing scheduler, the 
    * maximum concurrency per unique key, and how keyed limiter threads should be named.
    * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
+   * 
    * @param scheduler Scheduler to execute and schedule tasks on
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
-   * @param expectedTaskAdditionParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
    */
   public KeyedSchedulerServiceLimiter(SchedulerService scheduler, int maxConcurrency, 
                                       String subPoolName, boolean addKeyToThreadName, 
-                                      int expectedTaskAdditionParallism) {
-    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, expectedTaskAdditionParallism);
+                                      int expectedParallism) {
+    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, expectedParallism);
     
     this.scheduler = scheduler;
   }

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedSubmitterSchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedSubmitterSchedulerLimiter.java
@@ -48,16 +48,21 @@ public class KeyedSubmitterSchedulerLimiter extends AbstractKeyedSchedulerLimite
    * Construct a new {@link KeyedSubmitterSchedulerLimiter} providing the backing scheduler, the 
    * maximum concurrency per unique key, and how keyed limiter threads should be named.
    * 
+   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
+   * given period of time.  Depending on task execution duration, and quantity of threads executing 
+   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
+   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
+   * 
    * @param scheduler Scheduler to execute and schedule tasks on
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
-   * @param expectedTaskAdditionParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
    */
   public KeyedSubmitterSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
                                         String subPoolName, boolean addKeyToThreadName, 
-                                        int expectedTaskAdditionParallism) {
-    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, expectedTaskAdditionParallism);
+                                        int expectedParallism) {
+    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, expectedParallism);
   }
   
   @Override

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/RateLimiterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/RateLimiterExecutor.java
@@ -79,9 +79,11 @@ public class RateLimiterExecutor extends AbstractSubmitterExecutor {
    * @return minimum delay in milliseconds for the next task to be provided
    */
   public int getMinimumDelay() {
+    double accurateDelayMillis;
     synchronized (permitLock) {
-      return (int)Math.max(0, lastScheduleTime - Clock.lastKnownForwardProgressingMillis());
+      accurateDelayMillis = lastScheduleTime - Clock.lastKnownForwardProgressingMillis();
     }
+    return (int)Math.max(0, Math.ceil(accurateDelayMillis));
   }
   
   /**

--- a/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutorTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutorTest.java
@@ -1,0 +1,227 @@
+package org.threadly.concurrent.wrapper.limiter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.threadly.TestConstants.SLOW_MACHINE;
+import static org.threadly.TestConstants.TEST_PROFILE;
+import static org.threadly.TestConstants.TEST_QTY;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.TestConstants.TestLoad;
+import org.threadly.concurrent.DoNothingRunnable;
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.StrictPriorityScheduler;
+import org.threadly.concurrent.SubmitterExecutor;
+import org.threadly.concurrent.SubmitterExecutorInterfaceTest;
+import org.threadly.concurrent.TestCallable;
+import org.threadly.concurrent.PrioritySchedulerTest.PrioritySchedulerFactory;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.test.concurrent.TestUtils;
+import org.threadly.test.concurrent.TestableScheduler;
+import org.threadly.util.Clock;
+
+@SuppressWarnings("javadoc")
+public class KeyedRateLimiterExecutorTest extends SubmitterExecutorInterfaceTest {
+  private TestableScheduler scheduler;
+  private KeyedRateLimiterExecutor limiter;
+  
+  @Before
+  public void setup() {
+    scheduler = new TestableScheduler();
+    limiter = new KeyedRateLimiterExecutor(scheduler, 1);
+  }
+
+  @Override
+  protected SubmitterExecutorFactory getSubmitterExecutorFactory() {
+    return new KeyedRateLimiterFactory();
+  }
+  
+  @SuppressWarnings("unused")
+  @Test
+  public void constructorFail() {
+    try {
+      new KeyedRateLimiterExecutor(null, 10);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      new KeyedRateLimiterExecutor(scheduler, 0);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void getCurrentMinimumDelayTest() {
+    Object key = new Object();
+    assertEquals(0, limiter.getMinimumDelay(key));
+    
+    limiter.execute(10, key, DoNothingRunnable.instance());
+    int delay = limiter.getMinimumDelay(key);
+    assertEquals(10000, delay, 1000);
+    
+    limiter.execute(10, key, DoNothingRunnable.instance());
+    delay = limiter.getMinimumDelay(key);
+    assertEquals(20000, delay, 1000);
+  }
+  
+  @Test
+  public void getFutureTillDelayTest() {
+    Object key = new Object();
+    // verify that an empty limiter returns a finished future
+    ListenableFuture<?> f = limiter.getFutureTillDelay(key, 0);
+    assertTrue(f.isDone());
+    
+    // verify it works if the limiter has waiting tasks
+    limiter.execute(key, DoNothingRunnable.instance());
+    f = limiter.getFutureTillDelay(key, 0);
+    assertFalse(f.isDone());
+    
+    scheduler.advance(1000);
+    assertTrue(f.isDone());
+  }
+  
+  @Test
+  public void limitTest() throws InterruptedException, ExecutionException {
+    Object key = new Object();
+    int rateLimit = 100;
+    final AtomicInteger ranPermits = new AtomicInteger();
+    PriorityScheduler pse = new StrictPriorityScheduler(32);
+    try {
+      KeyedRateLimiterExecutor krls = new KeyedRateLimiterExecutor(pse, rateLimit);
+      ListenableFuture<?> lastFuture = null;
+      double startTime = Clock.accurateForwardProgressingMillis();
+      boolean flip = true;
+      for (int i = 0; i < TEST_QTY * 2; i++) {
+        final int permit = 5;
+        if (flip) {
+          lastFuture = krls.submit(permit, key, new Runnable() {
+            @Override
+            public void run() {
+              ranPermits.addAndGet(permit);
+            }
+          });
+          flip = false;
+        } else {
+          lastFuture = krls.submit(permit, key, new Callable<Void>() {
+            @Override
+            public Void call() {
+              ranPermits.addAndGet(permit);
+              return null;
+            }
+          });
+          flip = true;
+        }
+      }
+      lastFuture.get();
+      long endTime = Clock.accurateForwardProgressingMillis();
+      double actualLimit = ranPermits.get() / ((endTime - startTime) / 1000);
+      
+      assertEquals(rateLimit, actualLimit, SLOW_MACHINE ? 75 : 50);
+    } finally {
+      pse.shutdownNow();
+    }
+  }
+  
+  @Test
+  public void executeWithPermitsFail() {
+    try {
+      limiter.execute(-1, new Object(), DoNothingRunnable.instance());
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      limiter.execute(1, new Object(), null);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void submitRunnableWithPermitsFail() {
+    try {
+      limiter.submit(-1, new Object(), DoNothingRunnable.instance());
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      limiter.submit(1, new Object(), (Runnable)null);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void submitCallableWithPermitsFail() {
+    try {
+      limiter.submit(-1, new Object(), new TestCallable());
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      limiter.submit(1, new Object(), (Callable<?>)null);
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void submitWithNoKeyFail() {
+    try {
+      limiter.submit(1, null, DoNothingRunnable.instance());
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      limiter.submit(1, null, new TestCallable());
+      fail("Exception should have thrown");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void verifyCleanupTaskTest() {
+    Object key = new Object();
+    limiter.execute(.1, key, DoNothingRunnable.instance());
+    assertEquals(2, scheduler.advance(1000));
+    assertFalse(limiter.currentLimiters.isEmpty()); // should have item for 100 millis
+    TestUtils.sleep(100);
+    TestUtils.blockTillClockAdvances();
+    assertEquals(1, scheduler.advance(1000));
+    assertTrue(limiter.currentLimiters.isEmpty());
+  }
+  
+  private static class KeyedRateLimiterFactory implements SubmitterExecutorFactory {
+    private final PrioritySchedulerFactory schedulerFactory = new PrioritySchedulerFactory();
+    private final int rateLimit = TEST_PROFILE == TestLoad.Stress ? 50 : 1000; 
+
+    @Override
+    public SubmitterExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
+      return new KeyedRateLimiterExecutor(schedulerFactory.makeSchedulerService(poolSize, 
+                                                                           prestartIfAvailable), 
+                                          rateLimit).getSubmitterExecutorForKey(new Object());
+    }
+
+    @Override
+    public void shutdown() {
+      schedulerFactory.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
This new executor is similar to `KeyedExecutorLimiter` in that it limits based off a key.  But it applies the principles of rate limiting from `RateLimiterExecutor`.
Allowing a task submission key to indicate what rate limit should be applied to a given task.

The biggest difference implementation wise between this and `KeyedExecutorLimiter` (or more specifically `AbstractKeyedLimiter`) is in how we check if the limiter has become idle.  In `AbstractKeyedLimiter` we can look for how many tasks are running (since it's limiting concurrency).  Here instead we schedule a task out after construction.  It will run regularly and check if the limiter is idle, if so it will remove it.  If not it will go ahead and reschedule itself to check later.  As far as if it's better or worse, it depends on how many keys there are.  For few but heavily used keys this design will be better (reduced overhead for individual task execution).

I also went through and described in the javadocs more about what "expectedParallelism" actually means.

@lwahlmeier if you have the time take a look and let me know if you see any issues.  I may merge this tomorrow though.