### PR TITLE
Adds an additional option to optimize the listener executor on a per-listener basis

### DIFF
--- a/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
@@ -128,7 +128,7 @@ public abstract class AbstractPriorityScheduler extends AbstractSubmitterSchedul
       priority = defaultPriority;
     }
 
-    ListenableRunnableFuture<T> rf = new ListenableFutureTask<>(false, task);
+    ListenableRunnableFuture<T> rf = new ListenableFutureTask<>(false, task, this);
     doSchedule(rf, delayInMs, priority);
     
     return rf;

--- a/src/main/java/org/threadly/concurrent/AbstractSubmitterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/AbstractSubmitterExecutor.java
@@ -45,7 +45,7 @@ public abstract class AbstractSubmitterExecutor implements SubmitterExecutor {
   public <T> ListenableFuture<T> submit(Callable<T> task) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, this);
     
     doExecute(lft);
     

--- a/src/main/java/org/threadly/concurrent/AbstractSubmitterScheduler.java
+++ b/src/main/java/org/threadly/concurrent/AbstractSubmitterScheduler.java
@@ -52,7 +52,7 @@ public abstract class AbstractSubmitterScheduler extends AbstractSubmitterExecut
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(delayInMs, "delayInMs");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, this);
 
     doSchedule(lft, delayInMs);
     

--- a/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
@@ -21,7 +21,7 @@ abstract class AbstractImmediateListenableFuture<T> extends AbstractNoncancelabl
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor) {
+  public void addListener(Runnable listener, Executor executor, boolean optimizeExecution) {
     if (executor != null) {
       executor.execute(listener);
     } else {

--- a/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
@@ -21,8 +21,10 @@ abstract class AbstractImmediateListenableFuture<T> extends AbstractNoncancelabl
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor, boolean optimizeExecution) {
-    if (executor != null) {
+  public void addListener(Runnable listener, Executor executor, 
+                          ListenerOptimizationStrategy optimize) {
+    if (executor != null && 
+        optimize != ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
       executor.execute(listener);
     } else {
       listener.run();

--- a/src/main/java/org/threadly/concurrent/future/ExecuteOnGetFutureTask.java
+++ b/src/main/java/org/threadly/concurrent/future/ExecuteOnGetFutureTask.java
@@ -33,7 +33,7 @@ public class ExecuteOnGetFutureTask<T> extends ListenableFutureTask<T> {
    * @param task runnable to be run
    */
   public ExecuteOnGetFutureTask(Runnable task) {
-    super(false, task, null);
+    super(false, task);
   }
   
   /**

--- a/src/main/java/org/threadly/concurrent/future/FutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureUtils.java
@@ -1078,7 +1078,7 @@ public class FutureUtils {
    */
   protected static <ST, RT> ListenableFuture<RT> transform(ListenableFuture<ST> sourceFuture, 
                                                            Function<? super ST, ? extends RT> transformer, 
-                                                           Executor executor) {
+                                                           Executor executor, boolean optimizeExecution) {
     if (executor == null & sourceFuture.isDone() && ! sourceFuture.isCancelled()) {
       // optimized path for already complete futures which we can now process in thread
       try {
@@ -1110,7 +1110,7 @@ public class FutureUtils {
             slf.setFailure(t);
           }
         }
-      }, executor);
+      }, executor, optimizeExecution);
       return slf;
     }
   }
@@ -1131,7 +1131,7 @@ public class FutureUtils {
    */
   protected static <ST, RT> ListenableFuture<RT> flatTransform(ListenableFuture<ST> sourceFuture, 
                                                                Function<? super ST, ListenableFuture<RT>> transformer, 
-                                                               Executor executor) {
+                                                               Executor executor, boolean optimizeExecution) {
     if (executor == null & sourceFuture.isDone() && ! sourceFuture.isCancelled()) {
       // optimized path for already complete futures which we can now process in thread
       try {
@@ -1167,7 +1167,7 @@ public class FutureUtils {
             slf.setFailure(t);
           }
         }
-      }, executor);
+      }, executor, optimizeExecution);
       return slf;
     }
   }

--- a/src/main/java/org/threadly/concurrent/future/FutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureUtils.java
@@ -1168,6 +1168,7 @@ public class FutureUtils {
                 slf.setResult(result);
               }
             });
+            slf.setRunningThread(null); // may be processing async now
           } catch (Throwable t) {
             slf.setFailure(t);
           }

--- a/src/main/java/org/threadly/concurrent/future/ImmediateFailureListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateFailureListenableFuture.java
@@ -36,8 +36,10 @@ public class ImmediateFailureListenableFuture<T> extends AbstractImmediateListen
   }
 
   @Override
-  public void addCallback(FutureCallback<? super T> callback, Executor executor) {
-    if (executor != null) {
+  public void addCallback(FutureCallback<? super T> callback, Executor executor, 
+                          ListenerOptimizationStrategy optimize) {
+    if (executor != null && 
+        optimize != ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
       executor.execute(new CallbackInvokingTask(callback));
     } else {
       callback.handleFailure(failure);

--- a/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
@@ -57,8 +57,9 @@ public class ImmediateResultListenableFuture<T> extends AbstractImmediateListena
 
   @Override
   public void addCallback(FutureCallback<? super T> callback, Executor executor, 
-                          boolean optimizeExecution) {
-    if (executor != null) {
+                          ListenerOptimizationStrategy optimize) {
+    if (executor != null && 
+        optimize != ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
       executor.execute(new CallbackInvokingTask(callback));
     } else {
       callback.handleResult(result);

--- a/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
@@ -56,7 +56,8 @@ public class ImmediateResultListenableFuture<T> extends AbstractImmediateListena
   }
 
   @Override
-  public void addCallback(FutureCallback<? super T> callback, Executor executor) {
+  public void addCallback(FutureCallback<? super T> callback, Executor executor, 
+                          boolean optimizeExecution) {
     if (executor != null) {
       executor.execute(new CallbackInvokingTask(callback));
     } else {

--- a/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
+++ b/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
@@ -66,12 +66,14 @@ public class ScheduledFutureDelegate<T> implements ListenableScheduledFuture<T> 
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor, boolean optimizeExecution) {
+  public void addListener(Runnable listener, Executor executor, 
+                          ListenerOptimizationStrategy optimizeExecution) {
     futureImp.addListener(listener, executor, optimizeExecution);
   }
 
   @Override
-  public void addCallback(FutureCallback<? super T> callback, Executor executor, boolean optimizeExecution) {
+  public void addCallback(FutureCallback<? super T> callback, Executor executor, 
+                          ListenerOptimizationStrategy optimizeExecution) {
     futureImp.addCallback(callback, executor, optimizeExecution);
   }
 }

--- a/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
+++ b/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
@@ -66,22 +66,12 @@ public class ScheduledFutureDelegate<T> implements ListenableScheduledFuture<T> 
   }
 
   @Override
-  public void addListener(Runnable listener) {
-    futureImp.addListener(listener);
+  public void addListener(Runnable listener, Executor executor, boolean optimizeExecution) {
+    futureImp.addListener(listener, executor, optimizeExecution);
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor) {
-    futureImp.addListener(listener, executor);
-  }
-
-  @Override
-  public void addCallback(FutureCallback<? super T> callback) {
-    futureImp.addCallback(callback);
-  }
-
-  @Override
-  public void addCallback(FutureCallback<? super T> callback, Executor executor) {
-    futureImp.addCallback(callback, executor);
+  public void addCallback(FutureCallback<? super T> callback, Executor executor, boolean optimizeExecution) {
+    futureImp.addCallback(callback, executor, optimizeExecution);
   }
 }

--- a/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
@@ -67,12 +67,7 @@ public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureC
   }
 
   @Override
-  public void addListener(Runnable listener) {
-    listenerHelper.addListener(listener);
-  }
-
-  @Override
-  public void addListener(Runnable listener, Executor executor) {
+  public void addListener(Runnable listener, Executor executor, boolean optimizeExecution) {
     listenerHelper.addListener(listener, executor);
   }
   

--- a/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -307,8 +308,9 @@ abstract class AbstractExecutorServiceWrapper implements ScheduledExecutorServic
     private final SchedulerService scheduler;
 
     public CancelRemovingListenableFutureTask(SchedulerService scheduler, 
-                                              boolean recurring, Runnable task) {
-      super(recurring, task);
+                                              boolean recurring, Runnable task, 
+                                              Executor executingExecutor) {
+      super(recurring, task, executingExecutor);
       
       this.scheduler = scheduler;
     }

--- a/src/main/java/org/threadly/concurrent/wrapper/compatibility/PrioritySchedulerServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/compatibility/PrioritySchedulerServiceWrapper.java
@@ -87,7 +87,7 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
 
   @Override
   protected ListenableScheduledFuture<?> schedule(Runnable task, long delayInMillis) {
-    ListenableRunnableFuture<Void> taskFuture = new ListenableFutureTask<>(false, task);
+    ListenableRunnableFuture<Void> taskFuture = new ListenableFutureTask<>(false, task, pScheduler);
     Delayed d = ThreadlyInternalAccessor.doScheduleAndGetDelayed(pScheduler, taskFuture, 
                                                                  taskPriority, delayInMillis);
     
@@ -96,7 +96,7 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
 
   @Override
   protected <V> ListenableScheduledFuture<V> schedule(Callable<V> callable, long delayInMillis) {
-    ListenableRunnableFuture<V> taskFuture = new ListenableFutureTask<>(false, callable);
+    ListenableRunnableFuture<V> taskFuture = new ListenableFutureTask<>(false, callable, pScheduler);
     Delayed d = ThreadlyInternalAccessor.doScheduleAndGetDelayed(pScheduler, taskFuture, 
                                                                  taskPriority, delayInMillis);
     
@@ -109,7 +109,8 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     // wrap the task to ensure the correct behavior on exceptions
     task = new ThrowableHandlingRecurringRunnable(scheduler, task);
     
-    ListenableRunnableFuture<Void> lft = new CancelRemovingListenableFutureTask<>(scheduler, true, task);
+    ListenableRunnableFuture<Void> lft = 
+        new CancelRemovingListenableFutureTask<>(scheduler, true, task, pScheduler);
     Delayed d = ThreadlyInternalAccessor.doScheduleWithFixedDelayAndGetDelayed(pScheduler, 
                                                                                lft, taskPriority, 
                                                                                initialDelay, 
@@ -124,7 +125,8 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     // wrap the task to ensure the correct behavior on exceptions
     task = new ThrowableHandlingRecurringRunnable(pScheduler, task);
     
-    ListenableRunnableFuture<Void> lft = new CancelRemovingListenableFutureTask<>(scheduler, true, task);
+    ListenableRunnableFuture<Void> lft = 
+        new CancelRemovingListenableFutureTask<>(scheduler, true, task, pScheduler);
     Delayed d = ThreadlyInternalAccessor.doScheduleAtFixedRateAndGetDelayed(pScheduler, 
                                                                             lft, taskPriority, 
                                                                             initialDelay, 

--- a/src/main/java/org/threadly/concurrent/wrapper/compatibility/SingleThreadSchedulerServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/compatibility/SingleThreadSchedulerServiceWrapper.java
@@ -73,7 +73,7 @@ public class SingleThreadSchedulerServiceWrapper extends AbstractExecutorService
 
   @Override
   protected ListenableScheduledFuture<?> schedule(Runnable task, long delayInMillis) {
-    ListenableFutureTask<Void> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<Void> lft = new ListenableFutureTask<>(false, task, singleThreadScheduler);
     Delayed d = ThreadlyInternalAccessor.doScheduleAndGetDelayed(singleThreadScheduler, 
                                                                  lft, taskPriority, delayInMillis);
     
@@ -82,7 +82,7 @@ public class SingleThreadSchedulerServiceWrapper extends AbstractExecutorService
 
   @Override
   protected <V> ListenableScheduledFuture<V> schedule(Callable<V> callable, long delayInMillis) {
-    ListenableFutureTask<V> lft = new ListenableFutureTask<>(false, callable);
+    ListenableFutureTask<V> lft = new ListenableFutureTask<>(false, callable, singleThreadScheduler);
     Delayed d = ThreadlyInternalAccessor.doScheduleAndGetDelayed(singleThreadScheduler, 
                                                                  lft, taskPriority, delayInMillis);
     
@@ -95,7 +95,8 @@ public class SingleThreadSchedulerServiceWrapper extends AbstractExecutorService
     // wrap the task to ensure the correct behavior on exceptions
     task = new ThrowableHandlingRecurringRunnable(scheduler, task);
     
-    ListenableFutureTask<Void> lft = new CancelRemovingListenableFutureTask<>(scheduler, true, task);
+    ListenableFutureTask<Void> lft = 
+        new CancelRemovingListenableFutureTask<>(scheduler, true, task, singleThreadScheduler);
     Delayed d = ThreadlyInternalAccessor.doScheduleWithFixedDelayAndGetDelayed(singleThreadScheduler, 
                                                                                lft, taskPriority, 
                                                                                initialDelay, 
@@ -110,7 +111,8 @@ public class SingleThreadSchedulerServiceWrapper extends AbstractExecutorService
     // wrap the task to ensure the correct behavior on exceptions
     task = new ThrowableHandlingRecurringRunnable(scheduler, task);
     
-    ListenableFutureTask<Void> lft = new CancelRemovingListenableFutureTask<>(scheduler, true, task);
+    ListenableFutureTask<Void> lft = 
+        new CancelRemovingListenableFutureTask<>(scheduler, true, task, singleThreadScheduler);
     Delayed d = ThreadlyInternalAccessor.doScheduleAtFixedRateAndGetDelayed(singleThreadScheduler, 
                                                                             lft, taskPriority, 
                                                                             initialDelay, 

--- a/src/main/java/org/threadly/concurrent/wrapper/interceptor/ExecutorTaskInterceptor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/interceptor/ExecutorTaskInterceptor.java
@@ -82,7 +82,7 @@ public class ExecutorTaskInterceptor implements SubmitterExecutor {
   public <T> ListenableFuture<T> submit(Runnable task, T result) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, wrapTask(task), result);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, wrapTask(task), result, this);
     
     parentExecutor.execute(lft);
     
@@ -93,7 +93,7 @@ public class ExecutorTaskInterceptor implements SubmitterExecutor {
   public <T> ListenableFuture<T> submit(Callable<T> task) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, this);
 
     parentExecutor.execute(wrapTask(lft));
     

--- a/src/main/java/org/threadly/concurrent/wrapper/interceptor/PrioritySchedulerTaskInterceptor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/interceptor/PrioritySchedulerTaskInterceptor.java
@@ -69,7 +69,7 @@ public class PrioritySchedulerTaskInterceptor extends SchedulerServiceTaskInterc
   public <T> ListenableFuture<T> submit(Callable<T> task, TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, this);
 
     parentScheduler.execute(wrapTask(lft, false), priority);
     
@@ -93,7 +93,7 @@ public class PrioritySchedulerTaskInterceptor extends SchedulerServiceTaskInterc
                                                  TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, this);
 
     parentScheduler.schedule(wrapTask(lft, false), delayInMs, priority);
     

--- a/src/main/java/org/threadly/concurrent/wrapper/interceptor/SubmitterSchedulerTaskInterceptor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/interceptor/SubmitterSchedulerTaskInterceptor.java
@@ -104,7 +104,7 @@ public class SubmitterSchedulerTaskInterceptor extends ExecutorTaskInterceptor
   public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, this);
 
     parentScheduler.schedule(wrapTask(lft, false), delayInMs);
     

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/AbstractKeyedLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/AbstractKeyedLimiter.java
@@ -199,9 +199,10 @@ abstract class AbstractKeyedLimiter<T extends ExecutorLimiter> {
     ArgumentVerifier.assertNotNull(taskKey, "taskKey");
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableRunnableFuture<TT> rf = new ListenableFutureTask<>(false, task);
+    LimiterContainer lc = getLimiterContainer(taskKey);
+    ListenableRunnableFuture<TT> rf = new ListenableFutureTask<>(false, task, lc.limiter);
     
-    getLimiterContainer(taskKey).submit(rf);
+    lc.submit(rf);
     
     return rf;
   }

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/ExecutorLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/ExecutorLimiter.java
@@ -92,7 +92,7 @@ public class ExecutorLimiter implements SubmitterExecutor {
   public <T> ListenableFuture<T> submit(Callable<T> task) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, this);
     
     executeOrQueue(lft, lft);
     

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/PrioritySchedulerServiceQueueLimitRejector.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/PrioritySchedulerServiceQueueLimitRejector.java
@@ -136,7 +136,7 @@ public class PrioritySchedulerServiceQueueLimitRejector extends SchedulerService
   public <T> ListenableFuture<T> submit(Callable<T> task, TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task, this);
     
     doSchedule(lft, 0, priority);
     
@@ -168,7 +168,7 @@ public class PrioritySchedulerServiceQueueLimitRejector extends SchedulerService
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(delayInMs, "delayInMs");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<T>(false, task, this);
 
     doSchedule(lft, delayInMs, priority);
     

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/RateLimiterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/RateLimiterExecutor.java
@@ -163,7 +163,7 @@ public class RateLimiterExecutor extends AbstractSubmitterExecutor {
     if (currentMinimumDelay == 0) {
       return ImmediateResultListenableFuture.NULL_RESULT;
     } else {
-      ListenableFutureTask<?> lft = new ListenableFutureTask<>(false, DoNothingRunnable.instance());
+      ListenableFutureTask<?> lft = new ListenableFutureTask<>(false, DoNothingRunnable.instance(), this);
       
       long futureDelay;
       if (maximumDelay > 0 && currentMinimumDelay > maximumDelay) {
@@ -222,7 +222,7 @@ public class RateLimiterExecutor extends AbstractSubmitterExecutor {
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(permits, "permits");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, result);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, result, this);
     
     doExecute(permits, lft);
     
@@ -243,7 +243,7 @@ public class RateLimiterExecutor extends AbstractSubmitterExecutor {
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(permits, "permits");
     
-    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, this);
     
     doExecute(permits, lft);
     

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/SubmitterSchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/SubmitterSchedulerLimiter.java
@@ -77,7 +77,7 @@ public class SubmitterSchedulerLimiter extends ExecutorLimiter implements Submit
   public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs) {
     ArgumentVerifier.assertNotNull(task, "task");
     
-    ListenableFutureTask<T> ft = new ListenableFutureTask<>(false, task);
+    ListenableFutureTask<T> ft = new ListenableFutureTask<>(false, task, this);
     
     doSchedule(ft, ft, delayInMs);
     

--- a/src/main/java/org/threadly/concurrent/wrapper/traceability/ThreadRenamingPriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/traceability/ThreadRenamingPriorityScheduler.java
@@ -123,7 +123,7 @@ public class ThreadRenamingPriorityScheduler extends AbstractSubmitterScheduler
                                                  TaskPriority priority) {
     ArgumentVerifier.assertNotNull(task, "task");
 
-    ListenableRunnableFuture<T> rf = new ListenableFutureTask<>(false, task);
+    ListenableRunnableFuture<T> rf = new ListenableFutureTask<>(false, task, this);
     doSchedule(rf, delayInMs, priority);
     
     return rf;

--- a/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
+++ b/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
@@ -968,6 +968,26 @@ public class FutureUtilsTest {
     
     ImmediateListenableFutureTest.failureAddCallbackTest(testFuture, failure);
   }
+
+  @Test
+  public void immediateResultFutureListenerOptimizeListenerExecutorTest() throws InterruptedException, TimeoutException {
+    ListenableFutureInterfaceTest.optimizeDoneListenerExecutorTest(FutureUtils.immediateResultFuture(null));
+  }
+
+  @Test
+  public void immediateResultFutureDontOptimizeListenerExecutorTest() throws InterruptedException, TimeoutException {
+    ListenableFutureInterfaceTest.dontOptimizeDoneListenerExecutorTest(FutureUtils.immediateResultFuture(null));
+  }
+
+  @Test
+  public void immediateFailureFutureListenerOptimizeListenerExecutorTest() throws InterruptedException, TimeoutException {
+    ListenableFutureInterfaceTest.optimizeDoneListenerExecutorTest(FutureUtils.immediateFailureFuture(null));
+  }
+
+  @Test
+  public void immediateFailureFutureDontOptimizeListenerExecutorTest() throws InterruptedException, TimeoutException {
+    ListenableFutureInterfaceTest.dontOptimizeDoneListenerExecutorTest(FutureUtils.immediateFailureFuture(null));
+  }
   
   @Test
   public void scheduleWhileTaskResultNullFirstRunInThreadTest() throws Exception {

--- a/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
+++ b/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
@@ -62,7 +62,8 @@ public class TestFutureImp implements ListenableFuture<Object> {
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor, boolean optimizeExecution) {
+  public void addListener(Runnable listener, Executor executor, 
+                          ListenerOptimizationStrategy optimizeExecution) {
     addListener(listener);
   }
 }

--- a/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
+++ b/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
@@ -62,7 +62,7 @@ public class TestFutureImp implements ListenableFuture<Object> {
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor) {
+  public void addListener(Runnable listener, Executor executor, boolean optimizeExecution) {
     addListener(listener);
   }
 }


### PR DESCRIPTION
This adds four new functions to `ListenableFuture` where the executor for the listener may be optimized away.
This can allow the listener to avoid the need to re-queue in the executor and get thread time _again_ before it can be executed.
However, if the listener was complex, or wanted to be run concurrently this will cause issues, and thus why we can't default enable this type of operation.

@lwahlmeier This can improve litesockets performance fairly significantly for some applications.  With my experience in litesockets I am often needing to specify pools because I don't know where the future will complete on.  This can allow those calls to optimize away and only re-queue on the pool if needed.

However I am not convinced that this optimization is worth the API bloat of the important `ListenableFuture` interface.  Thoughts?  Ideas on how else it could be applied in the api?