### PR TITLE
Add `ListenableFuture.mapFailure` / `flatMapFailure`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins.withType(JavaPlugin) {
 }
 
 test {
+  maxParallelForks = Math.max(1, (int)(Runtime.getRuntime().availableProcessors() / 4))
   jacoco {
     excludes = ['**/package-info**','**/*Test']
     destinationFile = file("$buildDir/reports/jacoco/test.exec")

--- a/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
@@ -2,6 +2,7 @@ package org.threadly.concurrent.future;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Completed implementation of {@link ListenableFuture} that will immediately return a result.  
@@ -48,6 +49,24 @@ public class ImmediateResultListenableFuture<T> extends AbstractImmediateListena
    */
   public ImmediateResultListenableFuture(T result) {
     this.result = result;
+  }
+
+  @Override
+  public <TT extends Throwable> ListenableFuture<T> mapFailure(Class<TT> throwableType,
+                                                               Function<TT, T> mapper,
+                                                               Executor executor,
+                                                               ListenerOptimizationStrategy optimizeExecution) {
+    // nothing to map, we are not in error
+    return this;
+  }
+
+  @Override
+  public <TT extends Throwable> ListenableFuture<T> flatMapFailure(Class<TT> throwableType,
+                                                                   Function<TT, ListenableFuture<T>> mapper,
+                                                                   Executor executor,
+                                                                   ListenerOptimizationStrategy optimizeExecution) {
+    // nothing to map, we are not in error
+    return this;
   }
 
   @Override

--- a/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
@@ -376,6 +376,141 @@ public interface ListenableFuture<T> extends Future<T> {
   }
   
   /**
+   * Similar to {@link #throwMap(Function)} except this mapper will only be invoked when the 
+   * future is in a failure state (from either the original computation or an earlier mapper 
+   * throwing an exception).  If this future does resolve in a failure state, and that exception 
+   * class matches the one provided here.  The mapper function will then be provided that 
+   * throwable, it can then map that throwable back into a result (perhaps an {@code Optional}), 
+   * or re-throw either the same or a different exception keep the future in a failure state.  If 
+   * the future completes with a normal result, this mapper will be ignored, and the result will 
+   * be forwarded on without invoking this mapper.
+   * 
+   * @since 5.17
+   * @param <TT> The type of throwable that should be handled 
+   * @param throwableType The class referencing to the type of throwable this mapper handles
+   * @param mapper The mapper to convert a thrown exception to either a result or thrown exception
+   * @return A {@link ListenableFuture} that will resolve after the mapper is considered
+   */
+  default <TT extends Throwable> ListenableFuture<T> mapFailure(Class<TT> throwableType, 
+                                                                Function<TT, T> mapper) {
+    return mapFailure(throwableType, mapper, null, null);
+  }
+
+  /**
+   * Similar to {@link #throwMap(Function, Executor)} except this mapper will only be invoked when 
+   * the future is in a failure state (from either the original computation or an earlier mapper 
+   * throwing an exception).  If this future does resolve in a failure state, and that exception 
+   * class matches the one provided here.  The mapper function will then be provided that 
+   * throwable, it can then map that throwable back into a result (perhaps an {@code Optional}), 
+   * or re-throw either the same or a different exception keep the future in a failure state.  If 
+   * the future completes with a normal result, this mapper will be ignored, and the result will 
+   * be forwarded on without invoking this mapper.
+   * 
+   * @since 5.17
+   * @param <TT> The type of throwable that should be handled 
+   * @param throwableType The class referencing to the type of throwable this mapper handles
+   * @param mapper The mapper to convert a thrown exception to either a result or thrown exception
+   * @param executor Executor to invoke mapper function on, or {@code null} 
+   *          to invoke on this thread or future complete thread (depending on future state)
+   * @return A {@link ListenableFuture} that will resolve after the mapper is considered
+   */
+  default <TT extends Throwable> ListenableFuture<T> mapFailure(Class<TT> throwableType, 
+                                                                Function<TT, T> mapper, 
+                                                                Executor executor) {
+    return mapFailure(throwableType, mapper, executor, null);
+  }
+
+  /**
+   * Similar to {@link #throwMap(Function, Executor, ListenerOptimizationStrategy)} except this 
+   * mapper will only be invoked when the future is in a failure state (from either the original 
+   * computation or an earlier mapper throwing an exception).  If this future does resolve in a 
+   * failure state, and that exception class matches the one provided here.  The mapper function 
+   * will then be provided that throwable, it can then map that throwable back into a result 
+   * perhaps an {@code Optional}), or re-throw either the same or a different exception keep the 
+   * future in a failure state.  If the future completes with a normal result, this mapper will be 
+   * ignored, and the result will be forwarded on without invoking this mapper.
+   * 
+   * @since 5.17
+   * @param <TT> The type of throwable that should be handled 
+   * @param throwableType The class referencing to the type of throwable this mapper handles
+   * @param mapper The mapper to convert a thrown exception to either a result or thrown exception
+   * @param executor Executor to invoke mapper function on, or {@code null} 
+   *          to invoke on this thread or future complete thread (depending on future state)
+   * @param optimizeExecution {@code true} to avoid listener queuing for execution if already on the desired pool
+   * @return A {@link ListenableFuture} that will resolve after the mapper is considered
+   */
+  default <TT extends Throwable> ListenableFuture<T> mapFailure(Class<TT> throwableType, 
+                                                                Function<TT, T> mapper, 
+                                                                Executor executor, 
+                                                                ListenerOptimizationStrategy optimizeExecution) {
+    return FutureUtils.failureTransform(this, mapper, throwableType, executor, optimizeExecution);
+  }
+
+  /**
+   * Similar to {@link #mapFailure(Class, Function)} except that this mapper function returns a 
+   * {@link ListenableFuture} if it needs to map the Throwable / failure into a result or another 
+   * failure.  The mapper function can return a Future that will (or may) provide a result, or it 
+   * can provide a future that will result in the same or another failure.  Similar to  
+   * {@link #mapFailure(Class, Function)} the mapper can also throw an exception directly.
+   * 
+   * @since 5.17
+   * @param <TT> The type of throwable that should be handled 
+   * @param throwableType The class referencing to the type of throwable this mapper handles
+   * @param mapper Function to invoke in order to transform the futures result
+   * @return A {@link ListenableFuture} that will resolve after the mapper is considered
+   */
+  default <TT extends Throwable> ListenableFuture<T> flatMapFailure(Class<TT> throwableType, 
+                                                                    Function<TT, ListenableFuture<T>> mapper) {
+    return flatMapFailure(throwableType, mapper, null, null);
+  }
+
+  /**
+   * Similar to {@link #mapFailure(Class, Function, Executor)} except that this mapper function 
+   * returns a {@link ListenableFuture} if it needs to map the Throwable / failure into a result 
+   * or another failure.  The mapper function can return a Future that will (or may) provide a 
+   * result, or it can provide a future that will result in the same or another failure.  Similar 
+   * to {@link #mapFailure(Class, Function, Executor)} the mapper can also throw an exception 
+   * directly.
+   * 
+   * @since 5.17
+   * @param <TT> The type of throwable that should be handled 
+   * @param throwableType The class referencing to the type of throwable this mapper handles
+   * @param mapper Function to invoke in order to transform the futures result
+   * @param executor Executor to invoke mapper function on, or {@code null} 
+   *          to invoke on this thread or future complete thread (depending on future state)
+   * @return A {@link ListenableFuture} that will resolve after the mapper is considered
+   */
+  default <TT extends Throwable> ListenableFuture<T> flatMapFailure(Class<TT> throwableType, 
+                                                                    Function<TT, ListenableFuture<T>> mapper, 
+                                                                    Executor executor) {
+    return flatMapFailure(throwableType, mapper, executor, null);
+  }
+
+  /**
+   * Similar to {@link #mapFailure(Class, Function, Executor, ListenerOptimizationStrategy)} except 
+   * that this mapper function returns a {@link ListenableFuture} if it needs to map the Throwable 
+   * into a result or another failure.  The mapper function can return a Future that will (or may) 
+   * provide a result, or it can provide a future that will result in the same or another failure.  
+   * Similar to {@link #mapFailure(Class, Function, Executor, ListenerOptimizationStrategy)} the 
+   * mapper can also throw an exception directly.
+   * 
+   * @since 5.17
+   * @param <TT> The type of throwable that should be handled 
+   * @param throwableType The class referencing to the type of throwable this mapper handles
+   * @param mapper Function to invoke in order to transform the futures result
+   * @param executor Executor to invoke mapper function on, or {@code null} 
+   *          to invoke on this thread or future complete thread (depending on future state)
+   * @param optimizeExecution {@code true} to avoid listener queuing for execution if already on the desired pool
+   * @return A {@link ListenableFuture} that will resolve after the mapper is considered
+   */
+  default <TT extends Throwable> ListenableFuture<T> flatMapFailure(Class<TT> throwableType, 
+                                                                    Function<TT, ListenableFuture<T>> mapper, 
+                                                                    Executor executor, 
+                                                                    ListenerOptimizationStrategy optimizeExecution) {
+    return FutureUtils.flatFailureTransform(this, mapper, throwableType, executor, optimizeExecution);
+  }
+  
+  /**
    * Add a listener to be called once the future has completed.  If the future has already 
    * finished, this will be called immediately.
    * <p>

--- a/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
@@ -386,7 +386,7 @@ public interface ListenableFuture<T> extends Future<T> {
    * be forwarded on without invoking this mapper.
    * 
    * @since 5.17
-   * @param <TT> The type of throwable that should be handled 
+   * @param <TT> The type of throwable that should be handled
    * @param throwableType The class referencing to the type of throwable this mapper handles
    * @param mapper The mapper to convert a thrown exception to either a result or thrown exception
    * @return A {@link ListenableFuture} that will resolve after the mapper is considered
@@ -407,7 +407,7 @@ public interface ListenableFuture<T> extends Future<T> {
    * be forwarded on without invoking this mapper.
    * 
    * @since 5.17
-   * @param <TT> The type of throwable that should be handled 
+   * @param <TT> The type of throwable that should be handled
    * @param throwableType The class referencing to the type of throwable this mapper handles
    * @param mapper The mapper to convert a thrown exception to either a result or thrown exception
    * @param executor Executor to invoke mapper function on, or {@code null} 
@@ -431,7 +431,7 @@ public interface ListenableFuture<T> extends Future<T> {
    * ignored, and the result will be forwarded on without invoking this mapper.
    * 
    * @since 5.17
-   * @param <TT> The type of throwable that should be handled 
+   * @param <TT> The type of throwable that should be handled
    * @param throwableType The class referencing to the type of throwable this mapper handles
    * @param mapper The mapper to convert a thrown exception to either a result or thrown exception
    * @param executor Executor to invoke mapper function on, or {@code null} 
@@ -454,7 +454,7 @@ public interface ListenableFuture<T> extends Future<T> {
    * {@link #mapFailure(Class, Function)} the mapper can also throw an exception directly.
    * 
    * @since 5.17
-   * @param <TT> The type of throwable that should be handled 
+   * @param <TT> The type of throwable that should be handled
    * @param throwableType The class referencing to the type of throwable this mapper handles
    * @param mapper Function to invoke in order to transform the futures result
    * @return A {@link ListenableFuture} that will resolve after the mapper is considered
@@ -473,7 +473,7 @@ public interface ListenableFuture<T> extends Future<T> {
    * directly.
    * 
    * @since 5.17
-   * @param <TT> The type of throwable that should be handled 
+   * @param <TT> The type of throwable that should be handled
    * @param throwableType The class referencing to the type of throwable this mapper handles
    * @param mapper Function to invoke in order to transform the futures result
    * @param executor Executor to invoke mapper function on, or {@code null} 
@@ -495,7 +495,7 @@ public interface ListenableFuture<T> extends Future<T> {
    * mapper can also throw an exception directly.
    * 
    * @since 5.17
-   * @param <TT> The type of throwable that should be handled 
+   * @param <TT> The type of throwable that should be handled
    * @param throwableType The class referencing to the type of throwable this mapper handles
    * @param mapper Function to invoke in order to transform the futures result
    * @param executor Executor to invoke mapper function on, or {@code null} 

--- a/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
@@ -74,8 +74,8 @@ public class ExecuteOnGetFutureTaskTest extends ListenableFutureTaskTest {
     }
 
     @Override
-    public ListenableFuture<?> makeWithFailure(Exception t) {
-      ListenableFutureTask<?> lft = new ExecuteOnGetFutureTask<>(() -> { throw t; });
+    public ListenableFuture<Object> makeWithFailure(Exception t) {
+      ListenableFutureTask<Object> lft = new ExecuteOnGetFutureTask<>(() -> { throw t; });
       lft.run();
       return lft;
     }

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -207,8 +207,8 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     }
 
     @Override
-    public ListenableFuture<?> makeWithFailure(Exception e) {
-      ListenableFutureTask<?> lft = new ListenableFutureTask<>(false, () -> { throw e; });
+    public ListenableFuture<Object> makeWithFailure(Exception e) {
+      ListenableFutureTask<Object> lft = new ListenableFutureTask<>(false, () -> { throw e; });
       lft.run();
       return lft;
     }

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -415,8 +415,8 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     }
     
     @Override
-    public ListenableFuture<?> makeWithFailure(Exception e) {
-      SettableListenableFuture<?> slf = new SettableListenableFuture<>();
+    public ListenableFuture<Object> makeWithFailure(Exception e) {
+      SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
       slf.handleFailure(e);
       return slf;
     }


### PR DESCRIPTION
These are similar to `throwMap` and `flatMap` in that they allow you to transform an async result from one future into another.
However instead of mapping one result into another result, these map the failure conditions into another failure condition, or back into the expected result type.
This means they wont be invoked if the future is not in an error condition (similar to how `map` wont be invoked if the future IS in a failure condition).  That is why they can only map the failure into either another failure, or back into the expected result type.

@AltSysrq let me know if you have any thoughts here.  I decided to just start with this, and not provide the functions that allow you to map the normal result and failure all at once.  Those could be added if we want to expand the API for it.  However I am also considering a new API that would allow you to compact multiple async actions rather than requiring an intermediate future inbetween.  It seems like something like that may be a better solution (but I am unsure what an API for that might look like, or how it might work right now, just nervous about expanding the API further for cases we are unsure about).

If you think that the need to map the failure and result types in one action are a really important and common use case, speak up and we can consider adding it sooner than later.