### PR TITLE
Setup for Buildkite as our new CI solution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 group = org.threadly
-version = 5.21
-org.gradle.daemon = false
+version = 5.22-SNAPSHOT

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,0 +1,27 @@
+steps:
+  - command: "./gradlew clean assemble"
+    label: "compile"
+    artifact_paths: "build/libs/*.jar"
+    timeout: 2
+
+  - wait
+
+  - command: "./gradlew test"
+    label: "unit tests"
+    artifact_paths: "build/reports/tests/xml/*.xml"
+    timeout: 10
+
+  - wait: ~
+    continue_on_failure: true
+
+  - plugins:
+      junit-annotate#v1.2.0:
+        artifacts: build/reports/tests/xml/*.xml
+
+  - command: "./gradlew checkstyleMain"
+    label: "checkstyle"
+    timeout: 2
+
+  - command: "./gradlew jacocoTestCoverageVerification"
+    label: "jacoco"
+    timeout: 2

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.threadly</groupId>
   <artifactId>threadly</artifactId>
-  <version>5.21</version>
+  <version>5.22-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Threadly</name>


### PR DESCRIPTION
Add a pipeline.xml for a buildkite build. It's rather simple since it just delegates to our gradle wrapper.
This enables the gradle daemon. While it can use a chunk of memory, it does gain significant speeds on the build system.

This is a (second) test PR to resolve #230

Initially this will require buildkite logins to see the full details of build failures (though status will be shown to everyone). I talked to Buildkite and they are working on improving this currently, which is awesome news.

Assuming things keep looking good I will update other threadly projects to be in the same way.