### PR TITLE
(Keyed)RateLimiterExecutor improvements

### DIFF
--- a/src/main/java/org/threadly/concurrent/DoNothingRunnable.java
+++ b/src/main/java/org/threadly/concurrent/DoNothingRunnable.java
@@ -7,6 +7,16 @@ package org.threadly.concurrent;
  */
 public class DoNothingRunnable implements Runnable {
   private static final DoNothingRunnable DEFAULT_INSTANCE = new DoNothingRunnable();
+  
+  /**
+   * Constructs a new {@link DoNothingRunnable}.
+   * 
+   * @deprecated Please use {@link DoNothingRunnable#instance()} instead
+   */
+  @Deprecated
+  public DoNothingRunnable() {
+    // nothing here by default
+  }
 
   /**
    * Call to get a default instance of the {@link DoNothingRunnable}.  Because there is no saved 

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutor.java
@@ -2,7 +2,6 @@ package org.threadly.concurrent.wrapper.limiter;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 
 import org.threadly.concurrent.AbstractSubmitterExecutor;
 import org.threadly.concurrent.DoNothingRunnable;
@@ -302,7 +301,7 @@ public class KeyedRateLimiterExecutor {
     ArgumentVerifier.assertNotNegative(permits, "permits");
     ArgumentVerifier.assertNotNull(task, "task");
     
-    return limiterForKey(taskKey, (l) -> l.execute(permits, task));
+    return limiterForKey(taskKey).execute(permits, task);
   }
   
   /**
@@ -365,7 +364,7 @@ public class KeyedRateLimiterExecutor {
    */
   public <T> ListenableFuture<T> submit(double permits, Object taskKey, Runnable task, T result) {
     // we go directly to the limiter here to get DoNothingRunnable optimizations (can't wrap task)
-    return limiterForKey(taskKey, (l) -> l.submit(permits, task, result));
+    return limiterForKey(taskKey).submit(permits, task, result);
   }
   
   /**
@@ -396,41 +395,36 @@ public class KeyedRateLimiterExecutor {
    * @return Future to represent when the execution has occurred and provide the result from the callable
    */
   public <T> ListenableFuture<T> submit(double permits, Object taskKey, Callable<T> task) {
-    return limiterForKey(taskKey, (l) -> l.submit(permits, task));
+    return limiterForKey(taskKey).submit(permits, task);
   }
   
   /**
-   * This invokes a function with a provided {@link RateLimiterExecutor}.  This invocation is 
-   * atomic using {@link ConcurrentHashMap#compute(Object, java.util.function.BiFunction)} so that 
-   * it will not interfere with others.
+   * Get a limiter for a given task key.  The returned limiter may be considered "cleaned up" at 
+   * any time.  If that occurs it can continue to function, but other task keys may use a different 
+   * limiter (thus the limit per-key would not be respected).  As long as operations use the 
+   * limiter quickly (sub second), this should not be possible.
    * 
-   * @param <T> Type of result from provided function
    * @param taskKey object key where {@code equals()} will be used to determine execution thread
    * @return A {@link RateLimiterExecutor} that is shared by the key
    */
-  @SuppressWarnings("unchecked")
-  protected <T> T limiterForKey(Object taskKey, Function<RateLimiterExecutor, ? extends T> c) {
+  protected RateLimiterExecutor limiterForKey(Object taskKey) {
     ArgumentVerifier.assertNotNull(taskKey, "taskKey");
     
-    Object[] capture = new Object[1];
-    currentLimiters.compute(taskKey, (k, v) -> {
-      if (v == null) {
-        String keyedPoolName = subPoolName + (addKeyToThreadName ? taskKey.toString() : "");
-        SubmitterScheduler threadNamedScheduler;
-        if (StringUtils.isNullOrEmpty(keyedPoolName)) {
-          threadNamedScheduler = scheduler;
-        } else {
-          threadNamedScheduler = new ThreadRenamingSubmitterScheduler(scheduler, keyedPoolName, false);
-        }
-        v = new RateLimiterExecutor(threadNamedScheduler, permitsPerSecond, 
-                                    maxScheduleDelayMillis, rejectedExecutionHandler);
-        // schedule task to check for removal later, should only be one task per limiter
-        limiterCheckerScheduler.schedule(new LimiterChecker(taskKey, v), LIMITER_IDLE_TIMEOUT);
+    return currentLimiters.computeIfAbsent(taskKey, (k) -> {
+      String keyedPoolName = subPoolName + (addKeyToThreadName ? taskKey.toString() : "");
+      SubmitterScheduler threadNamedScheduler;
+      if (StringUtils.isNullOrEmpty(keyedPoolName)) {
+        threadNamedScheduler = scheduler;
+      } else {
+        threadNamedScheduler = new ThreadRenamingSubmitterScheduler(scheduler, keyedPoolName, false);
       }
-      capture[0] = c.apply(v);
-      return v;
+      RateLimiterExecutor rle = 
+          new RateLimiterExecutor(threadNamedScheduler, permitsPerSecond, 
+                                  maxScheduleDelayMillis, rejectedExecutionHandler);
+      // schedule task to check for removal later, should only be one task per limiter
+      limiterCheckerScheduler.schedule(new LimiterChecker(taskKey, rle), LIMITER_IDLE_TIMEOUT);
+      return rle;
     });
-    return (T)capture[0];
   }
 
   /**
@@ -477,7 +471,7 @@ public class KeyedRateLimiterExecutor {
     
     @Override
     protected void doExecute(Runnable task) {
-      limiterForKey(taskKey, (l) -> l.execute(permits, task));
+      limiterForKey(taskKey).execute(permits, task);
     }
   }
   
@@ -499,14 +493,11 @@ public class KeyedRateLimiterExecutor {
 
     @Override
     public void run() {
-      currentLimiters.computeIfPresent(taskKey, (k, v) -> {
-        if (Clock.lastKnownForwardProgressingMillis() - v.getLastScheduleTime() < LIMITER_IDLE_TIMEOUT) {
-          limiterCheckerScheduler.schedule(this, LIMITER_IDLE_TIMEOUT / 2);
-          return v;
-        } else {
-          return null;  // remove
-        }
-      });
+      if (Clock.lastKnownForwardProgressingMillis() - limiter.getLastScheduleTime() > LIMITER_IDLE_TIMEOUT) {
+        currentLimiters.remove(taskKey);
+      } else {
+        limiterCheckerScheduler.schedule(this, LIMITER_IDLE_TIMEOUT / 2);
+      }
     }
   }
 }

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutor.java
@@ -1,5 +1,7 @@
 package org.threadly.concurrent.wrapper.limiter;
 
+import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -7,6 +9,7 @@ import java.util.function.Function;
 import org.threadly.concurrent.AbstractSubmitterExecutor;
 import org.threadly.concurrent.DoNothingRunnable;
 import org.threadly.concurrent.PrioritySchedulerService;
+import org.threadly.concurrent.ReschedulingOperation;
 import org.threadly.concurrent.SubmitterExecutor;
 import org.threadly.concurrent.SubmitterScheduler;
 import org.threadly.concurrent.TaskPriority;
@@ -46,6 +49,7 @@ public class KeyedRateLimiterExecutor {
   protected final String subPoolName;
   protected final boolean addKeyToThreadName;
   protected final ConcurrentHashMap<Object, RateLimiterExecutor> currentLimiters;
+  protected final LimiterChecker limiterChecker;
   
   /**
    * Constructs a new key rate limiting executor.  Using sensible default options.
@@ -181,6 +185,7 @@ public class KeyedRateLimiterExecutor {
     this.subPoolName = StringUtils.nullToEmpty(subPoolName);
     this.addKeyToThreadName = addKeyToThreadName;
     this.currentLimiters = new ConcurrentHashMap<>(CONCURRENT_HASH_MAP_INITIAL_SIZE);
+    this.limiterChecker = new LimiterChecker(scheduler, LIMITER_IDLE_TIMEOUT / 2);
   }
   
   /**
@@ -424,9 +429,22 @@ public class KeyedRateLimiterExecutor {
         }
         v = new RateLimiterExecutor(threadNamedScheduler, permitsPerSecond, 
                                     maxScheduleDelayMillis, rejectedExecutionHandler);
-        // schedule task to check for removal later, should only be one task per limiter
-        limiterCheckerScheduler.schedule(new LimiterChecker(taskKey, v), LIMITER_IDLE_TIMEOUT);
+        limiterChecker.signalToRun();
       }
+      // TODO - I would like to improve this
+      //          This is awkward having to construct an Object[] just to get the result returned
+      //          Ideally we would avoid both that, and the lambda's that need to be passed in, but 
+      //          how to do that is not super obvious.  By applying the function inside the `compute` 
+      //          we are ensuring the operation is atomic compared to any removes that might want 
+      //          to happen.
+      //          Other ideas I have:
+      //            * Increase memory overhead by having the value be an Object[] of size 2
+      //                Index 0 would be the RateLimiterExecutor, 1 would be able to be used for the capture
+      //            * Extend RateLimiterExecutor and store a timestamp that is updated here in compute.
+      //                This is probably the simplest, but does not completely solve the problem
+      //                This would just ensure the timestamp is updated when looking to remove, but 
+      //                If the action took X milliseconds after the update, then it may still be removed.
+      //                Highly unlikely, but I prefer impossibility if we can
       capture[0] = c.apply(v);
       return v;
     });
@@ -482,31 +500,36 @@ public class KeyedRateLimiterExecutor {
   }
   
   /**
-   * Task which checks to see if a limiter has become idle.  If so it removes the limiter in a 
-   * thread safe way.  If the limiter is still active then it will schedule itself to check again 
-   * later.
+   * Task which checks over all limiters to see if any should be expired / removed.
    * 
-   * @since 4.7.0
+   * @since 5.25
    */
-  protected class LimiterChecker implements Runnable {
-    public final Object taskKey;
-    public final RateLimiterExecutor limiter;
-    
-    public LimiterChecker(Object taskKey, RateLimiterExecutor limiter) {
-      this.taskKey = taskKey;
-      this.limiter = limiter;
+  protected class LimiterChecker extends ReschedulingOperation {
+    protected LimiterChecker(SubmitterScheduler scheduler, long scheduleDelay) {
+      super(scheduler, scheduleDelay);
     }
 
     @Override
     public void run() {
-      currentLimiters.computeIfPresent(taskKey, (k, v) -> {
-        if (Clock.lastKnownForwardProgressingMillis() - v.getLastScheduleTime() < LIMITER_IDLE_TIMEOUT) {
-          limiterCheckerScheduler.schedule(this, LIMITER_IDLE_TIMEOUT / 2);
-          return v;
-        } else {
-          return null;  // remove
+      Iterator<Map.Entry<Object, RateLimiterExecutor>> it = currentLimiters.entrySet().iterator();
+      long now = Clock.lastKnownForwardProgressingMillis();
+      while (it.hasNext()) {
+        Map.Entry<Object, RateLimiterExecutor> e = it.next();
+        if (now - e.getValue().getLastScheduleTime() > LIMITER_IDLE_TIMEOUT) {
+          // if optimistic check above failed, we must remove in `compute` to ensure
+          // no tasks are being submitted while we are removing the limiter
+          currentLimiters.computeIfPresent(e.getKey(), (k, v) -> {
+            if (now - v.getLastScheduleTime() > LIMITER_IDLE_TIMEOUT) {
+              return null;
+            } else {
+              return v;
+            }
+          });
         }
-      });
+      }
+      if (! currentLimiters.isEmpty()) {
+        signalToRun();
+      }
     }
   }
 }

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/RateLimiterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/RateLimiterExecutor.java
@@ -237,19 +237,17 @@ public class RateLimiterExecutor extends AbstractSubmitterExecutor {
     
     if (task == DoNothingRunnable.instance()) {
       long taskDelay = getTaskDelay(permits);
-      if (taskDelay < 0) {
-        ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, result, this);
-
-        rejectedExecutionHandler.handleRejectedTask(lft);
-        
-        return lft;
-      } else if (taskDelay == 0) {
+      if (taskDelay == 0) {
         // don't even need to burden the scheduler
-        return FutureUtils.immediateResultFuture(null);
+        return FutureUtils.immediateResultFuture(result);
       } else {
         ListenableFutureTask<T> lft = new ListenableFutureTask<>(false, task, result, this);
-
-        scheduler.schedule(lft, taskDelay);
+        
+        if (taskDelay < 0) {
+          rejectedExecutionHandler.handleRejectedTask(lft);
+        } else {
+          scheduler.schedule(lft, taskDelay);
+        }
         
         return lft;
       }

--- a/src/test/java/org/threadly/concurrent/ContainerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/ContainerHelperTest.java
@@ -90,6 +90,7 @@ public class ContainerHelperTest extends ThreadlyTester {
                                              implements RunnableContainer {
     private final Runnable r;
     
+    @SuppressWarnings("deprecation")
     private TestRunnableContainer(Runnable r) {
       this.r = r;
     }
@@ -104,7 +105,8 @@ public class ContainerHelperTest extends ThreadlyTester {
   private static class TestCallableContainer extends DoNothingRunnable 
                                              implements CallableContainer, Runnable {
     private final Callable<?> c;
-    
+
+    @SuppressWarnings("deprecation")
     private TestCallableContainer(Callable<?> c) {
       this.c = c;
     }

--- a/src/test/java/org/threadly/concurrent/DoNothingRunnableTest.java
+++ b/src/test/java/org/threadly/concurrent/DoNothingRunnableTest.java
@@ -8,13 +8,13 @@ import org.threadly.ThreadlyTester;
 @SuppressWarnings("javadoc")
 public class DoNothingRunnableTest extends ThreadlyTester {
   @Test
-  public void doNothingRun() {
-    new DoNothingRunnable().run();
-    // no exception
+  public void staticInstanceTest() {
+    assertNotNull(DoNothingRunnable.instance());
   }
   
   @Test
-  public void staticInstanceTest() {
-    assertNotNull(DoNothingRunnable.instance());
+  public void doNothingRun() {
+    DoNothingRunnable.instance().run();
+    // no exception
   }
 }


### PR DESCRIPTION
This combines several improvements to the rate limiter executors:
* The initial motivation was to improve the performance when `DoNothingRunnable` is submitted.  This is a fairly likely use case when you just want listeners to resolve at a given rate.  So this seems like the one executor where it probably makes sense to have special logic to ensure these types of tasks are executed as fast as possible, and with low overhead.  This does mean that they are skipping the execution queue of course (which is why we likely would not want this type of logic in other pools).

Because of that the constructor for `DoNothingRunnable` was deprecated so that we can use the cheaper `==` check instead of `instanceof`.

* `KeyedRateLimiterExecutor` had several internal improvements.  Initially the code was simplified by removing `StripedLock` and instead using the ConcurrentHashMap `compute` to ensure atomic operations.

I am fairly happy with these changes in general, benchmarking shows them to be on par with the old design, and I think they are simpler (not to mention I kind of want to get away from striped lock).

In addition as I was benchmarking the code the task per-key for key expiration seemed pretty problematic.  I changed that to be a single `ReschedulingOperation` (which did not exist when this was initially implemented).  As mentioned in the commit message this should be better for 1 or 10 million or less keys.  At 100+ million keys we could start to saturate a single core, but if we want to support that level of load I think it would be better to build off this rather than the old design.

@lwahlmeier Let me know if you have any creative ideas on the capture / large TODO note.  That's the only part I wish was simpler / cleaner.  You can see in commit e4ed157 I tried to avoid it, but the risk made me fall back to the more thread safe design even though I like that commit's code better.