### PR TITLE
Deprecate StripedLock

### DIFF
--- a/src/main/java/org/threadly/concurrent/lock/StripedLock.java
+++ b/src/main/java/org/threadly/concurrent/lock/StripedLock.java
@@ -13,8 +13,11 @@ import org.threadly.util.ArgumentVerifier;
  * and {@code unlock()} functionality.  This choice was primarily because of the way the internals 
  * of threadly work.
  * 
+ * @deprecated To be removed without replacement, if this is useful please file an issue on github
+ * 
  * @since 1.0.0
  */
+@Deprecated
 public class StripedLock {
   private final Object[] locks;
   

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/AbstractKeyedSchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/AbstractKeyedSchedulerLimiter.java
@@ -27,10 +27,8 @@ abstract class AbstractKeyedSchedulerLimiter<T extends SubmitterSchedulerLimiter
   
   protected AbstractKeyedSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
                                           String subPoolName, boolean addKeyToThreadName, 
-                                          boolean limitFutureListenersExecution, 
-                                          int expectedTaskAdditionParallism) {
-    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution, 
-          expectedTaskAdditionParallism);
+                                          boolean limitFutureListenersExecution) {
+    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution);
     
     this.scheduler = scheduler;
   }

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedExecutorLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedExecutorLimiter.java
@@ -89,43 +89,32 @@ public class KeyedExecutorLimiter extends AbstractKeyedLimiter<ExecutorLimiter> 
   public KeyedExecutorLimiter(Executor executor, int maxConcurrency, 
                               String subPoolName, boolean addKeyToThreadName,
                               boolean limitFutureListenersExecution) {
-    this(executor, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution, 
-         DEFAULT_LOCK_PARALISM);
+    super(executor, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution);
   }
 
   /**
    * Construct a new {@link KeyedExecutorLimiter} providing the backing executor, the maximum 
    * concurrency per unique key, and how keyed limiter threads should be named.
-   * <p>
-   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
-   * given period of time.  Depending on task execution duration, and quantity of threads executing 
-   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
-   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * 
-   * @deprecated Please use {@link #KeyedExecutorLimiter(Executor, int, String, boolean, boolean, int)}
+   * @deprecated Please use {@link #KeyedExecutorLimiter(Executor, int, String, boolean, boolean)}
    * 
    * @param executor Executor to execute tasks on to
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
-   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism IGNORED AND DEPRECATED
    */
   @Deprecated
   public KeyedExecutorLimiter(Executor executor, int maxConcurrency, 
                               String subPoolName, boolean addKeyToThreadName, 
-                              int expectedParallism) {
+                              @SuppressWarnings("unused") int expectedParallism) {
     this(executor, maxConcurrency, subPoolName, addKeyToThreadName, 
-         ExecutorLimiter.DEFAULT_LIMIT_FUTURE_LISTENER_EXECUTION, expectedParallism);
+         ExecutorLimiter.DEFAULT_LIMIT_FUTURE_LISTENER_EXECUTION);
   }
 
   /**
    * Construct a new {@link KeyedExecutorLimiter} providing the backing executor, the maximum 
    * concurrency per unique key, and how keyed limiter threads should be named.
-   * <p>
-   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
-   * given period of time.  Depending on task execution duration, and quantity of threads executing 
-   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
-   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * <p>
    * This constructor allows you to specify if listeners / 
    * {@link org.threadly.concurrent.future.FutureCallback}'s / functions in 
@@ -135,19 +124,21 @@ public class KeyedExecutorLimiter extends AbstractKeyedLimiter<ExecutorLimiter> 
    * task completes.  Specifying {@code true} will continue to enforce the limit until all listeners 
    * (without an executor) complete.
    * 
+   * @deprecated Please use {@link #KeyedExecutorLimiter(Executor, int, String, boolean, boolean)}
+   * 
    * @param executor Executor to execute tasks on to
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
    * @param limitFutureListenersExecution {@code true} to include listener / mapped functions towards execution limit
-   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism IGNORED AND DEPRECATED
    */
+  @Deprecated
   public KeyedExecutorLimiter(Executor executor, int maxConcurrency, 
                               String subPoolName, boolean addKeyToThreadName,
                               boolean limitFutureListenersExecution, 
-                              int expectedParallism) {
-    super(executor, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution, 
-          expectedParallism);
+                              @SuppressWarnings("unused") int expectedParallism) {
+    this(executor, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution);
   }
   
   @Override

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutor.java
@@ -201,7 +201,7 @@ public class KeyedRateLimiterExecutor {
    * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
    * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * 
-   * @deprecated Please use {@link #KeyedRateLimiterExecutor(SubmitterScheduler, double, long, RejectedExecutionHandler, String, boolean)}
+   * @deprecated Please use constructor without the {@code expectedParallism} field
    * 
    * @since 4.8.0
    * @param scheduler Scheduler to defer executions to

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedSchedulerServiceLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedSchedulerServiceLimiter.java
@@ -92,8 +92,9 @@ public class KeyedSchedulerServiceLimiter extends AbstractKeyedSchedulerLimiter<
   public KeyedSchedulerServiceLimiter(SchedulerService scheduler, int maxConcurrency, 
                                       String subPoolName, boolean addKeyToThreadName, 
                                       boolean limitFutureListenersExecution) {
-    this(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution, 
-         DEFAULT_LOCK_PARALISM);
+    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution);
+    
+    this.scheduler = scheduler;
   }
 
   /**
@@ -105,13 +106,13 @@ public class KeyedSchedulerServiceLimiter extends AbstractKeyedSchedulerLimiter<
    * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
    * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * 
-   * @deprecated Please use {@link #KeyedSchedulerServiceLimiter(SchedulerService, int, String, boolean, boolean, int)}
+   * @deprecated Please use {@link #KeyedSchedulerServiceLimiter(SchedulerService, int, String, boolean, boolean)}
    * 
    * @param scheduler Scheduler to execute and schedule tasks on
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
-   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism IGNORED AND DEPRECATED
    */
   @Deprecated
   public KeyedSchedulerServiceLimiter(SchedulerService scheduler, int maxConcurrency, 
@@ -125,11 +126,6 @@ public class KeyedSchedulerServiceLimiter extends AbstractKeyedSchedulerLimiter<
    * Construct a new {@link KeyedSchedulerServiceLimiter} providing the backing scheduler, the 
    * maximum concurrency per unique key, and how keyed limiter threads should be named.
    * <p>
-   * The parallelism value should be a factor of how many keys are submitted to the pool during any 
-   * given period of time.  Depending on task execution duration, and quantity of threads executing 
-   * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
-   * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
-   * <p>
    * This constructor allows you to specify if listeners / 
    * {@link org.threadly.concurrent.future.FutureCallback}'s / functions in 
    * {@link ListenableFuture#map(java.util.function.Function)} or 
@@ -138,21 +134,22 @@ public class KeyedSchedulerServiceLimiter extends AbstractKeyedSchedulerLimiter<
    * task completes.  Specifying {@code true} will continue to enforce the limit until all listeners 
    * (without an executor) complete.
    * 
+   * @deprecated Please use {@link #KeyedSchedulerServiceLimiter(SchedulerService, int, String, boolean, boolean)}
+   * 
    * @param scheduler Scheduler to execute and schedule tasks on
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
    * @param limitFutureListenersExecution {@code true} to include listener / mapped functions towards execution limit
-   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism IGNORED AND DEPRECATED
    */
+  @Deprecated
   public KeyedSchedulerServiceLimiter(SchedulerService scheduler, int maxConcurrency, 
                                       String subPoolName, boolean addKeyToThreadName, 
                                       boolean limitFutureListenersExecution, 
-                                      int expectedParallism) {
-    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, 
-          limitFutureListenersExecution, expectedParallism);
-    
-    this.scheduler = scheduler;
+                                      @SuppressWarnings("unused") int expectedParallism) {
+    this(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, 
+         limitFutureListenersExecution);
   }
   
   @Override

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedSubmitterSchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/KeyedSubmitterSchedulerLimiter.java
@@ -64,7 +64,7 @@ public class KeyedSubmitterSchedulerLimiter extends AbstractKeyedSchedulerLimite
   public KeyedSubmitterSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
                                         String subPoolName, boolean addKeyToThreadName) {
     this(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, 
-         ExecutorLimiter.DEFAULT_LIMIT_FUTURE_LISTENER_EXECUTION, DEFAULT_LOCK_PARALISM);
+         ExecutorLimiter.DEFAULT_LIMIT_FUTURE_LISTENER_EXECUTION);
   }
 
   /**
@@ -88,8 +88,7 @@ public class KeyedSubmitterSchedulerLimiter extends AbstractKeyedSchedulerLimite
   public KeyedSubmitterSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
                                         String subPoolName, boolean addKeyToThreadName,
                                         boolean limitFutureListenersExecution) {
-    this(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution, 
-         DEFAULT_LOCK_PARALISM);
+    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution);
   }
 
   /**
@@ -101,20 +100,20 @@ public class KeyedSubmitterSchedulerLimiter extends AbstractKeyedSchedulerLimite
    * tasks this value may be able to be smaller than expected.  Higher values result in less lock 
    * contention, but more memory usage.  Most systems will run fine with this anywhere from 4 to 64.
    * 
-   * @deprecated Please use construct by specifying {@code limitFutureListenersExecution}
+   * @deprecated Please use {@link #KeyedSubmitterSchedulerLimiter(SubmitterScheduler, int, String, boolean)}
    * 
    * @param scheduler Scheduler to execute and schedule tasks on
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
-   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism IGNORED AND DEPRECATED
    */
   @Deprecated
   public KeyedSubmitterSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
                                         String subPoolName, boolean addKeyToThreadName, 
-                                        int expectedParallism) {
+                                        @SuppressWarnings("unused") int expectedParallism) {
     this(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, 
-         ExecutorLimiter.DEFAULT_LIMIT_FUTURE_LISTENER_EXECUTION, expectedParallism);
+         ExecutorLimiter.DEFAULT_LIMIT_FUTURE_LISTENER_EXECUTION);
   }
 
   /**
@@ -134,19 +133,21 @@ public class KeyedSubmitterSchedulerLimiter extends AbstractKeyedSchedulerLimite
    * task completes.  Specifying {@code true} will continue to enforce the limit until all listeners 
    * (without an executor) complete.
    * 
+   * @deprecated Please use {@link #KeyedSubmitterSchedulerLimiter(SubmitterScheduler, int, String, boolean, boolean)}
+   * 
    * @param scheduler Scheduler to execute and schedule tasks on
    * @param maxConcurrency Maximum concurrency allowed per task key
    * @param subPoolName Name prefix for sub pools, {@code null} to not change thread names
    * @param addKeyToThreadName If {@code true} the key's .toString() will be added in the thread name
    * @param limitFutureListenersExecution {@code true} to include listener / mapped functions towards execution limit
-   * @param expectedParallism Expected concurrent task addition access, used for performance tuning
+   * @param expectedParallism IGNORED AND DEPRECATED
    */
+  @Deprecated
   public KeyedSubmitterSchedulerLimiter(SubmitterScheduler scheduler, int maxConcurrency, 
                                         String subPoolName, boolean addKeyToThreadName,
                                         boolean limitFutureListenersExecution, 
-                                        int expectedParallism) {
-    super(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, 
-          limitFutureListenersExecution, expectedParallism);
+                                        @SuppressWarnings("unused") int expectedParallism) {
+    this(scheduler, maxConcurrency, subPoolName, addKeyToThreadName, limitFutureListenersExecution);
   }
   
   @Override

--- a/src/test/java/org/threadly/concurrent/lock/StripedLockTest.java
+++ b/src/test/java/org/threadly/concurrent/lock/StripedLockTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class StripedLockTest extends ThreadlyTester {
   private static final int LOCK_QTY = 10;
   

--- a/src/test/java/org/threadly/concurrent/wrapper/KeyDistributedSchedulerKeySchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/KeyDistributedSchedulerKeySchedulerTest.java
@@ -23,7 +23,7 @@ public class KeyDistributedSchedulerKeySchedulerTest extends SubmitterSchedulerI
     public SubmitterScheduler makeSubmitterScheduler(int poolSize, boolean prestartIfAvailable) {
       SubmitterScheduler scheduler = schedulerFactory.makeSubmitterScheduler(poolSize, prestartIfAvailable);
       
-      KeyDistributedScheduler distributor = new KeyDistributedScheduler(poolSize, scheduler);
+      KeyDistributedScheduler distributor = new KeyDistributedScheduler(scheduler);
       
       return distributor.getSchedulerForKey(this);
     }

--- a/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedExecutorLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedExecutorLimiterTest.java
@@ -25,7 +25,7 @@ public class KeyedExecutorLimiterTest extends AbstractKeyedLimiterTest {
 
   @Override
   protected AbstractKeyedLimiter<?> makeLimiter(int limit) {
-    return new KeyedExecutorLimiter(executor, limit, null, true, true, 1);
+    return new KeyedExecutorLimiter(executor, limit, null, true, true);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutorInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedRateLimiterExecutorInterfaceTest.java
@@ -3,22 +3,23 @@ package org.threadly.concurrent.wrapper.limiter;
 import org.threadly.concurrent.PrioritySchedulerTest.PrioritySchedulerFactory;
 import org.threadly.concurrent.SubmitterExecutor;
 import org.threadly.concurrent.SubmitterExecutorInterfaceTest;
+import org.threadly.concurrent.SubmitterScheduler;
 
 @SuppressWarnings("javadoc")
-public class KeyedExecutorLimiterInterfaceTest extends SubmitterExecutorInterfaceTest {
+public class KeyedRateLimiterExecutorInterfaceTest extends SubmitterExecutorInterfaceTest {
   @Override
   protected SubmitterExecutorFactory getSubmitterExecutorFactory() {
-    return new KeyedExecutorLimiterFactory();
+    return new KeyedRateLimiterExecutorFactory();
   }
   
-  private static class KeyedExecutorLimiterFactory implements SubmitterExecutorFactory {
+  private static class KeyedRateLimiterExecutorFactory implements SubmitterExecutorFactory {
     private final PrioritySchedulerFactory schedulerFactory = new PrioritySchedulerFactory();
     
     @Override
     public SubmitterExecutor makeSubmitterExecutor(int poolSize, boolean prestartIfAvailable) {
-      SubmitterExecutor executor = schedulerFactory.makeSubmitterExecutor(poolSize * 2, prestartIfAvailable);
+      SubmitterScheduler scheduler = schedulerFactory.makeSubmitterScheduler(poolSize, prestartIfAvailable);
       
-      return new KeyedExecutorLimiter(executor, poolSize).getSubmitterExecutorForKey(new Object());
+      return new KeyedRateLimiterExecutor(scheduler, 100_000, 600_000, null).getSubmitterExecutorForKey(new Object());
     }
 
     @Override

--- a/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedSchedulerServiceLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedSchedulerServiceLimiterTest.java
@@ -30,7 +30,7 @@ public class KeyedSchedulerServiceLimiterTest extends AbstractKeyedLimiterTest {
 
   @Override
   protected KeyedSchedulerServiceLimiter makeLimiter(int limit) {
-    return new KeyedSchedulerServiceLimiter(scheduler, limit, null, true, true, 1);
+    return new KeyedSchedulerServiceLimiter(scheduler, limit, null, true, true);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedSubmitterSchedulerLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/limiter/KeyedSubmitterSchedulerLimiterTest.java
@@ -24,7 +24,7 @@ public class KeyedSubmitterSchedulerLimiterTest extends AbstractKeyedLimiterTest
 
   @Override
   protected AbstractKeyedLimiter<?> makeLimiter(int limit) {
-    return new KeyedSubmitterSchedulerLimiter(scheduler, limit, null, true, true, 1);
+    return new KeyedSubmitterSchedulerLimiter(scheduler, limit, null, true, true);
   }
   
   @Test


### PR DESCRIPTION
#239 got me thinking...This removes the remaining usage of StripedLock (to be removed in 6.0).  Instead we use ConcurrentHashMap.compute as our method of per-key concurrency control.

In general I think this translates fairly cleanly, and I definitely appreciate removing the extra constructors.

The first commit does have the "use an array to capture results" trick that I hate, and would still like to find an alternative.  But I think in general these is more good than bad in these changes.

@lwahlmeier do you agree?