### PR TITLE
ListenableFuture.flatMap cancel async returned future fix

### DIFF
--- a/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
@@ -284,8 +284,6 @@ public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureC
     synchronized (resultLock) {
       canceled = ! done;
       if (canceled) {
-        this.canceled = true;
-        
         if (interruptThread) {
           Thread runningThread = this.runningThread;
           if (runningThread != null) {
@@ -293,7 +291,7 @@ public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureC
           }
         }
         
-        setDone(null);
+        setCanceled();
       }
     }
     
@@ -329,6 +327,13 @@ public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureC
       result = null;
       failure = null;
     }
+  }
+
+  // MUST be synchronized on resultLock before calling
+  protected void setCanceled() {
+    this.canceled = true;
+    
+    setDone(null);
   }
   
   // MUST be synchronized on resultLock before calling

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureInterfaceTest.java
@@ -483,7 +483,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
   }
   
   @Test
-  public void cancelWhileFlatMappedMapFutureIncompleteRunningInterruptTest() {
+  public void cancelFlatMappedCompletedFutureTest() {
     SingleThreadScheduler sts = new SingleThreadScheduler();
     try {
       ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -182,6 +182,18 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     future.get(100, TimeUnit.MILLISECONDS);
   }
   
+  @Test
+  public void cancelFlatMappedAsyncFutureTest() {
+    ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
+    SettableListenableFuture<Void> asyncSLF = new SettableListenableFuture<>();
+    ListenableFuture<Void> mappedLF = future.flatMap(asyncSLF);
+      
+    future.run();  // complete source future before cancel
+    assertFalse(mappedLF.isDone());
+    assertTrue(mappedLF.cancel(false)); // no interrupt needed, delegate future not started
+    assertTrue(asyncSLF.isCancelled());
+  }
+  
   private class ListenableFutureTaskFactory implements ExecuteOnGetFutureFactory {
     @Override
     public RunnableFuture<?> make(Runnable run) {

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -405,6 +405,17 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     assertTrue(slf.isCancelled());
   }
   
+  @Test
+  public void cancelFlatMappedAsyncFutureTest() {
+    SettableListenableFuture<Void> asyncSLF = new SettableListenableFuture<>();
+    ListenableFuture<Void> mappedLF = slf.flatMap(asyncSLF);
+      
+    slf.setResult(null);  // complete source future before cancel
+    assertFalse(mappedLF.isDone());
+    assertTrue(mappedLF.cancel(false)); // no interrupt needed, delegate future not started
+    assertTrue(asyncSLF.isCancelled());
+  }
+  
   private static class SettableListenableFutureFactory implements ListenableFutureFactory {
     @Override
     public ListenableFuture<?> makeCanceled() {


### PR DESCRIPTION
This improves the behavior when ListenableFuture.flatMap is used, and the mapped future is canceled AFTER the source future has completed, but before the returned future from the mapper has completed.
Previously the returned future from the mapper would not be canceled, though if the source future was already complete before the mapping was attempted this would be canceled.
This change makes the behavior more consistent and ensures that futures intended to be canceled are in fact canceled.