### PR TITLE
Add java 9 jigsaw module definition

### DIFF
--- a/build.shared
+++ b/build.shared
@@ -9,6 +9,30 @@ dependencies {
   testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
+sourceSets {
+  moduleInfo {
+    java {
+      srcDir 'src/module-info/java'
+    }
+  }
+}
+
+compileModuleInfoJava {
+  sourceCompatibility = 9
+  targetCompatibility = 9
+
+  inputs.property("moduleName", moduleName)
+
+  doFirst {
+    classpath += sourceSets.main.compileClasspath
+
+    options.compilerArgs = [
+                            '--module-path', classpath.asPath,
+                            '-d', sourceSets.main.output.classesDirs.asPath
+                           ]
+  }
+}
+
 compileJava {
   options.compilerArgs << "-Xlint:all" << "-Xlint:-deprecation" << "-Werror"
 }
@@ -24,6 +48,9 @@ test {
 }
 
 jar {
+  from sourceSets.main.output
+  from sourceSets.moduleInfo.output
+
   manifest {
     attributes 'Implementation-Title': 'Threadly', 'Implementation-Version': version
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 group = org.threadly
 version = 5.28-SNAPSHOT
+moduleName = org.threadly

--- a/src/module-info/java/module-info.java
+++ b/src/module-info/java/module-info.java
@@ -1,0 +1,3 @@
+module org.threadly {
+  requires java.base;
+}


### PR DESCRIPTION
This should maintain java 8 compatibility, while adding in support for java 9 jigsaw modules.

This should resolve #224 and may be needed for potential future changes to maintain java 10+ compatibility.