### PR TITLE
ListenableFuture: add getRunningStackTrace()

### DIFF
--- a/build.shared
+++ b/build.shared
@@ -11,6 +11,10 @@ dependencies {
 
 compileJava {
   options.compilerArgs << "-Xlint:all" << "-Xlint:-deprecation" << "-Werror"
+
+  if (JavaVersion.current().isJava8()) {
+    options.compilerArgs << "-XDenableSunApiLintControl" << "-Xlint:-sunapi"
+  }
 }
 
 compileTestJava {

--- a/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
@@ -30,4 +30,9 @@ abstract class AbstractImmediateListenableFuture<T> extends AbstractNoncancelabl
       listener.run();
     }
   }
+
+  @Override
+  public StackTraceElement[] getRunningStackTrace() {
+    return null;
+  }
 }

--- a/src/main/java/org/threadly/concurrent/future/CancelDebuggingListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/CancelDebuggingListenableFuture.java
@@ -1,0 +1,112 @@
+package org.threadly.concurrent.future;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.threadly.util.ArgumentVerifier;
+import org.threadly.util.ExceptionUtils;
+import org.threadly.util.SuppressedStackRuntimeException;
+
+/**
+ * Wrapper for a {@link ListenableFuture} to provide enhanced features for debugging the state at 
+ * which at which it was canceled.  When a cancel request comes in this class will attempt to 
+ * record the stack trace of the delegateFuture.  If it then cancels, and is able to get a stack 
+ * trace from the processing thread at time of cancellation, then any requests to {@link #get()} 
+ * that result in a {@link CancellationException}, the exception will have a cause of 
+ * {@link FutureProcessingStack} with the previous stack trace included.
+ *
+ * @since 5.28
+ * @param <T> Type of result provided by this ListenableFuture
+ */
+public class CancelDebuggingListenableFuture<T> implements ListenableFuture<T> {
+  private final ListenableFuture<T> delegateFuture;
+  private StackTraceElement[] cancelStack;
+  
+  /**
+   * Construct a new {@link CancelDebuggingListenableFuture} by wrapping the provided future.
+   * 
+   * @param delegateFuture A non-null future to wrap
+   */
+  public CancelDebuggingListenableFuture(ListenableFuture<T> delegateFuture) {
+    ArgumentVerifier.assertNotNull(delegateFuture, "delegateFuture");
+    
+    this.delegateFuture = delegateFuture;
+    cancelStack = null;
+  }
+
+  @Override
+  public boolean cancel(boolean interrupt) {
+    StackTraceElement[] cancelStack = 
+        delegateFuture.getRunningStackTrace();  // must get stack BEFORE cancel
+    if (delegateFuture.cancel(interrupt)) {
+      this.cancelStack = cancelStack;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public T get() throws InterruptedException, ExecutionException {
+    try {
+      return delegateFuture.get();
+    } catch (CancellationException e) {
+      prepareCancellationException(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public T get(long arg0, TimeUnit arg1) throws InterruptedException, ExecutionException,
+                                                TimeoutException {
+    try {
+      return delegateFuture.get(arg0, arg1);
+    } catch (CancellationException e) {
+      prepareCancellationException(e);
+      throw e;
+    }
+  }
+  
+  private void prepareCancellationException(CancellationException e) {
+    if (cancelStack != null) {
+      Throwable rootCause = ExceptionUtils.getRootCause(e);
+      rootCause.initCause(new FutureProcessingStack(cancelStack));
+    }
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return delegateFuture.isCancelled();
+  }
+
+  @Override
+  public boolean isDone() {
+    return delegateFuture.isDone();
+  }
+
+  @Override
+  public void addListener(Runnable listener, Executor executor,
+                          ListenerOptimizationStrategy optimizeExecution) {
+    delegateFuture.addListener(listener, executor, optimizeExecution);
+  }
+
+  @Override
+  public StackTraceElement[] getRunningStackTrace() {
+    return delegateFuture.getRunningStackTrace();
+  }
+  
+  /**
+   * Throwable that is not thrown, but instead added as a cause to indicate the processing stack 
+   * trace at the time of cancellation.
+   */
+  public static class FutureProcessingStack extends SuppressedStackRuntimeException {
+    private static final long serialVersionUID = 5326874345871027481L;
+
+    protected FutureProcessingStack(StackTraceElement[] cancelStack) {
+      this.setStackTrace(cancelStack);
+    }
+  }
+}

--- a/src/main/java/org/threadly/concurrent/future/FutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureUtils.java
@@ -1688,7 +1688,7 @@ public class FutureUtils {
       
       if (callListeners) {
         // call outside of lock
-        listenerHelper.callListeners();
+        finishCompletion();
       }
       
       return canceled;

--- a/src/main/java/org/threadly/concurrent/future/FutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureUtils.java
@@ -1611,7 +1611,30 @@ public class FutureUtils {
       this.cancelDelegateFuture = lf;
     }
     
+    @Override
+    protected boolean setDone(Throwable cause) {
+      if (super.setDone(cause)) {
+        cancelDelegateFuture = null;
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public StackTraceElement[] getRunningStackTrace() {
+      ListenableFuture<?> delegateFuture = this.cancelDelegateFuture;
+      if (delegateFuture != null) {
+        StackTraceElement[] result = delegateFuture.getRunningStackTrace();
+        if (result != null) {
+          return result;
+        }
+      }
+      return super.getRunningStackTrace();
+    }
+    
     protected boolean cancelRegardlessOfDelegateFutureState(boolean interruptThread) {
+      ListenableFuture<?> cancelDelegateFuture = this.cancelDelegateFuture;
       if (super.cancel(interruptThread)) {
         cancelDelegateFuture.cancel(interruptThread);
         return true;

--- a/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
@@ -670,4 +670,18 @@ public interface ListenableFuture<T> extends Future<T> {
       }, executor, optimizeExecution);
     }
   }
+  
+  /**
+   * A best effort to return the stack trace for for the executing thread of either this future, 
+   * or a future which this depends on through the use of {@link #map(Function)} or similar 
+   * functions.  If there is no thread executing the future yet, or the future has already 
+   * completed, then this will return {@code null}. 
+   * <p>
+   * This is done without locking (though generating a stack trace still requires a JVM safe point), 
+   * so the resulting stack trace is NOT guaranteed to be accurate.  In most cases (particularly 
+   * when blocking) this should be accurate though.
+   * 
+   * @return The stack trace currently executing the future, or {@code null} if unavailable
+   */
+  public StackTraceElement[] getRunningStackTrace();
 }

--- a/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
+++ b/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
@@ -79,4 +79,9 @@ public class ScheduledFutureDelegate<T> implements ListenableScheduledFuture<T> 
                           ListenerOptimizationStrategy optimizeExecution) {
     futureImp.addCallback(callback, executor, optimizeExecution);
   }
+
+  @Override
+  public StackTraceElement[] getRunningStackTrace() {
+    return futureImp.getRunningStackTrace();
+  }
 }

--- a/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
@@ -337,7 +337,7 @@ public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureC
   }
   
   // MUST be synchronized on resultLock before calling
-  private boolean setDone(Throwable cause) {
+  protected boolean setDone(Throwable cause) {
     if (done) {
       if (throwIfAlreadyComplete) {
         throw new IllegalStateException("Future already done", cause);
@@ -400,6 +400,21 @@ public class SettableListenableFuture<T> implements ListenableFuture<T>, FutureC
         return result;
       } else {
         throw new TimeoutException();
+      }
+    }
+  }
+
+  @Override
+  public StackTraceElement[] getRunningStackTrace() {
+    Thread t = runningThread;
+    if (t == null) {
+      return null;
+    } else {
+      StackTraceElement[] stack = t.getStackTrace();
+      if (stack.length == 0 || t != runningThread) {
+        return null;
+      } else {
+        return stack;
       }
     }
   }

--- a/src/main/java/org/threadly/concurrent/future/Watchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/Watchdog.java
@@ -17,6 +17,9 @@ import org.threadly.util.Clock;
  * timeout.  Once the timeout is reached, if the future has not already completed this will 
  * attempt to invoke {@link ListenableFuture#cancel(boolean)}.  The future should then throw a 
  * {@link java.util.concurrent.CancellationException} on a {@link ListenableFuture#get()} call.
+ * <p>
+ * Using {@link CancelDebuggingListenableFuture} to wrap the futures before providing to this class 
+ * can provide an easier understanding of the state of a Future when it was timed out by this class.
  * 
  * @since 4.0.0
  */

--- a/src/main/java/org/threadly/concurrent/future/WatchdogCache.java
+++ b/src/main/java/org/threadly/concurrent/future/WatchdogCache.java
@@ -14,6 +14,9 @@ import org.threadly.util.ArgumentVerifier;
  * A class which handles a collection of  {@link Watchdog} instances.  Because the timeout for 
  * {@link Watchdog} is set in the constructor {@link Watchdog#Watchdog(long, boolean)}, you can 
  * use this class to be more flexible and set the timeout at the time of watching the future.
+ * <p>
+ * Using {@link CancelDebuggingListenableFuture} to wrap the futures before providing to this class 
+ * can provide an easier understanding of the state of a Future when it was timed out by this class.
  * 
  * @since 4.0.0
  */

--- a/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
@@ -329,6 +329,11 @@ abstract class AbstractExecutorServiceWrapper implements ScheduledExecutorServic
                             ListenerOptimizationStrategy optimizeExecution) {
       futureImp.addCallback(callback, executor, optimizeExecution);
     }
+
+    @Override
+    public StackTraceElement[] getRunningStackTrace() {
+      return futureImp.getRunningStackTrace();
+    }
   }
   
   /**

--- a/src/main/java/org/threadly/util/UnsafeAccess.java
+++ b/src/main/java/org/threadly/util/UnsafeAccess.java
@@ -1,0 +1,71 @@
+package org.threadly.util;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import sun.misc.Unsafe;
+
+/**
+ * Used for internal access to UNSAFE actions.  This uses the {@link sun.misc.Unsafe} class to do 
+ * visibility modifications and potentially other low level access.
+ * 
+ * @since 5.28
+ */
+public class UnsafeAccess {
+  private static final Unsafe UNSAFE;
+  private static final Method SET_ACCESSIBLE;
+  
+  static {
+    try {
+      Field theUnsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+      theUnsafeField.setAccessible(true);
+      UNSAFE = (Unsafe) theUnsafeField.get(null);
+      
+      /*Constructor<Unsafe> unsafeConstructor = Unsafe.class.getDeclaredConstructor();
+      unsafeConstructor.setAccessible(true);
+      UNSAFE = unsafeConstructor.newInstance();*/
+    } catch (NoSuchFieldException | SecurityException | 
+             IllegalArgumentException | IllegalAccessException e) {
+      throw new RuntimeException("Unsupported JVM version, please update threadly or file an issue" + 
+                                   "...Could not get Unsafe reference", e);
+    }
+    
+    Method setAccessible;
+    try {
+      // setAccessible0 will avoid SecurityManager permission check, avoiding jdk9+ errors
+      setAccessible = AccessibleObject.class.getDeclaredMethod("setAccessible0", boolean.class);
+      
+      Field methodModifiers = Method.class.getDeclaredField("modifiers");
+      long methodModifiersOffset = UNSAFE.objectFieldOffset(methodModifiers);
+      
+      UNSAFE.getAndSetInt(setAccessible, methodModifiersOffset, Modifier.PUBLIC);
+    } catch (NoSuchMethodException | NoSuchFieldException | SecurityException e) {
+      try {
+        // makes usable for eclipse jvm
+        setAccessible = AccessibleObject.class.getDeclaredMethod("setAccessible", boolean.class);
+      } catch (NoSuchMethodException | SecurityException e1) {
+        e1.initCause(e);
+        throw new RuntimeException("Unsupported JVM version, please update threadly or file an issue" + 
+                                      "...Could not set setAccessible to public", e1);
+      }
+    }
+    SET_ACCESSIBLE = setAccessible;
+  }
+  
+  /**
+   * Takes in a {@link Field} and sets the accessibility to be public.
+   * 
+   * @param f Field to be modified
+   */
+  public static void setFieldToPublic(Field f) {
+    try {
+      SET_ACCESSIBLE.invoke(f, true);
+    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      throw new RuntimeException("Unsupported JVM version, please update threadly or file an issue" + 
+                                    "...Could not set Field to public: " + f, e);
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/future/CancelDebuggingListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/CancelDebuggingListenableFutureTest.java
@@ -1,0 +1,48 @@
+package org.threadly.concurrent.future;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+import org.threadly.concurrent.future.CancelDebuggingListenableFuture.FutureProcessingStack;
+
+@SuppressWarnings("javadoc")
+public class CancelDebuggingListenableFutureTest {
+  @Test
+  public void notStartedTest() throws InterruptedException, ExecutionException {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    CancelDebuggingListenableFuture<Object> debugFuture = new CancelDebuggingListenableFuture<>(slf);
+    
+    assertTrue(debugFuture.cancel(false));
+    
+    try {
+      debugFuture.get();
+      fail("Exception should have thrown");
+    } catch (CancellationException e) {
+      // expected
+      assertNull(e.getCause());
+    }
+  }
+  
+
+  @Test
+  public void withRunningStackTest() throws InterruptedException, ExecutionException {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    slf.setRunningThread(Thread.currentThread());
+    CancelDebuggingListenableFuture<Object> debugFuture = new CancelDebuggingListenableFuture<>(slf);
+    
+    assertTrue(debugFuture.cancel(false));
+    
+    try {
+      debugFuture.get();
+      fail("Exception should have thrown");
+    } catch (CancellationException e) {
+      // expected
+      assertNotNull(e.getCause());
+      assertTrue(e.getCause() instanceof FutureProcessingStack);
+      assertEquals(this.getClass().getName(), e.getCause().getStackTrace()[3].getClassName());
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/future/ImmediateFailureListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateFailureListenableFutureTest.java
@@ -34,4 +34,11 @@ public class ImmediateFailureListenableFutureTest extends ThreadlyTester {
     
     ImmediateListenableFutureTest.failureAddCallbackTest(testFuture, failure);
   }
+  
+  @Test
+  public void getRunningStackTraceTest() {
+    ListenableFuture<?> testFuture = new ImmediateFailureListenableFuture<>(null);
+    
+    ImmediateListenableFutureTest.getRunningStackTraceTest(testFuture);
+  }
 }

--- a/src/test/java/org/threadly/concurrent/future/ImmediateListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateListenableFutureTest.java
@@ -88,4 +88,8 @@ public class ImmediateListenableFutureTest extends ThreadlyTester {
     testFuture.addCallback(tfc, new SameThreadSubmitterExecutor());
     assertTrue(tfc.getLastFailure() == expectedFailure);
   }
+  
+  public static void getRunningStackTraceTest(ListenableFuture<?> testFuture) {
+    assertNull(testFuture.getRunningStackTrace());
+  }
 }

--- a/src/test/java/org/threadly/concurrent/future/ImmediateResultListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateResultListenableFutureTest.java
@@ -82,4 +82,11 @@ public class ImmediateResultListenableFutureTest extends ThreadlyTester {
                                                        (t) -> FutureUtils.immediateFailureFuture(new RuntimeException()), 
                                                        SameThreadSubmitterExecutor.instance(), null));
   }
+  
+  @Test
+  public void getRunningStackTraceTest() {
+    ListenableFuture<?> testFuture = new ImmediateResultListenableFuture<>(null);
+    
+    ImmediateListenableFutureTest.getRunningStackTraceTest(testFuture);
+  }
 }

--- a/src/test/java/org/threadly/concurrent/future/ScheduledFutureDelegateTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ScheduledFutureDelegateTest.java
@@ -182,4 +182,16 @@ public class ScheduledFutureDelegateTest extends ThreadlyTester {
     
     assertEquals(1, future.listeners.size());
   }
+  
+  @Test
+  public void getRunningStackTraceTest() {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    ScheduledFutureDelegate<?> testItem = new ScheduledFutureDelegate<>(slf, null);
+    
+    assertNull(testItem.getRunningStackTrace());
+    
+    slf.setRunningThread(Thread.currentThread());
+
+    assertNotNull(testItem.getRunningStackTrace());
+  }
 }

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -416,6 +416,48 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     assertTrue(asyncSLF.isCancelled());
   }
   
+  @Test
+  public void getRunningStackTraceTest() {
+    assertNull(slf.getRunningStackTrace());
+    
+    slf.setRunningThread(Thread.currentThread());
+    StackTraceElement[] stack = slf.getRunningStackTrace();
+    assertEquals(this.getClass().getName(), stack[2].getClassName());
+
+    slf.setResult(null);
+    assertNull(slf.getRunningStackTrace());
+  }
+  
+  @Test
+  public void getMappedRunningStackTraceTest() {
+    ListenableFuture<Object> mappedFuture = slf.map((o) -> o).map((o) -> null);
+    
+    assertNull(mappedFuture.getRunningStackTrace());
+    
+    slf.setRunningThread(Thread.currentThread());
+    StackTraceElement[] stack = mappedFuture.getRunningStackTrace();
+    assertEquals(this.getClass().getName(), stack[4].getClassName());
+
+    slf.setResult(null);
+    assertNull(mappedFuture.getRunningStackTrace());
+  }
+  
+  @Test
+  public void getFlatMappedRunningStackTraceTest() {
+    ListenableFuture<Object> mappedFuture = 
+        slf.flatMap((o) -> FutureUtils.immediateResultFuture(o))
+           .flatMap((o) -> FutureUtils.immediateResultFuture(null));
+    
+    assertNull(mappedFuture.getRunningStackTrace());
+    
+    slf.setRunningThread(Thread.currentThread());
+    StackTraceElement[] stack = mappedFuture.getRunningStackTrace();
+    assertEquals(this.getClass().getName(), stack[4].getClassName());
+
+    slf.setResult(null);
+    assertNull(mappedFuture.getRunningStackTrace());
+  }
+  
   private static class SettableListenableFutureFactory implements ListenableFutureFactory {
     @Override
     public ListenableFuture<?> makeCanceled() {

--- a/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
+++ b/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
@@ -66,4 +66,9 @@ public class TestFutureImp implements ListenableFuture<Object> {
                           ListenerOptimizationStrategy optimizeExecution) {
     addListener(listener);
   }
+
+  @Override
+  public StackTraceElement[] getRunningStackTrace() {
+    return null;
+  }
 }


### PR DESCRIPTION
This adds the ability to get the stack trace for the thread currently processing the future (or a future which we need the result for currently).
This thread may be `null` if not started, or already completed, or because of a potential inconsistent state as futures are processed.  Despite the lack of guarantees, this should provide some basic abilities for debugging.

The big unfortunate fact here is the inclusion of Unsafe.  We have resisted it for so long, but this brings it in for very frustrating reasons.
We need to be able to access the `runner` field in java.util.concurrent.FutureTask, otherwise we need another native invocation to set the Thread reference for this implementation.
In theory this should be a simple:
```
  Field field = FutureTask.class.getDeclaredField("runner");
  field.setAccessible(true);
```
However java9+ restricts reflection in a way that this wont work.  I tried building jigsaw modules to `export java.base` in a way to allow this, but could never get it to work.

Instead this PR adds in `UnsafeAccess`, which gets a handle on `Unsafe`, and then uses it to make `AccessibleObject.setAccessible0()` visible.  `setAccessible0` allows us to modify access while bypassing the SecurityManager permission checks.  Believe it or not, but the requirements to get Unsafe working in java8 and java9+ seemed to be way simpler than getting SecurityManager to allow us to otherwise modify the permissions.  Though the resulting code code is much more complicated.

The second commit of this PR demonstrates the value by making use of this in the implementation of `CancelDebuggingListenableFuture`.