### PR TITLE
FutureUils.makeComplete/Success/FailureList order and performance improvements

### DIFF
--- a/src/main/java/org/threadly/concurrent/future/FutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureUtils.java
@@ -449,8 +449,8 @@ public class FutureUtils extends InternalFutureUtils {
    * This call is similar to {@link #makeCompleteFuture(Iterable)} in that it will immediately 
    * provide a future that will not be satisfied till all provided futures complete.  
    * <p>
-   * This future provides a list of the completed futures as the result.  The order of this list 
-   * is NOT deterministic.
+   * This future provides a list of the completed futures as the result.  The order of the result 
+   * list will match the order returned by the provided {@link Iterable}.
    * <p>
    * If {@link ListenableFuture#cancel(boolean)} is invoked on the returned future, all provided 
    * futures will attempt to be canceled in the same way.
@@ -470,7 +470,8 @@ public class FutureUtils extends InternalFutureUtils {
    * provide a future that will not be satisfied till all provided futures complete.  
    * <p>
    * This future provides a list of the futures that completed without throwing an exception nor 
-   * were canceled.  The order of the resulting list is NOT deterministic.
+   * were canceled.  The order of the resulting list is NOT deterministic.  If order is needed 
+   * please see {@link #makeCompleteListFuture(Iterable)} and check for results.
    * <p>
    * If {@link ListenableFuture#cancel(boolean)} is invoked on the returned future, all provided 
    * futures will attempt to be canceled in the same way.
@@ -490,7 +491,8 @@ public class FutureUtils extends InternalFutureUtils {
    * provide a future that will not be satisfied till all provided futures complete.  
    * <p>
    * This future provides a list of the futures that failed by either throwing an exception or 
-   * were canceled.  The order of the resulting list is NOT deterministic.
+   * were canceled.  The order of the resulting list is NOT deterministic.  If order is needed 
+   * please see {@link #makeCompleteListFuture(Iterable)} and check for results.
    * <p>
    * If {@link ListenableFuture#cancel(boolean)} is invoked on the returned future, all provided 
    * futures will attempt to be canceled in the same way.
@@ -511,7 +513,7 @@ public class FutureUtils extends InternalFutureUtils {
    * call does NOT block, instead it will return a future which will not complete until all the 
    * provided futures complete.  
    * <p>
-   * The order of the result list is NOT deterministic.
+   * The order of the result list will match the order returned by the provided {@link Iterable}.
    * <p>
    * If called with {@code true} for {@code ignoreFailedFutures}, even if some of the provided 
    * futures finished in error, they will be ignored and just the successful results will be 
@@ -537,9 +539,10 @@ public class FutureUtils extends InternalFutureUtils {
     if (futures == null) {
       return immediateResultFuture(Collections.<T>emptyList());
     }
-    ListenableFuture<List<ListenableFuture<? extends T>>> completeFuture = makeCompleteListFuture(futures);
-    final SettableListenableFuture<List<T>> result;
-    result = new CancelDelegateSettableListenableFuture<>(completeFuture, null);
+    ListenableFuture<List<ListenableFuture<? extends T>>> completeFuture = 
+        makeCompleteListFuture(futures);
+    final SettableListenableFuture<List<T>> result = 
+        new CancelDelegateSettableListenableFuture<>(completeFuture, null);
     
     completeFuture.addCallback(new FutureCallback<List<ListenableFuture<? extends T>>>() {
       @Override

--- a/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
+++ b/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
@@ -575,6 +575,7 @@ public class FutureUtilsTest extends ThreadlyTester {
     }
     
     assertFalse(result.contains(excludedFuture));
+    assertEquals(expected.size() - (excludedFuture == null ? 0 : 1), result.size());
   }
   
   @Test
@@ -833,6 +834,36 @@ public class FutureUtilsTest extends ThreadlyTester {
    
     assertTrue(actualResults.containsAll(expectedResults));
     assertTrue(expectedResults.containsAll(actualResults));
+  }
+  
+  @Test
+  public void makeResultListOrderTest() throws InterruptedException, ExecutionException {
+    List<String> expectedResults = new ArrayList<>(TEST_QTY);
+    List<SettableListenableFuture<String>> futures = new ArrayList<>(TEST_QTY);
+    for (int i = 0; i < TEST_QTY; i++) {
+      String result = StringUtils.makeRandomString(5);
+      expectedResults.add(result);
+      SettableListenableFuture<String> slf = new SettableListenableFuture<>();
+      if (i % 2 == 1) {
+        slf.setResult(result);
+      }
+      futures.add(slf);
+    }
+    
+    ListenableFuture<List<String>> collectionFuture = FutureUtils.makeResultListFuture(futures, false);
+
+    for (int i = 0; i < TEST_QTY; i++) {
+      SettableListenableFuture<String> slf = futures.get(i);
+      if (! slf.isDone()) {
+        slf.setResult(expectedResults.get(i));
+      }
+    }
+    
+    List<String> actualResults = collectionFuture.get();
+
+    for (int i = 0; i < TEST_QTY; i++) {
+      assertEquals(expectedResults.get(i), actualResults.get(i));
+    }
   }
   
   @Test


### PR DESCRIPTION
I got bit by the order of these results being non-deterministic recently.  After spending some time and falling back to an old fashioned `array` I think I am able to provide order determinism without a performance penalty (in fact benchmarks show an improvement here).

Broken down by commit, the first commit provides the bulk of the benefit here.  The second commit edges some of those performance improvements back in order to provide deterministic result ordering for `Success` and `Failure` lists (with the biggest performance losses being in the `Failure` case).

Overall I think this is an improvement all around.  @lwahlmeier let me know if you see any flaws or concerns with this