### PR TITLE
ListenableFuture API changes and deprecations around callbacks and listeners

### DIFF
--- a/src/main/java/org/threadly/concurrent/future/AbstractFutureCallbackFailureHandler.java
+++ b/src/main/java/org/threadly/concurrent/future/AbstractFutureCallbackFailureHandler.java
@@ -7,8 +7,12 @@ package org.threadly.concurrent.future;
  * <p>
  * For simpler construction using a lambda look at {@link FutureCallbackFailureHandler}.
  * 
+ * @deprecated Instead use a {@link java.util.function.Consumer} provided to 
+ *               {@link ListenableFuture#failureCallback(java.util.function.Consumer)}
+ * 
  * @since 4.4.0
  */
+@Deprecated
 public abstract class AbstractFutureCallbackFailureHandler implements FutureCallback<Object> {
   @Override
   public void handleResult(Object result) {

--- a/src/main/java/org/threadly/concurrent/future/AbstractFutureCallbackResultHandler.java
+++ b/src/main/java/org/threadly/concurrent/future/AbstractFutureCallbackResultHandler.java
@@ -11,9 +11,13 @@ package org.threadly.concurrent.future;
  * <p>
  * For a simpler construction using a lambda look at {@link FutureCallbackResultHandler}.
  * 
+ * @deprecated Instead use a {@link java.util.function.Consumer} provided to 
+ *               {@link ListenableFuture#resultCallback(java.util.function.Consumer)}
+ * 
  * @param <T> Type of result returned
  * @since 4.4.0
  */
+@Deprecated
 public abstract class AbstractFutureCallbackResultHandler<T> implements FutureCallback<T> {
   @Override
   public void handleFailure(Throwable t) {

--- a/src/main/java/org/threadly/concurrent/future/AbstractFutureCallbackResultHandler.java
+++ b/src/main/java/org/threadly/concurrent/future/AbstractFutureCallbackResultHandler.java
@@ -6,8 +6,8 @@ package org.threadly.concurrent.future;
  * provided by {@link FutureCallback#handleResult(Object)}.
  * <p>
  * It is important to know that if a failure did occur, and your using this, unless your using 
- * some other means to detect it (like ListenableFuture#addListener(Runnable), you may never know 
- * the computation is complete.
+ * some other means to detect it (like {@link ListenableFuture#listener(Runnable)}, you may never 
+ * know the computation is complete.
  * <p>
  * For a simpler construction using a lambda look at {@link FutureCallbackResultHandler}.
  * 

--- a/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/AbstractImmediateListenableFuture.java
@@ -16,19 +16,23 @@ abstract class AbstractImmediateListenableFuture<T> extends AbstractNoncancelabl
   }
 
   @Override
-  public void addListener(Runnable listener) {
+  public ListenableFuture<T> listener(Runnable listener) {
     listener.run();
+    
+    return this;
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor, 
-                          ListenerOptimizationStrategy optimize) {
+  public ListenableFuture<T> listener(Runnable listener, Executor executor, 
+                                      ListenerOptimizationStrategy optimize) {
     if (executor != null && 
         optimize != ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
       executor.execute(listener);
     } else {
       listener.run();
     }
+    
+    return this;
   }
 
   @Override

--- a/src/main/java/org/threadly/concurrent/future/CancelDebuggingListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/CancelDebuggingListenableFuture.java
@@ -88,9 +88,11 @@ public class CancelDebuggingListenableFuture<T> implements ListenableFuture<T> {
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor,
-                          ListenerOptimizationStrategy optimizeExecution) {
-    delegateFuture.addListener(listener, executor, optimizeExecution);
+  public ListenableFuture<T> listener(Runnable listener, Executor executor,
+                                      ListenerOptimizationStrategy optimizeExecution) {
+    delegateFuture.listener(listener, executor, optimizeExecution);
+    
+    return this;
   }
 
   @Override

--- a/src/main/java/org/threadly/concurrent/future/FutureCallbackExceptionHandlerAdapter.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureCallbackExceptionHandlerAdapter.java
@@ -9,8 +9,12 @@ import org.threadly.util.ExceptionHandler;
  * handle results, as well as have failures mapped you can override 
  * {@link FutureCallback#handleResult(Object)}.
  * 
+ * @deprecated Instead provide the {@link ExceptionHandler} directly into 
+ *               {@link ListenableFuture#failureCallback(java.util.function.Consumer)}
+ * 
  * @since 4.4.0
  */
+@Deprecated
 public class FutureCallbackExceptionHandlerAdapter extends AbstractFutureCallbackFailureHandler {
   private final ExceptionHandler handler;
   

--- a/src/main/java/org/threadly/concurrent/future/FutureCallbackFailureHandler.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureCallbackFailureHandler.java
@@ -12,8 +12,12 @@ import org.threadly.util.ArgumentVerifier;
  * See {@link AbstractFutureCallbackFailureHandler} for a similar implementation except using an 
  * abstract class rather than accepting a lambda.
  * 
+ * @deprecated Instead provide {@link Consumer} directly to 
+ *               {@link ListenableFuture#failureCallback(java.util.function.Consumer)}
+ * 
  * @since 5.0
  */
+@Deprecated
 public class FutureCallbackFailureHandler extends AbstractFutureCallbackFailureHandler {
   private final Consumer<Throwable> failureHandler;
   

--- a/src/main/java/org/threadly/concurrent/future/FutureCallbackResultHandler.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureCallbackResultHandler.java
@@ -11,9 +11,13 @@ import org.threadly.util.ArgumentVerifier;
  * See {@link AbstractFutureCallbackResultHandler} for a similar implementation except using an 
  * abstract class rather than accepting a lambda.
  * 
+ * @deprecated Instead provide {@link Consumer} directly to 
+ *               {@link ListenableFuture#resultCallback(java.util.function.Consumer)}
+ * 
  * @param <T> Type of result returned
  * @since 5.0
  */
+@Deprecated
 public class FutureCallbackResultHandler<T> extends AbstractFutureCallbackResultHandler<T> {
   private final Consumer<T> resultHandler;
   

--- a/src/main/java/org/threadly/concurrent/future/FutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureUtils.java
@@ -259,7 +259,7 @@ public class FutureUtils extends InternalFutureUtils {
    * implementation of {@link #blockTillAllComplete(Iterable)}.  If the listener needs to be 
    * invoked on another thread than one of the provided futures please use 
    * {@link #invokeAfterAllComplete(Collection, Runnable, Executor)}.  Please see 
-   * {@link ListenableFuture#addListener(Runnable)} for more information on execution without an 
+   * {@link ListenableFuture#listener(Runnable)} for more information on execution without an 
    * {@link Executor}.
    * <p>
    * It is critical that the collection is NOT modified while this is invoked.  A change in the 
@@ -286,7 +286,7 @@ public class FutureUtils extends InternalFutureUtils {
    * @param futures Futures that must complete before listener is invoked
    * @param listener Invoked once all the provided futures have completed
    * @param executor Executor (or {@code null}) to invoke listener on, see 
-   *                    {@link ListenableFuture#addListener(Runnable, Executor)}
+   *                    {@link ListenableFuture#listener(Runnable, Executor)}
    */
   public static void invokeAfterAllComplete(Collection<? extends ListenableFuture<?>> futures, 
                                             Runnable listener, Executor executor) {
@@ -300,7 +300,7 @@ public class FutureUtils extends InternalFutureUtils {
         executor.execute(listener);
       }
     } else if (size == 1) {
-      futures.iterator().next().addListener(listener, executor);
+      futures.iterator().next().listener(listener, executor);
     } else {
       AtomicInteger remaining = new AtomicInteger(size);
       Runnable decrementingListener = () -> {
@@ -313,7 +313,7 @@ public class FutureUtils extends InternalFutureUtils {
         }
       };
       for (ListenableFuture<?> lf : futures) {
-        lf.addListener(decrementingListener);
+        lf.listener(decrementingListener);
       }
     }
   }
@@ -434,7 +434,7 @@ public class FutureUtils extends InternalFutureUtils {
     
     final SettableListenableFuture<T> resultFuture = 
         new CancelDelegateSettableListenableFuture<>(efc, null);
-    efc.addCallback(new FutureCallback<Object>() {
+    efc.callback(new FutureCallback<Object>() {
       @Override
       public void handleResult(Object ignored) {
         resultFuture.setResult(result);
@@ -513,7 +513,7 @@ public class FutureUtils extends InternalFutureUtils {
     
     final CancelDelegateSettableListenableFuture<T> resultFuture = 
         new CancelDelegateSettableListenableFuture<>(ffc, null);
-    ffc.addCallback(new FutureCallback<List<ListenableFuture<?>>>() {
+    ffc.callback(new FutureCallback<List<ListenableFuture<?>>>() {
       @Override
       public void handleResult(List<ListenableFuture<?>> failedFutures) {
         if (failedFutures.isEmpty()) {
@@ -642,7 +642,7 @@ public class FutureUtils extends InternalFutureUtils {
     final SettableListenableFuture<List<T>> result = 
         new CancelDelegateSettableListenableFuture<>(completeFuture, null);
     
-    completeFuture.addCallback(new FutureCallback<List<ListenableFuture<? extends T>>>() {
+    completeFuture.callback(new FutureCallback<List<ListenableFuture<? extends T>>>() {
       @Override
       public void handleResult(List<ListenableFuture<? extends T>> resultFutures) {
         boolean needToCancel = false;
@@ -737,7 +737,7 @@ public class FutureUtils extends InternalFutureUtils {
       if (copy) {
         futuresCopy.add(f);
       }
-      f.addCallback(cancelingCallback);
+      f.callback(cancelingCallback);
     }
   }
   
@@ -1108,7 +1108,7 @@ public class FutureUtils extends InternalFutureUtils {
       }
     };
     
-    startingFuture.addCallback(new FailurePropogatingFutureCallback<T>(resultFuture) {
+    startingFuture.callback(new FailurePropogatingFutureCallback<T>(resultFuture) {
       @Override
       public void handleResult(T result) {
         try {
@@ -1123,7 +1123,7 @@ public class FutureUtils extends InternalFutureUtils {
                 scheduler.submitScheduled(cancelCheckingTask, scheduleDelayMillis);
             resultFuture.updateDelegateFuture(lf);
             // TODO - if future is always already complete, this may StackOverflow
-            lf.addCallback(this);  // add this to check again once execution completes
+            lf.callback(this);  // add this to check again once execution completes
           } else {
             // once we have our result, this will end our loop
             resultFuture.setResult(result);
@@ -1253,7 +1253,7 @@ public class FutureUtils extends InternalFutureUtils {
     CancelDelegateSettableListenableFuture<T> resultFuture = 
         new CancelDelegateSettableListenableFuture<>(startingFuture, null);
     
-    startingFuture.addCallback(new FailurePropogatingFutureCallback<T>(resultFuture) {
+    startingFuture.callback(new FailurePropogatingFutureCallback<T>(resultFuture) {
       @Override
       public void handleResult(T result) {
         resultFuture.setRunningThread(Thread.currentThread());
@@ -1283,7 +1283,7 @@ public class FutureUtils extends InternalFutureUtils {
               }
             } else {
               resultFuture.updateDelegateFuture(lf);
-              lf.addCallback(this);
+              lf.callback(this);
               return;
             }
           }

--- a/src/main/java/org/threadly/concurrent/future/FutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/FutureUtils.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -444,7 +445,7 @@ public class FutureUtils extends InternalFutureUtils {
       public void handleFailure(Throwable t) {
         resultFuture.setFailure(t);
       }
-    });
+    }, null, null);
     return resultFuture;
   }
   
@@ -539,7 +540,7 @@ public class FutureUtils extends InternalFutureUtils {
       public void handleFailure(Throwable t) {
         resultFuture.setFailure(t);
       }
-    });
+    }, null, null);
     return resultFuture;
   }
   
@@ -682,7 +683,7 @@ public class FutureUtils extends InternalFutureUtils {
       public void handleFailure(Throwable t) {
         result.setFailure(t);
       }
-    });
+    }, null, null);
     return result;
   }
   
@@ -731,13 +732,13 @@ public class FutureUtils extends InternalFutureUtils {
       futuresCopy = null;
       callbackFutures = futures;
     }
-    CancelOnErrorFutureCallback cancelingCallback = 
+    Consumer<Throwable> cancelingCallback = 
         new CancelOnErrorFutureCallback(callbackFutures, interruptThread);
     for (ListenableFuture<?> f : futures) {
       if (copy) {
         futuresCopy.add(f);
       }
-      f.callback(cancelingCallback);
+      f.failureCallback(cancelingCallback);
     }
   }
   
@@ -1136,7 +1137,7 @@ public class FutureUtils extends InternalFutureUtils {
           resultFuture.setFailure(t);
         }
       }
-    });
+    }, null, null);
     return resultFuture;
   }
   
@@ -1283,7 +1284,7 @@ public class FutureUtils extends InternalFutureUtils {
               }
             } else {
               resultFuture.updateDelegateFuture(lf);
-              lf.callback(this);
+              lf.callback(this, null, null);
               return;
             }
           }
@@ -1300,7 +1301,7 @@ public class FutureUtils extends InternalFutureUtils {
           resultFuture.setRunningThread(null);
         }
       }
-    });
+    }, null, null);
     return resultFuture;
   }
   

--- a/src/main/java/org/threadly/concurrent/future/ImmediateFailureListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateFailureListenableFuture.java
@@ -31,19 +31,23 @@ public class ImmediateFailureListenableFuture<T> extends AbstractImmediateListen
   }
 
   @Override
-  public void addCallback(FutureCallback<? super T> callback) {
+  public ListenableFuture<T> callback(FutureCallback<? super T> callback) {
     callback.handleFailure(failure);
+    
+    return this;
   }
 
   @Override
-  public void addCallback(FutureCallback<? super T> callback, Executor executor, 
-                          ListenerOptimizationStrategy optimize) {
+  public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
+                                      ListenerOptimizationStrategy optimize) {
     if (executor == null | 
         optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
       callback.handleFailure(failure);
     } else {
       executor.execute(new CallbackInvokingTask(callback));
     }
+    
+    return this;
   }
 
   @Override

--- a/src/main/java/org/threadly/concurrent/future/ImmediateFailureListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateFailureListenableFuture.java
@@ -3,6 +3,7 @@ package org.threadly.concurrent.future;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * Completed implementation of {@link ListenableFuture} that will immediately provide a failure 
@@ -31,20 +32,33 @@ public class ImmediateFailureListenableFuture<T> extends AbstractImmediateListen
   }
 
   @Override
-  public ListenableFuture<T> callback(FutureCallback<? super T> callback) {
-    callback.handleFailure(failure);
-    
-    return this;
-  }
-
-  @Override
   public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
                                       ListenerOptimizationStrategy optimize) {
     if (executor == null | 
         optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
       callback.handleFailure(failure);
     } else {
-      executor.execute(new CallbackInvokingTask(callback));
+      executor.execute(() -> callback.handleFailure(failure));
+    }
+    
+    return this;
+  }
+
+  @Override
+  public ListenableFuture<T> resultCallback(Consumer<? super T> callback, Executor executor, 
+                                            ListenerOptimizationStrategy optimize) {
+    // ignored
+    return this;
+  }
+
+  @Override
+  public ListenableFuture<T> failureCallback(Consumer<Throwable> callback, Executor executor, 
+                                             ListenerOptimizationStrategy optimize) {
+    if (executor == null | 
+        optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
+      callback.accept(failure);
+    } else {
+      executor.execute(() -> callback.accept(failure));
     }
     
     return this;
@@ -58,23 +72,5 @@ public class ImmediateFailureListenableFuture<T> extends AbstractImmediateListen
   @Override
   public T get(long timeout, TimeUnit unit) throws ExecutionException {
     throw new ExecutionException(failure);
-  }
-  
-  /**
-   * Small class to invoke callback with stored failure.
-   *
-   * @since 4.9.0
-   */
-  protected class CallbackInvokingTask implements Runnable {
-    protected final FutureCallback<? super T> callback;
-    
-    public CallbackInvokingTask(FutureCallback<? super T> callback) {
-      this.callback = callback;
-    }
-    
-    @Override
-    public void run() {
-      callback.handleFailure(failure);
-    }
   }
 }

--- a/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
@@ -102,19 +102,23 @@ public class ImmediateResultListenableFuture<T> extends AbstractImmediateListena
   }
 
   @Override
-  public void addCallback(FutureCallback<? super T> callback) {
+  public ListenableFuture<T> callback(FutureCallback<? super T> callback) {
     callback.handleResult(result);
+    
+    return this;
   }
 
   @Override
-  public void addCallback(FutureCallback<? super T> callback, Executor executor, 
-                          ListenerOptimizationStrategy optimize) {
+  public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
+                                      ListenerOptimizationStrategy optimize) {
     if (executor == null | 
         optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
       callback.handleResult(result);
     } else {
       executor.execute(new CallbackInvokingTask(callback));
     }
+    
+    return this;
   }
   
   @Override

--- a/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
@@ -541,12 +541,15 @@ public interface ListenableFuture<T> extends Future<T> {
    * <p>
    * The listener from this call will execute on the same thread the result was produced on, or on 
    * the adding thread if the future is already complete.  If the runnable has high complexity, 
-   * consider using {@link #addListener(Runnable, Executor)}.
+   * consider using {@link #listener(Runnable, Executor)}.
+   * 
+   * @deprecated Please use {@link #listener(Runnable)}
    * 
    * @param listener the listener to run when the computation is complete
    */
+  @Deprecated
   default void addListener(Runnable listener) {
-    addListener(listener, null, null);
+    listener(listener, null, null);
   }
   
   /**
@@ -557,11 +560,14 @@ public interface ListenableFuture<T> extends Future<T> {
    * computed the original future (once it is done).  If the future has already completed, the 
    * listener will execute immediately on the thread which is adding the listener.
    * 
+   * @deprecated Please use {@link #listener(Runnable, Executor)}
+   * 
    * @param listener the listener to run when the computation is complete
    * @param executor {@link Executor} the listener should be ran on, or {@code null}
    */
+  @Deprecated
   default void addListener(Runnable listener, Executor executor) {
-    addListener(listener, executor, null);
+    listener(listener, executor, null);
   }
   
   /**
@@ -580,13 +586,18 @@ public interface ListenableFuture<T> extends Future<T> {
    * optimization.  Please see {@link ListenerOptimizationStrategy} javadocs for more specific 
    * details of what optimizations are available.
    * 
+   * @deprecated Please use {@link #listener(Runnable, Executor, ListenerOptimizationStrategy)}
+   * 
    * @since 5.10
    * @param listener the listener to run when the computation is complete
    * @param executor {@link Executor} the listener should be ran on, or {@code null}
    * @param optimizeExecution {@code true} to avoid listener queuing for execution if already on the desired pool
    */
-  public void addListener(Runnable listener, Executor executor, 
-                          ListenerOptimizationStrategy optimizeExecution);
+  @Deprecated
+  default void addListener(Runnable listener, Executor executor, 
+                           ListenerOptimizationStrategy optimizeExecution) {
+    listener(listener, executor, optimizeExecution);
+  }
   
   /**
    * Add a {@link FutureCallback} to be called once the future has completed.  If the future has 
@@ -596,11 +607,14 @@ public interface ListenableFuture<T> extends Future<T> {
    * the adding thread if the future is already complete.  If the callback has high complexity, 
    * consider passing an executor in for it to be called on.
    * 
+   * @deprecated Please use {@link #callback(FutureCallback)}
+   * 
    * @since 1.2.0
    * @param callback to be invoked when the computation is complete
    */
+  @Deprecated
   default void addCallback(FutureCallback<? super T> callback) {
-    addCallback(callback, null, null);
+    callback(callback, null, null);
   }
   
   /**
@@ -611,12 +625,15 @@ public interface ListenableFuture<T> extends Future<T> {
    * computed the original future (once it is done).  If the future has already completed, the 
    * callback will execute immediately on the thread which is adding the callback.
    * 
+   * @deprecated Please use {@link #callback(FutureCallback, Executor)}
+   * 
    * @since 1.2.0
    * @param callback to be invoked when the computation is complete
    * @param executor {@link Executor} the callback should be ran on, or {@code null}
    */
+  @Deprecated
   default void addCallback(FutureCallback<? super T> callback, Executor executor) {
-    addCallback(callback, executor, null);
+    callback(callback, executor, null);
   }
   
   /**
@@ -635,14 +652,134 @@ public interface ListenableFuture<T> extends Future<T> {
    * optimization.  Please see {@link ListenerOptimizationStrategy} javadocs for more specific 
    * details of what optimizations are available.
    * 
+   * @deprecated Please use {@link #callback(FutureCallback, Executor, ListenerOptimizationStrategy)}
+   * 
    * @since 5.10
    * @param callback to be invoked when the computation is complete
    * @param executor {@link Executor} the callback should be ran on, or {@code null}
    * @param optimizeExecution {@code true} to avoid listener queuing for execution if already on the desired pool
    */
-  @SuppressWarnings("deprecation")
+  @Deprecated
   default void addCallback(FutureCallback<? super T> callback, Executor executor, 
                            ListenerOptimizationStrategy optimizeExecution) {
+    callback(callback, executor, optimizeExecution);
+  }
+  
+  /**
+   * Add a listener to be called once the future has completed.  If the future has already 
+   * finished, this will be called immediately.
+   * <p>
+   * The listener from this call will execute on the same thread the result was produced on, or on 
+   * the adding thread if the future is already complete.  If the runnable has high complexity, 
+   * consider using {@link #listener(Runnable, Executor)}.
+   * 
+   * @since 5.34
+   * @param listener the listener to run when the computation is complete
+   * @return Exactly {@code this} instance to add more listeners or other functional operations
+   */
+  default ListenableFuture<T> listener(Runnable listener) {
+    return listener(listener, null, null);
+  }
+  
+  /**
+   * Add a listener to be called once the future has completed.  If the future has already 
+   * finished, this will be called immediately.
+   * <p>
+   * If the provided {@link Executor} is null, the listener will execute on the thread which 
+   * computed the original future (once it is done).  If the future has already completed, the 
+   * listener will execute immediately on the thread which is adding the listener.
+   * 
+   * @since 5.34
+   * @param listener the listener to run when the computation is complete
+   * @param executor {@link Executor} the listener should be ran on, or {@code null}
+   * @return Exactly {@code this} instance to add more listeners or other functional operations
+   */
+  default ListenableFuture<T> listener(Runnable listener, Executor executor) {
+    return listener(listener, executor, null);
+  }
+  
+  /**
+   * Add a listener to be called once the future has completed.  If the future has already 
+   * finished, this will be called immediately.
+   * <p>
+   * If the provided {@link Executor} is null, the listener will execute on the thread which 
+   * computed the original future (once it is done).  If the future has already completed, the 
+   * listener will execute immediately on the thread which is adding the listener.
+   * <p>
+   * Caution should be used when choosing to optimize the listener execution.  If the listener is 
+   * complex, or wanting to be run concurrent, this optimization could prevent that.  In addition 
+   * it will prevent other listeners from potentially being invoked until it completes.  However 
+   * if the listener is small / fast, this can provide significant performance gains.  It should 
+   * also be known that not all {@link ListenableFuture} implementations may be able to do such an 
+   * optimization.  Please see {@link ListenerOptimizationStrategy} javadocs for more specific 
+   * details of what optimizations are available.
+   * 
+   * @since 5.34
+   * @param listener the listener to run when the computation is complete
+   * @param executor {@link Executor} the listener should be ran on, or {@code null}
+   * @param optimizeExecution {@code true} to avoid listener queuing for execution if already on the desired pool
+   * @return Exactly {@code this} instance to add more listeners or other functional operations
+   */
+  public ListenableFuture<T> listener(Runnable listener, Executor executor, 
+                                      ListenerOptimizationStrategy optimizeExecution);
+  
+  /**
+   * Add a {@link FutureCallback} to be called once the future has completed.  If the future has 
+   * already finished, this will be called immediately.
+   * <p>
+   * The callback from this call will execute on the same thread the result was produced on, or on 
+   * the adding thread if the future is already complete.  If the callback has high complexity, 
+   * consider passing an executor in for it to be called on.
+   * 
+   * @since 5.34
+   * @param callback to be invoked when the computation is complete
+   * @return Exactly {@code this} instance to add more callbacks or other functional operations
+   */
+  default ListenableFuture<T> callback(FutureCallback<? super T> callback) {
+    return callback(callback, null, null);
+  }
+  
+  /**
+   * Add a {@link FutureCallback} to be called once the future has completed.  If the future has 
+   * already finished, this will be called immediately.
+   * <p>
+   * If the provided {@link Executor} is null, the callback will execute on the thread which 
+   * computed the original future (once it is done).  If the future has already completed, the 
+   * callback will execute immediately on the thread which is adding the callback.
+   * 
+   * @since 5.34
+   * @param callback to be invoked when the computation is complete
+   * @param executor {@link Executor} the callback should be ran on, or {@code null}
+   * @return Exactly {@code this} instance to add more callbacks or other functional operations
+   */
+  default ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor) {
+    return callback(callback, executor, null);
+  }
+  
+  /**
+   * Add a {@link FutureCallback} to be called once the future has completed.  If the future has 
+   * already finished, this will be called immediately.
+   * <p>
+   * If the provided {@link Executor} is null, the callback will execute on the thread which 
+   * computed the original future (once it is done).  If the future has already completed, the 
+   * callback will execute immediately on the thread which is adding the callback.
+   * <p>
+   * Caution should be used when choosing to optimize the listener execution.  If the listener is 
+   * complex, or wanting to be run concurrent, this optimization could prevent that.  In addition 
+   * it will prevent other listeners from potentially being invoked until it completes.  However 
+   * if the listener is small / fast, this can provide significant performance gains.  It should 
+   * also be known that not all {@link ListenableFuture} implementations may be able to do such an 
+   * optimization.  Please see {@link ListenerOptimizationStrategy} javadocs for more specific 
+   * details of what optimizations are available.
+   * 
+   * @since 5.34
+   * @param callback to be invoked when the computation is complete
+   * @param executor {@link Executor} the callback should be ran on, or {@code null}
+   * @param optimizeExecution {@code true} to avoid listener queuing for execution if already on the desired pool
+   * @return Exactly {@code this} instance to add more callbacks or other functional operations
+   */
+  default ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
+                                       ListenerOptimizationStrategy optimizeExecution) {
     if ((executor == null | optimizeExecution == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) && 
         isDone()) {
       // no need to construct anything, just invoke directly
@@ -658,7 +795,7 @@ public interface ListenableFuture<T> extends Future<T> {
         callback.handleFailure(e);
       }
     } else {
-      addListener(() -> {
+      listener(() -> {
         try {
           callback.handleResult(get());
         } catch (InterruptedException e) {
@@ -672,6 +809,8 @@ public interface ListenableFuture<T> extends Future<T> {
         }
       }, executor, optimizeExecution);
     }
+    
+    return this;
   }
   
   /**

--- a/src/main/java/org/threadly/concurrent/future/ListenableFutureTask.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFutureTask.java
@@ -125,8 +125,8 @@ public class ListenableFutureTask<T> extends FutureTask<T>
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor, 
-                          ListenerOptimizationStrategy optimize) {
+  public ListenableFuture<T> listener(Runnable listener, Executor executor, 
+                                      ListenerOptimizationStrategy optimize) {
     listenerHelper.addListener(listener, 
                                executor == executingExecutor && 
                                    (optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone | 
@@ -134,10 +134,11 @@ public class ListenableFutureTask<T> extends FutureTask<T>
                                  null : executor, 
                                optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone ? 
                                  null : executor);
+    return this;
   }
   
   /**
-   * Can not be overridden, please use {@link #addListener(Runnable)} as an alternative.
+   * Can not be overridden, please use {@link #listener(Runnable)} as an alternative.
    */
   @Override
   protected final void done() {

--- a/src/main/java/org/threadly/concurrent/future/RunnableFutureCallbackAdapter.java
+++ b/src/main/java/org/threadly/concurrent/future/RunnableFutureCallbackAdapter.java
@@ -12,7 +12,7 @@ import org.threadly.util.ArgumentVerifier;
  * and have it convert the future's result into calls into a {@link FutureCallback}.
  * <p>
  * Instead of constructing this class, it is usually much easier to call into 
- * {@link ListenableFuture#addCallback(FutureCallback)}.
+ * {@link ListenableFuture#callback(FutureCallback)}.
  * 
  * @deprecated To be removed without replacement, if you use this, open an issue on github
  * 

--- a/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
+++ b/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
@@ -69,15 +69,19 @@ public class ScheduledFutureDelegate<T> implements ListenableScheduledFuture<T> 
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor, 
-                          ListenerOptimizationStrategy optimizeExecution) {
-    futureImp.addListener(listener, executor, optimizeExecution);
+  public ListenableFuture<T> listener(Runnable listener, Executor executor, 
+                                      ListenerOptimizationStrategy optimizeExecution) {
+    futureImp.listener(listener, executor, optimizeExecution);
+    
+    return this;
   }
 
   @Override
-  public void addCallback(FutureCallback<? super T> callback, Executor executor, 
-                          ListenerOptimizationStrategy optimizeExecution) {
-    futureImp.addCallback(callback, executor, optimizeExecution);
+  public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
+                                      ListenerOptimizationStrategy optimizeExecution) {
+    futureImp.callback(callback, executor, optimizeExecution);
+    
+    return this;
   }
 
   @Override

--- a/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
+++ b/src/main/java/org/threadly/concurrent/future/ScheduledFutureDelegate.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 /**
  * Implementation of the {@link ListenableScheduledFuture} interface.  This design delegates 
@@ -80,6 +81,22 @@ public class ScheduledFutureDelegate<T> implements ListenableScheduledFuture<T> 
   public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
                                       ListenerOptimizationStrategy optimizeExecution) {
     futureImp.callback(callback, executor, optimizeExecution);
+    
+    return this;
+  }
+
+  @Override
+  public ListenableFuture<T> resultCallback(Consumer<? super T> callback, Executor executor, 
+                                            ListenerOptimizationStrategy optimizeExecution) {
+    futureImp.resultCallback(callback, executor, optimizeExecution);
+    
+    return this;
+  }
+
+  @Override
+  public ListenableFuture<T> failureCallback(Consumer<Throwable> callback, Executor executor, 
+                                             ListenerOptimizationStrategy optimizeExecution) {
+    futureImp.failureCallback(callback, executor, optimizeExecution);
     
     return this;
   }

--- a/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/SettableListenableFuture.java
@@ -5,6 +5,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
 import org.threadly.concurrent.event.RunnableListenerHelper;
 import org.threadly.util.Clock;
 import org.threadly.util.StringUtils;
@@ -136,6 +138,73 @@ public class SettableListenableFuture<T> extends AbstractCancellationMessageProv
                                    callback.handleFailure(new CancellationException(getCancellationExceptionMessage()));
                                  } else {
                                    callback.handleResult(result);
+                                 }
+                               }, 
+                               executor == executingExecutor && 
+                                   (optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone | 
+                                    optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatch) ? 
+                                 null : executor, 
+                               optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone ? 
+                                 null : executor);
+    
+    return this;
+  }
+  
+  @Override
+  public ListenableFuture<T> resultCallback(Consumer<? super T> callback, Executor executor, 
+                                            ListenerOptimizationStrategy optimize) {
+    if (executor == null | optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
+      // can't check `done` without synchronizing, but we can check final states optimistically
+      // because a `null` result requires us to check `done` (which needs to synchronize or we may 
+      // see an inconsistent final state), this only works for non-null results
+      if (result != null) {
+        callback.accept(result);
+        return this;
+      }
+    }
+    // This allows us to avoid synchronization (since listeners wont be invoked till final / 
+    // result state has all be set and synced).  So this allows us to avoid synchronization (which 
+    // is important as we don't want to hold the lock while invoking into the callback
+    listenerHelper.addListener(() -> {
+                                 if (failure == null && cancelStateMessage == null) {
+                                   callback.accept(result);
+                                 }
+                               }, 
+                               executor == executingExecutor && 
+                                   (optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone | 
+                                    optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatch) ? 
+                                 null : executor, 
+                               optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone ? 
+                                 null : executor);
+    
+    return this;
+  }
+  
+  @Override
+  public ListenableFuture<T> failureCallback(Consumer<Throwable> callback, Executor executor, 
+                                             ListenerOptimizationStrategy optimize) {
+    if (executor == null | optimize == ListenerOptimizationStrategy.SingleThreadIfExecutorMatchOrDone) {
+      // can't check `done` without synchronizing, but we can check final states optimistically
+      // because a `null` result requires us to check `done` (which needs to synchronize or we may 
+      // see an inconsistent final state), this only works for non-null results
+      if (result != null) {
+        return this;
+      } else if (failure != null) {
+        callback.accept(failure);
+        return this;
+      } else if (cancelStateMessage != null) {
+        callback.accept(new CancellationException(getCancellationExceptionMessage()));
+        return this;
+      }
+    }
+    // This allows us to avoid synchronization (since listeners wont be invoked till final / 
+    // result state has all be set and synced).  So this allows us to avoid synchronization (which 
+    // is important as we don't want to hold the lock while invoking into the callback
+    listenerHelper.addListener(() -> {
+                                 if (failure != null) {
+                                   callback.accept(failure);
+                                 } else if (cancelStateMessage != null) {
+                                   callback.accept(new CancellationException(getCancellationExceptionMessage()));
                                  }
                                }, 
                                executor == executingExecutor && 

--- a/src/main/java/org/threadly/concurrent/future/Watchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/Watchdog.java
@@ -118,7 +118,7 @@ public class Watchdog {
     final FutureWrapper fw = new FutureWrapper(future);
     futures.add(fw);
     // we attempt to remove the future on completion to reduce inspection needed
-    future.addListener(new WrapperRemover(fw), SameThreadSubmitterExecutor.instance());
+    future.listener(new WrapperRemover(fw), SameThreadSubmitterExecutor.instance());
     
     checkRunner.signalToRun();
   }

--- a/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 import org.threadly.concurrent.RunnableContainer;
 import org.threadly.concurrent.SchedulerService;
@@ -330,6 +331,22 @@ abstract class AbstractExecutorServiceWrapper implements ScheduledExecutorServic
     public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
                                         ListenerOptimizationStrategy optimizeExecution) {
       futureImp.callback(callback, executor, optimizeExecution);
+      
+      return this;
+    }
+
+    @Override
+    public ListenableFuture<T> resultCallback(Consumer<? super T> callback, Executor executor, 
+                                              ListenerOptimizationStrategy optimizeExecution) {
+      futureImp.resultCallback(callback, executor, optimizeExecution);
+      
+      return this;
+    }
+
+    @Override
+    public ListenableFuture<T> failureCallback(Consumer<Throwable> callback, Executor executor, 
+                                               ListenerOptimizationStrategy optimizeExecution) {
+      futureImp.failureCallback(callback, executor, optimizeExecution);
       
       return this;
     }

--- a/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
@@ -319,15 +319,19 @@ abstract class AbstractExecutorServiceWrapper implements ScheduledExecutorServic
     }
 
     @Override
-    public void addListener(Runnable listener, Executor executor, 
-                            ListenerOptimizationStrategy optimizeExecution) {
-      futureImp.addListener(listener, executor, optimizeExecution);
+    public ListenableFuture<T> listener(Runnable listener, Executor executor, 
+                                        ListenerOptimizationStrategy optimizeExecution) {
+      futureImp.listener(listener, executor, optimizeExecution);
+      
+      return this;
     }
 
     @Override
-    public void addCallback(FutureCallback<? super T> callback, Executor executor, 
-                            ListenerOptimizationStrategy optimizeExecution) {
-      futureImp.addCallback(callback, executor, optimizeExecution);
+    public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
+                                        ListenerOptimizationStrategy optimizeExecution) {
+      futureImp.callback(callback, executor, optimizeExecution);
+      
+      return this;
     }
 
     @Override

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/ExecutorLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/ExecutorLimiter.java
@@ -214,7 +214,7 @@ public class ExecutorLimiter implements SubmitterExecutor {
       // we will release the limit restriction as soon as the future completes.
       // listeners should be invoked in order, so we just need to be the first listener here
       // We add a `SameThreadSubmitterExecutor` so that we get executed first as if it was async
-      future.addListener(this::releaseExecutionLimit, SameThreadSubmitterExecutor.instance());
+      future.listener(this::releaseExecutionLimit, SameThreadSubmitterExecutor.instance());
 
       if (canRunTask()) {
         executor.execute(task);

--- a/src/test/java/org/threadly/concurrent/future/AbstractFutureCallbackFailureHandlerTest.java
+++ b/src/test/java/org/threadly/concurrent/future/AbstractFutureCallbackFailureHandlerTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class AbstractFutureCallbackFailureHandlerTest extends ThreadlyTester {
   @Test
   public void resultIgnoredTest() {

--- a/src/test/java/org/threadly/concurrent/future/AbstractFutureCallbackResultHandlerTest.java
+++ b/src/test/java/org/threadly/concurrent/future/AbstractFutureCallbackResultHandlerTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class AbstractFutureCallbackResultHandlerTest extends ThreadlyTester {
   @Test
   public void failureIgnoredTest() {

--- a/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 import org.threadly.concurrent.DoNothingRunnable;
@@ -48,6 +49,27 @@ public class ExecuteOnGetFutureTaskTest extends ListenableFutureTaskTest {
     geft.run();
     
     assertTrue(tr.ranOnce());
+  }
+  
+  @Test
+  @Override
+  public void mapStackSizeTest() throws InterruptedException, TimeoutException {
+    ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
+    ListenableFutureInterfaceTest.mapStackDepthTest(future, future, 66, 37);
+  }
+  
+  @Test
+  @Override
+  public void mapFailureStackSize() throws InterruptedException, TimeoutException {
+    ListenableFutureTask<Object> future = makeFutureTask(() -> { throw new RuntimeException(); }, null);
+    ListenableFutureInterfaceTest.mapFailureStackDepthTest(future, future, 66);
+  }
+  
+  @Test
+  @Override
+  public void flatMapStackSizeTest() throws InterruptedException, TimeoutException {
+    ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
+    ListenableFutureInterfaceTest.flatMapStackDepthTest(future, future, 86, 15);
   }
   
   private class Factory implements ExecuteOnGetFutureFactory {

--- a/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
@@ -55,21 +55,21 @@ public class ExecuteOnGetFutureTaskTest extends ListenableFutureTaskTest {
   @Override
   public void mapStackSizeTest() throws InterruptedException, TimeoutException {
     ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
-    ListenableFutureInterfaceTest.mapStackDepthTest(future, future, 66, 37);
+    ListenableFutureInterfaceTest.mapStackDepthTest(future, future, 68, 37);
   }
   
   @Test
   @Override
   public void mapFailureStackSize() throws InterruptedException, TimeoutException {
     ListenableFutureTask<Object> future = makeFutureTask(() -> { throw new RuntimeException(); }, null);
-    ListenableFutureInterfaceTest.mapFailureStackDepthTest(future, future, 66);
+    ListenableFutureInterfaceTest.mapFailureStackDepthTest(future, future, 68);
   }
   
   @Test
   @Override
   public void flatMapStackSizeTest() throws InterruptedException, TimeoutException {
     ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
-    ListenableFutureInterfaceTest.flatMapStackDepthTest(future, future, 86, 15);
+    ListenableFutureInterfaceTest.flatMapStackDepthTest(future, future, 88, 15);
   }
   
   private class Factory implements ExecuteOnGetFutureFactory {

--- a/src/test/java/org/threadly/concurrent/future/FutureCallbackExceptionHandlerAdapterTest.java
+++ b/src/test/java/org/threadly/concurrent/future/FutureCallbackExceptionHandlerAdapterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.threadly.ThreadlyTester;
 import org.threadly.util.TestExceptionHandler;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class FutureCallbackExceptionHandlerAdapterTest extends ThreadlyTester {
   @SuppressWarnings("unused")
   @Test (expected = IllegalArgumentException.class)

--- a/src/test/java/org/threadly/concurrent/future/FutureCallbackFailureHandlerTest.java
+++ b/src/test/java/org/threadly/concurrent/future/FutureCallbackFailureHandlerTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class FutureCallbackFailureHandlerTest extends ThreadlyTester {
   @Test
   public void resultIgnoredTest() {

--- a/src/test/java/org/threadly/concurrent/future/FutureCallbackResultHandlerTest.java
+++ b/src/test/java/org/threadly/concurrent/future/FutureCallbackResultHandlerTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class FutureCallbackResultHandlerTest extends ThreadlyTester {
   @Test
   public void failureIgnoredTest() {

--- a/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
+++ b/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
@@ -261,7 +261,7 @@ public class FutureUtilsTest extends ThreadlyTester {
                                            final List<? extends ListenableFuture<?>> futures) throws InterruptedException, TimeoutException {
     final AsyncVerifier av = new AsyncVerifier();
     
-    f.addListener(new Runnable() {
+    f.listener(new Runnable() {
       @Override
       public void run() {
         av.assertTrue(f.isDone());
@@ -1095,18 +1095,18 @@ public class FutureUtilsTest extends ThreadlyTester {
   }
   
   @Test
-  public void immediateResultFutureAddListenerTest() {
+  public void immediateResultFutureListenerTest() {
     ListenableFuture<?> testFuture = FutureUtils.immediateResultFuture(null);
     
-    ImmediateListenableFutureTest.addListenerTest(testFuture);
+    ImmediateListenableFutureTest.listenerTest(testFuture);
   }
   
   @Test
-  public void immediateResultFutureAddCallbackTest() {
+  public void immediateResultFutureCallbackTest() {
     Object result = new Object();
     ListenableFuture<?> testFuture = FutureUtils.immediateResultFuture(result);
     
-    ImmediateListenableFutureTest.resultAddCallbackTest(testFuture, result);
+    ImmediateListenableFutureTest.resultCallbackTest(testFuture, result);
   }
   
   @Test
@@ -1125,18 +1125,18 @@ public class FutureUtilsTest extends ThreadlyTester {
   }
   
   @Test
-  public void immediateFailureFutureAddListenerTest() {
+  public void immediateFailureFutureListenerTest() {
     ListenableFuture<?> testFuture = FutureUtils.immediateFailureFuture(null);
     
-    ImmediateListenableFutureTest.addListenerTest(testFuture);
+    ImmediateListenableFutureTest.listenerTest(testFuture);
   }
   
   @Test
-  public void immediateFailureFutureAddCallbackTest() {
+  public void immediateFailureFutureCallbackTest() {
     Throwable failure = new Exception();
     ListenableFuture<?> testFuture = FutureUtils.immediateFailureFuture(failure);
     
-    ImmediateListenableFutureTest.failureAddCallbackTest(testFuture, failure);
+    ImmediateListenableFutureTest.failureCallbackTest(testFuture, failure);
   }
 
   @Test

--- a/src/test/java/org/threadly/concurrent/future/ImmediateFailureListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateFailureListenableFutureTest.java
@@ -21,18 +21,18 @@ public class ImmediateFailureListenableFutureTest extends ThreadlyTester {
   }
   
   @Test
-  public void addListenerTest() {
+  public void listenerTest() {
     ListenableFuture<?> testFuture = new ImmediateFailureListenableFuture<>(null);
     
-    ImmediateListenableFutureTest.addListenerTest(testFuture);
+    ImmediateListenableFutureTest.listenerTest(testFuture);
   }
   
   @Test
-  public void addCallbackTest() {
+  public void callbackTest() {
     Throwable failure = new Exception();
     ListenableFuture<?> testFuture = new ImmediateFailureListenableFuture<>(failure);
     
-    ImmediateListenableFutureTest.failureAddCallbackTest(testFuture, failure);
+    ImmediateListenableFutureTest.failureCallbackTest(testFuture, failure);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/future/ImmediateFailureListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateFailureListenableFutureTest.java
@@ -1,5 +1,9 @@
 package org.threadly.concurrent.future;
 
+import static org.junit.Assert.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
 
@@ -33,6 +37,16 @@ public class ImmediateFailureListenableFutureTest extends ThreadlyTester {
     ListenableFuture<?> testFuture = new ImmediateFailureListenableFuture<>(failure);
     
     ImmediateListenableFutureTest.failureCallbackTest(testFuture, failure);
+  }
+  
+  @Test
+  public void resultCallbackTest() {
+    Throwable failure = new Exception();
+    ListenableFuture<?> testFuture = new ImmediateFailureListenableFuture<>(failure);
+    
+    AtomicBoolean ran = new AtomicBoolean();
+    assertTrue(testFuture == testFuture.resultCallback((ignored) -> ran.set(true)));
+    assertFalse(ran.get());
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/future/ImmediateListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateListenableFutureTest.java
@@ -17,17 +17,17 @@ public class ImmediateListenableFutureTest extends ThreadlyTester {
     assertFalse(testFuture.isCancelled());
   }
   
-  public static void addListenerTest(ListenableFuture<?> testFuture) {
+  public static void listenerTest(ListenableFuture<?> testFuture) {
     TestRunnable tr = new TestRunnable();
-    testFuture.addListener(tr);
+    testFuture.listener(tr);
     assertTrue(tr.ranOnce());
     
     tr = new TestRunnable();
-    testFuture.addListener(tr, null);
+    testFuture.listener(tr, null);
     assertTrue(tr.ranOnce());
     
     tr = new TestRunnable();
-    testFuture.addListener(tr, new SameThreadSubmitterExecutor());
+    testFuture.listener(tr, new SameThreadSubmitterExecutor());
     assertTrue(tr.ranOnce());
   }
   
@@ -39,17 +39,17 @@ public class ImmediateListenableFutureTest extends ThreadlyTester {
     assertTrue(testFuture.get(1, TimeUnit.MILLISECONDS) == expectedResult);
   }
   
-  public static void resultAddCallbackTest(ListenableFuture<?> testFuture, Object expectedResult) {
+  public static void resultCallbackTest(ListenableFuture<?> testFuture, Object expectedResult) {
     TestFutureCallback tfc = new TestFutureCallback();
-    testFuture.addCallback(tfc);
+    testFuture.callback(tfc);
     assertTrue(tfc.getLastResult() == expectedResult);
     
     tfc = new TestFutureCallback();
-    testFuture.addCallback(tfc, null);
+    testFuture.callback(tfc, null);
     assertTrue(tfc.getLastResult() == expectedResult);
     
     tfc = new TestFutureCallback();
-    testFuture.addCallback(tfc, new SameThreadSubmitterExecutor());
+    testFuture.callback(tfc, new SameThreadSubmitterExecutor());
     assertTrue(tfc.getLastResult() == expectedResult);
   }
   
@@ -75,17 +75,17 @@ public class ImmediateListenableFutureTest extends ThreadlyTester {
     }
   }
   
-  public static void failureAddCallbackTest(ListenableFuture<?> testFuture, Throwable expectedFailure) {
+  public static void failureCallbackTest(ListenableFuture<?> testFuture, Throwable expectedFailure) {
     TestFutureCallback tfc = new TestFutureCallback();
-    testFuture.addCallback(tfc);
+    testFuture.callback(tfc);
     assertTrue(tfc.getLastFailure() == expectedFailure);
     
     tfc = new TestFutureCallback();
-    testFuture.addCallback(tfc, null);
+    testFuture.callback(tfc, null);
     assertTrue(tfc.getLastFailure() == expectedFailure);
     
     tfc = new TestFutureCallback();
-    testFuture.addCallback(tfc, new SameThreadSubmitterExecutor());
+    testFuture.callback(tfc, new SameThreadSubmitterExecutor());
     assertTrue(tfc.getLastFailure() == expectedFailure);
   }
   

--- a/src/test/java/org/threadly/concurrent/future/ImmediateListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateListenableFutureTest.java
@@ -51,6 +51,14 @@ public class ImmediateListenableFutureTest extends ThreadlyTester {
     tfc = new TestFutureCallback();
     testFuture.callback(tfc, new SameThreadSubmitterExecutor());
     assertTrue(tfc.getLastResult() == expectedResult);
+    
+    tfc = new TestFutureCallback();
+    testFuture.resultCallback(tfc::handleResult, null);
+    assertTrue(tfc.getLastResult() == expectedResult);
+    
+    tfc = new TestFutureCallback();
+    testFuture.resultCallback(tfc::handleResult, new SameThreadSubmitterExecutor());
+    assertTrue(tfc.getLastResult() == expectedResult);
   }
   
   public static void failureTest(ListenableFuture<?> testFuture, Throwable expectedFailure) {
@@ -86,6 +94,14 @@ public class ImmediateListenableFutureTest extends ThreadlyTester {
     
     tfc = new TestFutureCallback();
     testFuture.callback(tfc, new SameThreadSubmitterExecutor());
+    assertTrue(tfc.getLastFailure() == expectedFailure);
+    
+    tfc = new TestFutureCallback();
+    testFuture.failureCallback(tfc::handleFailure, null);
+    assertTrue(tfc.getLastFailure() == expectedFailure);
+    
+    tfc = new TestFutureCallback();
+    testFuture.failureCallback(tfc::handleFailure, new SameThreadSubmitterExecutor());
     assertTrue(tfc.getLastFailure() == expectedFailure);
   }
   

--- a/src/test/java/org/threadly/concurrent/future/ImmediateResultListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateResultListenableFutureTest.java
@@ -39,18 +39,18 @@ public class ImmediateResultListenableFutureTest extends ThreadlyTester {
   }
   
   @Test
-  public void addListenerTest() {
+  public void listenerTest() {
     ListenableFuture<?> testFuture = new ImmediateResultListenableFuture<>(null);
     
-    ImmediateListenableFutureTest.addListenerTest(testFuture);
+    ImmediateListenableFutureTest.listenerTest(testFuture);
   }
   
   @Test
-  public void addCallbackTest() {
+  public void callbackTest() {
     Object result = new Object();
     ListenableFuture<?> testFuture = new ImmediateResultListenableFuture<>(result);
     
-    ImmediateListenableFutureTest.resultAddCallbackTest(testFuture, result);
+    ImmediateListenableFutureTest.resultCallbackTest(testFuture, result);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/future/ImmediateResultListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ImmediateResultListenableFutureTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
@@ -51,6 +52,16 @@ public class ImmediateResultListenableFutureTest extends ThreadlyTester {
     ListenableFuture<?> testFuture = new ImmediateResultListenableFuture<>(result);
     
     ImmediateListenableFutureTest.resultCallbackTest(testFuture, result);
+  }
+  
+  @Test
+  public void failureCallbackTest() {
+    Object result = new Object();
+    ListenableFuture<?> testFuture = new ImmediateResultListenableFuture<>(result);
+    
+    AtomicBoolean ran = new AtomicBoolean();
+    assertTrue(testFuture == testFuture.failureCallback((ignored) -> ran.set(true)));
+    assertFalse(ran.get());
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -53,7 +53,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   public void addNullListenerTest() {
     ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
     
-    future.addListener(null);
+    future.listener(null);
     // no exception should have been thrown
   }
   
@@ -67,7 +67,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     
     TestRunnable listener = new TestRunnable();
     
-    future.addListener(listener);
+    future.listener(listener);
     
     assertEquals(1, future.listenerHelper.registeredListenerCount()); // should now have once now that the runnable has not run yet
     
@@ -79,7 +79,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     
     TestRunnable postRunListener = new TestRunnable();
     
-    future.addListener(postRunListener);
+    future.listener(postRunListener);
     
     assertTrue(postRunListener.ranOnce()); // verify listener was called
     
@@ -88,7 +88,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     // verify run on correct executor
     TestRunnable executorListener = new TestRunnable();
     TestExecutor executor = new TestExecutor();
-    future.addListener(executorListener, executor);
+    future.listener(executorListener, executor);
     
     assertEquals(1, executor.providedRunnables.size());
     assertTrue(executor.providedRunnables.get(0) == executorListener);
@@ -98,7 +98,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   public void cancelRunsListenersTest() {
     TestRunnable tr = new TestRunnable();
     ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
-    future.addListener(tr);
+    future.listener(tr);
     
     future.cancel(false);
     
@@ -111,7 +111,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     
     ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
     
-    future.addListener(listener);
+    future.listener(listener);
     future.run();
     
     assertTrue(listener.ranOnce());
@@ -125,7 +125,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     
     future.run();
     try {
-      future.addListener(listener);
+      future.listener(listener);
       fail("Exception should have thrown");
     } catch (RuntimeException e) {
       // expected
@@ -135,11 +135,11 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   }
   
   @Test
-  public void addCallbackTest() {
+  public void callbackTest() {
     TestCallable tc = new TestCallable();
     ListenableFutureTask<Object> future = makeFutureTask(tc);
     TestFutureCallback tfc = new TestFutureCallback();
-    future.addCallback(tfc);
+    future.callback(tfc);
     
     assertEquals(0, tfc.getCallCount());
     
@@ -150,11 +150,11 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   }
   
   @Test
-  public void addCallbackExecutionExceptionTest() {
+  public void callbackExecutionExceptionTest() {
     RuntimeException failure = new SuppressedStackRuntimeException();
     ListenableFutureTask<Object> future = makeFutureTask(new TestRuntimeFailureRunnable(failure), null);
     TestFutureCallback tfc = new TestFutureCallback();
-    future.addCallback(tfc);
+    future.callback(tfc);
     
     assertEquals(0, tfc.getCallCount());
     

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -150,11 +150,41 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   }
   
   @Test
+  public void resultCallbackTest() {
+    TestCallable tc = new TestCallable();
+    ListenableFutureTask<Object> future = makeFutureTask(tc);
+    TestFutureCallback tfc = new TestFutureCallback();
+    future.resultCallback(tfc::handleResult);
+    
+    assertEquals(0, tfc.getCallCount());
+    
+    future.run();
+    
+    assertEquals(1, tfc.getCallCount());
+    assertTrue(tc.getReturnedResult() == tfc.getLastResult());
+  }
+  
+  @Test
   public void callbackExecutionExceptionTest() {
     RuntimeException failure = new SuppressedStackRuntimeException();
     ListenableFutureTask<Object> future = makeFutureTask(new TestRuntimeFailureRunnable(failure), null);
     TestFutureCallback tfc = new TestFutureCallback();
     future.callback(tfc);
+    
+    assertEquals(0, tfc.getCallCount());
+    
+    future.run();
+    
+    assertEquals(1, tfc.getCallCount());
+    assertTrue(failure == tfc.getLastFailure());
+  }
+  
+  @Test
+  public void failureCallbackExecutionExceptionTest() {
+    RuntimeException failure = new SuppressedStackRuntimeException();
+    ListenableFutureTask<Object> future = makeFutureTask(new TestRuntimeFailureRunnable(failure), null);
+    TestFutureCallback tfc = new TestFutureCallback();
+    future.failureCallback(tfc::handleFailure);
     
     assertEquals(0, tfc.getCallCount());
     
@@ -199,19 +229,19 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   @Test
   public void mapStackSizeTest() throws InterruptedException, TimeoutException {
     ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
-    ListenableFutureInterfaceTest.mapStackDepthTest(future, future, 64, 37);
+    ListenableFutureInterfaceTest.mapStackDepthTest(future, future, 66, 37);
   }
   
   @Test
   public void mapFailureStackSize() throws InterruptedException, TimeoutException {
     ListenableFutureTask<Object> future = makeFutureTask(() -> { throw new RuntimeException(); }, null);
-    ListenableFutureInterfaceTest.mapFailureStackDepthTest(future, future, 64);
+    ListenableFutureInterfaceTest.mapFailureStackDepthTest(future, future, 66);
   }
   
   @Test
   public void flatMapStackSizeTest() throws InterruptedException, TimeoutException {
     ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
-    ListenableFutureInterfaceTest.flatMapStackDepthTest(future, future, 84, 15);
+    ListenableFutureInterfaceTest.flatMapStackDepthTest(future, future, 86, 15);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -197,6 +197,24 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   }
   
   @Test
+  public void mapStackSizeTest() throws InterruptedException, TimeoutException {
+    ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
+    ListenableFutureInterfaceTest.mapStackDepthTest(future, future, 64, 37);
+  }
+  
+  @Test
+  public void mapFailureStackSize() throws InterruptedException, TimeoutException {
+    ListenableFutureTask<Object> future = makeFutureTask(() -> { throw new RuntimeException(); }, null);
+    ListenableFutureInterfaceTest.mapFailureStackDepthTest(future, future, 64);
+  }
+  
+  @Test
+  public void flatMapStackSizeTest() throws InterruptedException, TimeoutException {
+    ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
+    ListenableFutureInterfaceTest.flatMapStackDepthTest(future, future, 84, 15);
+  }
+  
+  @Test
   public void getRunningStackTraceTest() {
     SingleThreadScheduler sts = new SingleThreadScheduler();
     BlockingTestRunnable btr = new BlockingTestRunnable();

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -155,7 +155,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   
   public void listenersCalledTest(boolean failure) {
     TestRunnable tr = new TestRunnable();
-    slf.addListener(tr);
+    slf.listener(tr);
     
     if (failure) {
       slf.setFailure(null);
@@ -167,15 +167,15 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     
     // verify new additions also get called
     tr = new TestRunnable();
-    slf.addListener(tr);
+    slf.listener(tr);
     assertTrue(tr.ranOnce());
   }
   
   @Test
-  public void addCallbackTest() {
+  public void callbackTest() {
     String result = StringUtils.makeRandomString(5);
     TestFutureCallback tfc = new TestFutureCallback();
-    slf.addCallback(tfc);
+    slf.callback(tfc);
     
     assertEquals(0, tfc.getCallCount());
     
@@ -186,10 +186,10 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   }
   
   @Test
-  public void addCallbackExecutionExceptionTest() {
+  public void callbackExecutionExceptionTest() {
     Throwable failure = new Exception();
     TestFutureCallback tfc = new TestFutureCallback();
-    slf.addCallback(tfc);
+    slf.callback(tfc);
     
     assertEquals(0, tfc.getCallCount());
     
@@ -204,7 +204,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     String testResult = StringUtils.makeRandomString(5);
     ListenableFuture<String> resultFuture = new ImmediateResultListenableFuture<>(testResult);
     
-    resultFuture.addCallback(slf);
+    resultFuture.callback(slf);
     
     assertTrue(slf.isDone());
     assertEquals(testResult, slf.get());
@@ -215,7 +215,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     Exception e = new Exception();
     ListenableFuture<String> failureFuture = new ImmediateFailureListenableFuture<>(e);
     
-    failureFuture.addCallback(slf);
+    failureFuture.callback(slf);
     
     assertTrue(slf.isDone());
     try {
@@ -238,7 +238,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   @Test
   public void cancelRunsListenersTest() {
     TestRunnable tr = new TestRunnable();
-    slf.addListener(tr);
+    slf.listener(tr);
     
     slf.cancel(false);
     
@@ -391,7 +391,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     SettableListenableFuture<String> canceledSlf = new SettableListenableFuture<>();
     assertTrue(canceledSlf.cancel(false));
     
-    canceledSlf.addCallback(slf);
+    canceledSlf.callback(slf);
     
     assertTrue(slf.isCancelled());
   }
@@ -400,7 +400,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   public void cancelChainedFutureTest() {
     SettableListenableFuture<String> canceledSlf = new SettableListenableFuture<>();
     
-    canceledSlf.addCallback(slf);
+    canceledSlf.callback(slf);
     assertTrue(canceledSlf.cancel(false));
     
     assertTrue(slf.isCancelled());
@@ -430,7 +430,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   
   private static void verifyCancelationExceptionMessageInCallback(String msg, ListenableFuture<?> lf) throws InterruptedException, TimeoutException {
     AsyncVerifier av = new AsyncVerifier();
-    lf.addCallback(new FutureCallback<Object>() {
+    lf.callback(new FutureCallback<Object>() {
       @Override
       public void handleResult(Object result) {
         av.fail();

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -186,10 +186,38 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   }
   
   @Test
+  public void resultCallbackTest() {
+    String result = StringUtils.makeRandomString(5);
+    TestFutureCallback tfc = new TestFutureCallback();
+    slf.resultCallback(tfc::handleResult);
+    
+    assertEquals(0, tfc.getCallCount());
+    
+    slf.setResult(result);
+    
+    assertEquals(1, tfc.getCallCount());
+    assertTrue(result == tfc.getLastResult());
+  }
+  
+  @Test
   public void callbackExecutionExceptionTest() {
     Throwable failure = new Exception();
     TestFutureCallback tfc = new TestFutureCallback();
     slf.callback(tfc);
+    
+    assertEquals(0, tfc.getCallCount());
+    
+    slf.setFailure(failure);
+    
+    assertEquals(1, tfc.getCallCount());
+    assertTrue(failure == tfc.getLastFailure());
+  }
+  
+  @Test
+  public void failureCallbackExecutionExceptionTest() {
+    Throwable failure = new Exception();
+    TestFutureCallback tfc = new TestFutureCallback();
+    slf.failureCallback(tfc::handleFailure);
     
     assertEquals(0, tfc.getCallCount());
     
@@ -488,13 +516,13 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   @Test
   public void mapStackSizeTest() throws InterruptedException, TimeoutException {
     SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
-    ListenableFutureInterfaceTest.mapStackDepthTest(slf, () -> slf.setResult(null), 61, 47);
+    ListenableFutureInterfaceTest.mapStackDepthTest(slf, () -> slf.setResult(null), 63, 47);
   }
   
   @Test
   public void mapFailureStackSize() throws InterruptedException, TimeoutException {
     SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
-    ListenableFutureInterfaceTest.mapFailureStackDepthTest(slf, () -> slf.setFailure(new RuntimeException()), 61);
+    ListenableFutureInterfaceTest.mapFailureStackDepthTest(slf, () -> slf.setFailure(new RuntimeException()), 63);
   }
   
   @Test
@@ -522,7 +550,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   @Test
   public void flatMapStackSizeTest() throws InterruptedException, TimeoutException {
     SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
-    ListenableFutureInterfaceTest.flatMapStackDepthTest(slf, () -> slf.setResult(null), 81, 17);
+    ListenableFutureInterfaceTest.flatMapStackDepthTest(slf, () -> slf.setResult(null), 83, 17);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -486,6 +486,18 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   }
   
   @Test
+  public void mapStackSizeTest() throws InterruptedException, TimeoutException {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    ListenableFutureInterfaceTest.mapStackDepthTest(slf, () -> slf.setResult(null), 61, 47);
+  }
+  
+  @Test
+  public void mapFailureStackSize() throws InterruptedException, TimeoutException {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    ListenableFutureInterfaceTest.mapFailureStackDepthTest(slf, () -> slf.setFailure(new RuntimeException()), 61);
+  }
+  
+  @Test
   public void flatMapCancelationExceptionMessageAlreadyDoneTest() throws InterruptedException, TimeoutException {
     String msg = StringUtils.makeRandomString(5);
     SettableListenableFuture<Void> slf = new CancelMessageTestSettableListenableFuture(msg);
@@ -505,6 +517,12 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
 
     verifyCancelationExceptionMessageOnGet(msg, mappedFuture);
     verifyCancelationExceptionMessageInCallback(msg, mappedFuture);
+  }
+  
+  @Test
+  public void flatMapStackSizeTest() throws InterruptedException, TimeoutException {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    ListenableFutureInterfaceTest.flatMapStackDepthTest(slf, () -> slf.setResult(null), 81, 17);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
+++ b/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
@@ -53,18 +53,20 @@ public class TestFutureImp implements ListenableFuture<Object> {
   }
 
   @Override
-  public void addListener(Runnable listener) {
+  public ListenableFuture<Object> listener(Runnable listener) {
     if (runListeners) {
       listener.run();
     } else {
       listeners.add(listener);
     }
+    
+    return this;
   }
 
   @Override
-  public void addListener(Runnable listener, Executor executor, 
-                          ListenerOptimizationStrategy optimizeExecution) {
-    addListener(listener);
+  public ListenableFuture<Object> listener(Runnable listener, Executor executor, 
+                                           ListenerOptimizationStrategy optimizeExecution) {
+    return listener(listener);
   }
 
   @Override

--- a/src/test/java/org/threadly/concurrent/wrapper/compatibility/PrioritySchedulerServiceWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/compatibility/PrioritySchedulerServiceWrapperTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.threadly.concurrent.DoNothingRunnable;
 import org.threadly.concurrent.PriorityScheduler;
 import org.threadly.concurrent.StrictPriorityScheduler;
-import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.test.concurrent.TestRunnable;
 
 @SuppressWarnings("javadoc")
@@ -32,8 +31,8 @@ public class PrioritySchedulerServiceWrapperTest extends ScheduledExecutorServic
     try {
       PrioritySchedulerServiceWrapper wrapper = new PrioritySchedulerServiceWrapper(executor);
       TestRunnable futureListener = new TestRunnable();
-      ListenableFuture<?> future = wrapper.submit(DoNothingRunnable.instance());
-      future.addListener(futureListener);
+      wrapper.submit(DoNothingRunnable.instance())
+             .listener(futureListener);
       
       futureListener.blockTillFinished(); // throws exception if never called
     } finally {

--- a/src/test/java/org/threadly/concurrent/wrapper/compatibility/ScheduledFutureDelegateTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/compatibility/ScheduledFutureDelegateTest.java
@@ -136,14 +136,14 @@ public class ScheduledFutureDelegateTest extends ThreadlyTester {
   }
 
   @Test
-  public void addListenerTest() {
+  public void listenerTest() {
     TestFutureImp future = new TestFutureImp(false);
     ScheduledFutureDelegate<?> testItem = new ScheduledFutureDelegate<>(future, null);
     
     TestRunnable firstListener = new TestRunnable();
     TestRunnable secondListener = new TestRunnable();
-    future.addListener(firstListener);
-    testItem.addListener(secondListener);
+    future.listener(firstListener);
+    testItem.listener(secondListener);
     
     assertEquals(2, future.listeners.size());
     assertTrue(future.listeners.contains(firstListener));
@@ -151,14 +151,14 @@ public class ScheduledFutureDelegateTest extends ThreadlyTester {
   }
 
   @Test
-  public void addListenerExecutorTest() {
+  public void listenerExecutorTest() {
     TestFutureImp future = new TestFutureImp(false);
     ScheduledFutureDelegate<?> testItem = new ScheduledFutureDelegate<>(future, null);
     
     TestRunnable firstListener = new TestRunnable();
     TestRunnable secondListener = new TestRunnable();
-    future.addListener(firstListener, null);
-    testItem.addListener(secondListener, null);
+    future.listener(firstListener, null);
+    testItem.listener(secondListener, null);
     
     assertEquals(2, future.listeners.size());
     assertTrue(future.listeners.contains(firstListener));
@@ -166,22 +166,22 @@ public class ScheduledFutureDelegateTest extends ThreadlyTester {
   }
   
   @Test
-  public void addCallbackAlreadyDoneTest() {
+  public void callbackAlreadyDoneTest() {
     TestFutureImp future = new TestFutureImp(false);
     ScheduledFutureDelegate<?> testItem = new ScheduledFutureDelegate<>(future, null);
     
-    testItem.addCallback(new TestFutureCallback());
+    testItem.callback(new TestFutureCallback());
     
     assertEquals(0, future.listeners.size());
   }
   
   @Test
-  public void addCallbackExecutorTest() {
+  public void callbackExecutorTest() {
     TestFutureImp future = new TestFutureImp(false);
     ScheduledFutureDelegate<?> testItem = new ScheduledFutureDelegate<>(future, null);
     
-    testItem.addCallback(new TestFutureCallback(), 
-                         SameThreadSubmitterExecutor.instance()); // trick so already-done optimization does not kick in
+    testItem.callback(new TestFutureCallback(), 
+                      SameThreadSubmitterExecutor.instance()); // trick so already-done optimization does not kick in
     
     assertEquals(1, future.listeners.size());
   }

--- a/src/test/java/org/threadly/concurrent/wrapper/limiter/ExecutorLimiterTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/limiter/ExecutorLimiterTest.java
@@ -242,7 +242,7 @@ public class ExecutorLimiterTest extends SubmitterExecutorInterfaceTest {
         @Override
         public void run() {
           if (Thread.currentThread() == callingThread) {
-            limiter.submit(DoNothingRunnable.instance()).addListener(this);
+            limiter.submit(DoNothingRunnable.instance()).listener(this);
           } else {
             btr.run();
           }


### PR DESCRIPTION
The first commit changes ListenableFuture.addCallback / addListener replaced with `callback` and `listener`

The motivation around this change is not really to make the function names more concise.  Instead it's more to allow these functions to return `this` (which we can't do without breaking byte code compatibility).
By returning `this` for `listener` and `callback` we can continue to use our more functional style similar to the other `map` and `flatMap` like functions.

The last commit is to add `resultCallback(Consumer<T>)` and `failureCallback(Consumer<Throwable>)` as replacements to the classes `AbstractFutureCallback(Result|Failure)Handler` and `FutureCallback(Result|Failure)Handler`.  This should be a bit more concise and allows for potential optimizations when only one type is needed.  In addition we can also deprecate `FutureCallbackExceptionHandlerAdapter` since `FutureCallback` already extends `Consumer<Throwable>`, allowing them to be provided directly into `failureCallback`.

There are also some minor changes around here to make sure we are not increasing the stack depths while trying to make sure the code remains maintainable with minimal duplication.

@lwahlmeier I want your opinions here.  I don't take these API changes lightly as I know they will be high friction for a lot of consumers of the library (these are some of the oldest and most used part of the library).  I do feel like despite the heartburn these may be valuable changes as they make the Future's easier to use, as well as reduce the classes / code / complexity within the library.  It also provides some potential for additional optimizations as you see here.