### PR TITLE
Add FilteredStackProfiler.

### DIFF
--- a/src/main/java/org/threadly/util/debug/FilteredStackProfiler.java
+++ b/src/main/java/org/threadly/util/debug/FilteredStackProfiler.java
@@ -1,0 +1,191 @@
+package org.threadly.util.debug;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.regex.Pattern;
+
+/**
+ * This class functions very similar to the {@link Profiler}.  The difference between the two is
+ * that this class only counts samples whose stack trace contains an entry matching a particular
+ * pattern.
+ *
+ * <p>This is useful for drilling down into particular regions of code within an application also
+ * busy doing other things; for exmaple, a production HTTP API may have many endpoints, but you
+ * only want to know what one of them spends its time doing.
+ *
+ * @since 5.35.0
+ */
+public class FilteredStackProfiler extends Profiler {
+  protected final FilteredStackProfileStorage filteredThreadStore;
+
+  /**
+   * Constructs a new profiler instance.  The only way to get results from this instance is to
+   * call {@code #dump()} with a provided output stream to get the results to.
+   *
+   * @param pattern Only stack traces where the string representation of a
+   * {@link StackTraceElement} matches this regular expression will be counted.
+   */
+  public FilteredStackProfiler(String pattern) {
+    this(Pattern.compile(pattern));
+  }
+
+  /**
+   * Constructs a new profiler instance.  The only way to get results from this instance is to
+   * call {@code #dump()} with a provided output stream to get the results to.
+   *
+   * @param pattern Only stack traces where the string representation of a
+   * {@link StackTraceElement} matches this regular expression will be counted.
+   */
+  public FilteredStackProfiler(Pattern pattern) {
+    this(DEFAULT_POLL_INTERVAL_IN_MILLIS, pattern);
+  }
+
+  /**
+   * Constructs a new profiler instance.  The only way to get results from this instance is to
+   * call {@code #dump()} with a provided output stream to get the results to.
+   *
+   * @param pollIntervalInMs frequency to check running threads
+   * @param pattern Only stack traces where the string representation of a
+   * {@link StackTraceElement} matches this regular expression will be counted.
+   */
+  public FilteredStackProfiler(int pollIntervalInMs, String pattern) {
+    this(pollIntervalInMs, Pattern.compile(pattern));
+  }
+
+  /**
+   * Constructs a new profiler instance.  The only way to get results from this instance is to
+   * call {@code #dump()} with a provided output stream to get the results to.
+   *
+   * @param pollIntervalInMs frequency to check running threads
+   * @param pattern Only stack traces where the string representation of a
+   * {@link StackTraceElement} matches this regular expression will be counted.
+   */
+  public FilteredStackProfiler(int pollIntervalInMs, Pattern pattern) {
+    super(new FilteredStackProfileStorage(pollIntervalInMs, pattern));
+
+    this.filteredThreadStore = (FilteredStackProfileStorage)super.pStore;
+  }
+
+  /**
+   * Extending class of {@link ProfileStorage} this overrides
+   * {@link #getProfileThreadsIterator()}.  It controls it so that only samples which match the
+   * desired pattern are returned to the profiler.
+   *
+   * @since 3.35.0
+   */
+  protected static class FilteredStackProfileStorage extends ProfileStorage {
+    protected final Pattern pattern;
+
+    public FilteredStackProfileStorage(int pollIntervalInMs, Pattern pattern) {
+      super(pollIntervalInMs);
+
+      if (null == pattern) {
+        throw new NullPointerException("pattern");
+      }
+
+      this.pattern = pattern;
+    }
+
+    @Override
+    protected Iterator<? extends ThreadSample> getProfileThreadsIterator() {
+      return new FilteredStackSampleIterator(super.getProfileThreadsIterator(), pattern);
+    }
+  }
+
+  /**
+   * Adapts a {@code ThreadSample} iterator to only return samples matching the desired pattern.
+   */
+  private static class FilteredStackSampleIterator implements Iterator<ThreadSample> {
+    private final Iterator<? extends ThreadSample> delegate;
+    private final Pattern pattern;
+    private ThreadSample next;
+
+    FilteredStackSampleIterator(
+      Iterator<? extends ThreadSample> delegate,
+      Pattern pattern
+    ) {
+      this.delegate = delegate;
+      this.pattern = pattern;
+
+      findNext();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return null != next;
+    }
+
+    @Override
+    public ThreadSample next() {
+      if (null == next) {
+        throw new NoSuchElementException();
+      }
+
+      ThreadSample toReturn = next;
+      findNext();
+      return toReturn;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+
+    private void findNext() {
+      while (delegate.hasNext()) {
+        // We need to cache the stack trace so that it doesn't change between filtering it and
+        // recording it in the profiler.
+        next = new CachedThreadSample(delegate.next());
+        for (StackTraceElement element: next.getStackTrace()) {
+          if (pattern.matcher(element.toString()).find()) {
+            return;
+          }
+        }
+      }
+
+      next = null;
+    }
+  }
+
+  /**
+   * A {@code ThreadSample} with a precalculated stack trace.
+   *
+   * <p>This is used internally so that the stack trace is the same when we apply the filter and
+   * then later add it to the profile.
+   */
+  private static class CachedThreadSample implements ThreadSample {
+    private final Thread thread;
+    private final StackTraceElement[] stackTrace;
+
+    CachedThreadSample(ThreadSample orig) {
+      this.thread = orig.getThread();
+      this.stackTrace = orig.getStackTrace();
+    }
+
+    @Override
+    public Thread getThread() {
+      return thread;
+    }
+
+    @Override
+    public StackTraceElement[] getStackTrace() {
+      return stackTrace;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      } else if (o instanceof ThreadSample) {
+        return ((ThreadSample)o).getThread() == thread;
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return thread.hashCode();
+    }
+  }
+}

--- a/src/test/java/org/threadly/util/debug/FilteredStackProfilerTest.java
+++ b/src/test/java/org/threadly/util/debug/FilteredStackProfilerTest.java
@@ -1,0 +1,99 @@
+package org.threadly.util.debug;
+
+import static org.junit.Assert.*;
+
+import java.util.Iterator;
+import java.util.regex.Pattern;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.threadly.util.debug.Profiler.ThreadSample;
+
+@SuppressWarnings("javadoc")
+public class FilteredStackProfilerTest extends ProfilerTest {
+  private static final int POLL_INTERVAL = 1;
+  private static final int WAIT_TIME_FOR_COLLECTION = 50;
+
+  @Before
+  @Override
+  public void setup() {
+    profiler = new FilteredStackProfiler(".");
+  }
+
+  @Test
+  @Override
+  public void constructorTest() {
+    int testPollInterval = Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS * 10;
+    FilteredStackProfiler p;
+
+    p = new FilteredStackProfiler("^org\\.threadly\\.");
+    assertNotNull(p.filteredThreadStore.threadTraces);
+    assertTrue(p.filteredThreadStore.threadTraces.isEmpty());
+    assertEquals(Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS, p.filteredThreadStore.pollIntervalInMs);
+    assertNull(p.filteredThreadStore.collectorThread.get());
+    assertNull(p.filteredThreadStore.dumpingThread);
+    assertNotNull(p.startStopLock);
+    assertTrue(p.filteredThreadStore.pattern.matcher("org.threadly.SomeClass.run").find());
+    assertFalse(p.filteredThreadStore.pattern.matcher("java.lang.Thread.run").find());
+
+    p = new FilteredStackProfiler(Pattern.compile("^org\\.threadly\\."));
+    assertNotNull(p.filteredThreadStore.threadTraces);
+    assertTrue(p.filteredThreadStore.threadTraces.isEmpty());
+    assertEquals(Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS, p.filteredThreadStore.pollIntervalInMs);
+    assertNull(p.filteredThreadStore.collectorThread.get());
+    assertNull(p.filteredThreadStore.dumpingThread);
+    assertNotNull(p.startStopLock);
+    assertTrue(p.filteredThreadStore.pattern.matcher("org.threadly.SomeClass.run").find());
+    assertFalse(p.filteredThreadStore.pattern.matcher("java.lang.Thread.run").find());
+
+    p = new FilteredStackProfiler(testPollInterval, "^org\\.threadly\\.");
+    assertNotNull(p.filteredThreadStore.threadTraces);
+    assertTrue(p.filteredThreadStore.threadTraces.isEmpty());
+    assertEquals(testPollInterval, p.filteredThreadStore.pollIntervalInMs);
+    assertNull(p.filteredThreadStore.collectorThread.get());
+    assertNull(p.filteredThreadStore.dumpingThread);
+    assertNotNull(p.startStopLock);
+    assertTrue(p.filteredThreadStore.pattern.matcher("org.threadly.SomeClass.run").find());
+    assertFalse(p.filteredThreadStore.pattern.matcher("java.lang.Thread.run").find());
+
+    p = new FilteredStackProfiler(testPollInterval, Pattern.compile("^org\\.threadly\\."));
+    assertNotNull(p.filteredThreadStore.threadTraces);
+    assertTrue(p.filteredThreadStore.threadTraces.isEmpty());
+    assertEquals(testPollInterval, p.filteredThreadStore.pollIntervalInMs);
+    assertNull(p.filteredThreadStore.collectorThread.get());
+    assertNull(p.filteredThreadStore.dumpingThread);
+    assertNotNull(p.startStopLock);
+    assertTrue(p.filteredThreadStore.pattern.matcher("org.threadly.SomeClass.run").find());
+    assertFalse(p.filteredThreadStore.pattern.matcher("java.lang.Thread.run").find());
+  }
+
+  @Test
+  public void getProfileThreadsIteratorEmptyTest() {
+    FilteredStackProfiler profiler = new FilteredStackProfiler("^no matching stack frames$");
+    Iterator<?> it = profiler.pStore.getProfileThreadsIterator();
+
+    assertNotNull(it);
+    assertFalse(it.hasNext());
+  }
+
+  @Test
+  public void getProfileThreadsIteratorTest() {
+    // This should only see this one thread executing this one particular test
+    FilteredStackProfiler profiler = new FilteredStackProfiler(
+      "^org\\.threadly\\.util\\.debug\\.FilteredStackProfilerTest\\.getProfileThreadsIteratorTest");
+    Iterator<? extends ThreadSample> it = profiler.pStore.getProfileThreadsIterator();
+
+    assertNotNull(it);
+    assertTrue(it.hasNext());
+    assertTrue(it.next().getThread() == Thread.currentThread());
+    assertFalse(it.hasNext());
+  }
+
+  @Override
+  @SuppressWarnings("unused")
+  @Test(expected = IllegalArgumentException.class)
+  public void constructorFail() {
+    new FilteredStackProfiler(-1, ".");
+  }
+}

--- a/src/test/java/org/threadly/util/debug/FilteredStackProfilerTest.java
+++ b/src/test/java/org/threadly/util/debug/FilteredStackProfilerTest.java
@@ -34,18 +34,22 @@ public class FilteredStackProfilerTest extends ProfilerTest {
     assertNull(p.filteredThreadStore.collectorThread.get());
     assertNull(p.filteredThreadStore.dumpingThread);
     assertNotNull(p.startStopLock);
-    assertTrue(p.filteredThreadStore.pattern.matcher("org.threadly.SomeClass.run").find());
-    assertFalse(p.filteredThreadStore.pattern.matcher("java.lang.Thread.run").find());
+    assertTrue(p.filteredThreadStore.filter.test(
+                 new StackTraceElement("org.threadly.SomeClass", "run", null, 42)));
+    assertFalse(p.filteredThreadStore.filter.test(
+                  new StackTraceElement("java.lang.Thread", "run", null, 456)));
 
-    p = new FilteredStackProfiler(Pattern.compile("^org\\.threadly\\."));
+    p = new FilteredStackProfiler(e -> e.getClassName().startsWith("org.threadly."));
     assertNotNull(p.filteredThreadStore.threadTraces);
     assertTrue(p.filteredThreadStore.threadTraces.isEmpty());
     assertEquals(Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS, p.filteredThreadStore.pollIntervalInMs);
     assertNull(p.filteredThreadStore.collectorThread.get());
     assertNull(p.filteredThreadStore.dumpingThread);
     assertNotNull(p.startStopLock);
-    assertTrue(p.filteredThreadStore.pattern.matcher("org.threadly.SomeClass.run").find());
-    assertFalse(p.filteredThreadStore.pattern.matcher("java.lang.Thread.run").find());
+    assertTrue(p.filteredThreadStore.filter.test(
+                 new StackTraceElement("org.threadly.SomeClass", "run", null, 42)));
+    assertFalse(p.filteredThreadStore.filter.test(
+                  new StackTraceElement("java.lang.Thread", "run", null, 456)));
 
     p = new FilteredStackProfiler(testPollInterval, "^org\\.threadly\\.");
     assertNotNull(p.filteredThreadStore.threadTraces);
@@ -54,18 +58,23 @@ public class FilteredStackProfilerTest extends ProfilerTest {
     assertNull(p.filteredThreadStore.collectorThread.get());
     assertNull(p.filteredThreadStore.dumpingThread);
     assertNotNull(p.startStopLock);
-    assertTrue(p.filteredThreadStore.pattern.matcher("org.threadly.SomeClass.run").find());
-    assertFalse(p.filteredThreadStore.pattern.matcher("java.lang.Thread.run").find());
+    assertTrue(p.filteredThreadStore.filter.test(
+                 new StackTraceElement("org.threadly.SomeClass", "run", null, 42)));
+    assertFalse(p.filteredThreadStore.filter.test(
+                  new StackTraceElement("java.lang.Thread", "run", null, 456)));
 
-    p = new FilteredStackProfiler(testPollInterval, Pattern.compile("^org\\.threadly\\."));
+    p = new FilteredStackProfiler(
+      testPollInterval, e -> e.getClassName().startsWith("org.threadly."));
     assertNotNull(p.filteredThreadStore.threadTraces);
     assertTrue(p.filteredThreadStore.threadTraces.isEmpty());
     assertEquals(testPollInterval, p.filteredThreadStore.pollIntervalInMs);
     assertNull(p.filteredThreadStore.collectorThread.get());
     assertNull(p.filteredThreadStore.dumpingThread);
     assertNotNull(p.startStopLock);
-    assertTrue(p.filteredThreadStore.pattern.matcher("org.threadly.SomeClass.run").find());
-    assertFalse(p.filteredThreadStore.pattern.matcher("java.lang.Thread.run").find());
+    assertTrue(p.filteredThreadStore.filter.test(
+                 new StackTraceElement("org.threadly.SomeClass", "run", null, 42)));
+    assertFalse(p.filteredThreadStore.filter.test(
+                  new StackTraceElement("java.lang.Thread", "run", null, 456)));
   }
 
   @Test


### PR DESCRIPTION
This provides a fairly simple way to profile a specific part of a busy
application.

~~I used java.util.regex for matching stack trace elements, which is
usually something I'd avoid. However, it didn't seem like such a bad
option here since the strings to be matched will always be small and
people are unlikely to try to use patterns with pathological performance
characteristics.~~

~~Another option might be to take a `Predicate<StackTraceElement>`, which
is more flexible but introduces the liability of calling back into user
code.~~