### PR TITLE
FilteredStackProfiler: Predicate test StackTraceElement[]

### DIFF
--- a/src/main/java/org/threadly/util/debug/FilteredStackProfiler.java
+++ b/src/main/java/org/threadly/util/debug/FilteredStackProfiler.java
@@ -142,7 +142,7 @@ public class FilteredStackProfiler extends Profiler {
       while (delegate.hasNext()) {
         // We need to cache the stack trace so that it doesn't change between filtering it and
         // recording it in the profiler.
-        next = new CachedThreadSample(delegate.next());
+        next = delegate.next();
         for (StackTraceElement element : next.getStackTrace()) {
           if (accept(element)) {
             return;
@@ -161,50 +161,6 @@ public class FilteredStackProfiler extends Profiler {
         // Be conservative and include the data
         return true;
       }
-    }
-  }
-
-  /**
-   * A {@code ThreadSample} with a precalculated stack trace.
-   * <p>
-   * This is used internally so that the stack trace is the same when we apply the filter and
-   * then later add it to the profile.
-   * 
-   * @since 3.35
-   */
-  private static class CachedThreadSample implements ThreadSample {
-    private final Thread thread;
-    private final StackTraceElement[] stackTrace;
-
-    CachedThreadSample(ThreadSample orig) {
-      this.thread = orig.getThread();
-      this.stackTrace = orig.getStackTrace();
-    }
-
-    @Override
-    public Thread getThread() {
-      return thread;
-    }
-
-    @Override
-    public StackTraceElement[] getStackTrace() {
-      return stackTrace;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (o == this) {
-        return true;
-      } else if (o instanceof ThreadSample) {
-        return ((ThreadSample)o).getThread() == thread;
-      } else {
-        return false;
-      }
-    }
-
-    @Override
-    public int hashCode() {
-      return thread.hashCode();
     }
   }
 }

--- a/src/test/java/org/threadly/util/debug/FilteredStackProfilerTest.java
+++ b/src/test/java/org/threadly/util/debug/FilteredStackProfilerTest.java
@@ -2,9 +2,8 @@ package org.threadly.util.debug;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.Iterator;
-import java.util.regex.Pattern;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,9 +11,6 @@ import org.threadly.util.debug.Profiler.ThreadSample;
 
 @SuppressWarnings("javadoc")
 public class FilteredStackProfilerTest extends ProfilerTest {
-  private static final int POLL_INTERVAL = 1;
-  private static final int WAIT_TIME_FOR_COLLECTION = 50;
-
   @Before
   @Override
   public void setup() {
@@ -35,11 +31,11 @@ public class FilteredStackProfilerTest extends ProfilerTest {
     assertNull(p.filteredThreadStore.dumpingThread);
     assertNotNull(p.startStopLock);
     assertTrue(p.filteredThreadStore.filter.test(
-                 new StackTraceElement("org.threadly.SomeClass", "run", null, 42)));
+                 new StackTraceElement[] { new StackTraceElement("org.threadly.SomeClass", "run", null, 42) }));
     assertFalse(p.filteredThreadStore.filter.test(
-                  new StackTraceElement("java.lang.Thread", "run", null, 456)));
+                  new StackTraceElement[] { new StackTraceElement("java.lang.Thread", "run", null, 456) }));
 
-    p = new FilteredStackProfiler(e -> e.getClassName().startsWith("org.threadly."));
+    p = new FilteredStackProfiler(stack -> Arrays.stream(stack).anyMatch(e -> e.getClassName().startsWith("org.threadly.")));
     assertNotNull(p.filteredThreadStore.threadTraces);
     assertTrue(p.filteredThreadStore.threadTraces.isEmpty());
     assertEquals(Profiler.DEFAULT_POLL_INTERVAL_IN_MILLIS, p.filteredThreadStore.pollIntervalInMs);
@@ -47,9 +43,9 @@ public class FilteredStackProfilerTest extends ProfilerTest {
     assertNull(p.filteredThreadStore.dumpingThread);
     assertNotNull(p.startStopLock);
     assertTrue(p.filteredThreadStore.filter.test(
-                 new StackTraceElement("org.threadly.SomeClass", "run", null, 42)));
+                 new StackTraceElement[] { new StackTraceElement("org.threadly.SomeClass", "run", null, 42) }));
     assertFalse(p.filteredThreadStore.filter.test(
-                  new StackTraceElement("java.lang.Thread", "run", null, 456)));
+                  new StackTraceElement[] { new StackTraceElement("java.lang.Thread", "run", null, 456) }));
 
     p = new FilteredStackProfiler(testPollInterval, "^org\\.threadly\\.");
     assertNotNull(p.filteredThreadStore.threadTraces);
@@ -59,12 +55,12 @@ public class FilteredStackProfilerTest extends ProfilerTest {
     assertNull(p.filteredThreadStore.dumpingThread);
     assertNotNull(p.startStopLock);
     assertTrue(p.filteredThreadStore.filter.test(
-                 new StackTraceElement("org.threadly.SomeClass", "run", null, 42)));
+                 new StackTraceElement[] { new StackTraceElement("org.threadly.SomeClass", "run", null, 42) }));
     assertFalse(p.filteredThreadStore.filter.test(
-                  new StackTraceElement("java.lang.Thread", "run", null, 456)));
+                  new StackTraceElement[] { new StackTraceElement("java.lang.Thread", "run", null, 456) }));
 
     p = new FilteredStackProfiler(
-      testPollInterval, e -> e.getClassName().startsWith("org.threadly."));
+      testPollInterval, stack -> Arrays.stream(stack).anyMatch(e -> e.getClassName().startsWith("org.threadly.")));
     assertNotNull(p.filteredThreadStore.threadTraces);
     assertTrue(p.filteredThreadStore.threadTraces.isEmpty());
     assertEquals(testPollInterval, p.filteredThreadStore.pollIntervalInMs);
@@ -72,9 +68,9 @@ public class FilteredStackProfilerTest extends ProfilerTest {
     assertNull(p.filteredThreadStore.dumpingThread);
     assertNotNull(p.startStopLock);
     assertTrue(p.filteredThreadStore.filter.test(
-                 new StackTraceElement("org.threadly.SomeClass", "run", null, 42)));
+                 new StackTraceElement[] { new StackTraceElement("org.threadly.SomeClass", "run", null, 42) }));
     assertFalse(p.filteredThreadStore.filter.test(
-                  new StackTraceElement("java.lang.Thread", "run", null, 456)));
+                  new StackTraceElement[] { new StackTraceElement("java.lang.Thread", "run", null, 456) }));
   }
 
   @Test
@@ -86,6 +82,7 @@ public class FilteredStackProfilerTest extends ProfilerTest {
     assertFalse(it.hasNext());
   }
 
+  @Override
   @Test
   public void getProfileThreadsIteratorTest() {
     // This should only see this one thread executing this one particular test


### PR DESCRIPTION
First commit is just trying to reduce / simplify some code by moving the `CachedThreadSample` to the super class `Profiler`.

The second commit introduces a minor API change.  Instead of having the predicate test each element in isolation we provide the entire `StackTraceElement[]` to the predicate.  The idea being that this can be more flexible for other conditionals (for example needing to match multiple stack trace elements, or wanting to know the stack size)

@AltSysrq Any opinions on this change?  The thought only came to me after I merged.