### PR TITLE
Add FlowControlledProcessor

### DIFF
--- a/src/main/java/org/threadly/concurrent/BlockingQueueConsumer.java
+++ b/src/main/java/org/threadly/concurrent/BlockingQueueConsumer.java
@@ -4,40 +4,34 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.threadly.util.AbstractService;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.ExceptionUtils;
+import org.threadly.util.StringUtils;
 
 /**
- * Producer consumer problems are very frequent within multi-threaded code.  This class is 
- * designed to be a throttle for both sides of the problem.  It takes in a {@link BlockingQueue} 
- * so that items are only consumed as they become available.  At the same time it has a 
- * {@link ConsumerAcceptor} that will only accept items as it is ready.  By accepting on the same 
- * thread as the consumer it will only try to take more items after the 
- * {@link ConsumerAcceptor#acceptConsumedItem(Object)} call returns.
- * <p>
- * Another way to look at it, this class provides the thread to handle blocking when consuming 
- * from a {@link BlockingQueue}.
- * <p>
- * Keep in mind that this class in no way attempts to solve the problem if the program is 
- * producing faster than the consumer accepts.  In those conditions the queue will still continue 
- * to grow, and consume memory.
+ * Migration off this deprecated implementation is highly encouraged.  Javadocs removed in 5.37 
+ * in replacement for {@link org.threadly.concurrent.processing.BlockingQueueConsumer}.  This class 
+ * slipped under the radar, causing the implementation and interface to be significantly behind in 
+ * threadly 5.X.  Please switch to 
+ * {@link Poller#consumeQueue(java.util.Queue, java.util.function.Consumer)} or 
+ * {@link org.threadly.concurrent.processing.BlockingQueueConsumer}.
+ * 
+ * @deprecated See {@link Poller#consumeQueue(java.util.Queue, java.util.function.Consumer)} or 
+ *               {@link org.threadly.concurrent.processing.BlockingQueueConsumer} for replacement
  * 
  * @since 1.0.0
  * @param <T> Type of items contained in the queue to be consumed
  */
-public class BlockingQueueConsumer<T> extends AbstractService {
+@Deprecated
+public class BlockingQueueConsumer<T> extends org.threadly.concurrent.processing.BlockingQueueConsumer<T> {
   private static final AtomicInteger DEFAULT_CONSUMER_VALUE = new AtomicInteger(0);
   
   private static String getDefaultThreadName() {
     return "QueueConsumer-" + DEFAULT_CONSUMER_VALUE.getAndIncrement();
   }
   
-  protected final ThreadFactory threadFactory;
   protected final String threadName;
-  protected final BlockingQueue<? extends T> queue;
   protected final ConsumerAcceptor<? super T> acceptor;
-  protected volatile Thread runningThread;
   
   /**
    * Constructs a new consumer, with a provided queue to consume from, and an acceptor to accept 
@@ -66,72 +60,33 @@ public class BlockingQueueConsumer<T> extends AbstractService {
                                String threadName, 
                                BlockingQueue<? extends T> queue, 
                                ConsumerAcceptor<? super T> acceptor) {
-    ArgumentVerifier.assertNotNull(threadFactory, "threadFactory");
-    ArgumentVerifier.assertNotNull(queue, "queue");
+    super(threadFactory, queue);
+    
     ArgumentVerifier.assertNotNull(acceptor, "acceptor");
     
-    this.threadFactory = threadFactory;
     this.threadName = threadName;
-    this.queue = queue;
     this.acceptor = acceptor;
-    runningThread = null;
   }
 
   @Override
   protected void startupService() {
-    runningThread = threadFactory.newThread(new ConsumerRunnable());
-    if (runningThread.isAlive()) {
-      throw new IllegalThreadStateException();
-    }
-    runningThread.setDaemon(true);
-    if (threadName == null || threadName.isEmpty()) {
+    super.startupService();
+    
+    if (StringUtils.isNullOrEmpty(threadName)) {
       runningThread.setName(getDefaultThreadName());
     } else {
       runningThread.setName(threadName);
     }
-    runningThread.start();
   }
 
   @Override
-  protected void shutdownService() {
-    Thread runningThread = this.runningThread;
-    this.runningThread = null;
-    runningThread.interrupt();
+  protected void accept(T next) throws Exception {
+    acceptor.acceptConsumedItem(next);
   }
-  
-  /**
-   * This function is provided so that it can be Overridden if necessary.  One example would be if 
-   * any locking needs to happen while consuming.
-   * 
-   * @return the next consumed item
-   * @throws InterruptedException thrown if thread is interrupted while blocking for next item
-   */
-  protected T getNext() throws InterruptedException {
-    return queue.take();
-  }
-  
-  /**
-   * Class which represents our runnable actions for the consumer.
-   *  
-   * @since 1.0.0
-   */
-  private class ConsumerRunnable implements Runnable {
-    @Override
-    public void run() {
-      while (runningThread != null) {
-        try {
-          T next = getNext();
-          
-          acceptor.acceptConsumedItem(next);
-        } catch (InterruptedException e) {
-          stopIfRunning();
-          // reset interrupted status
-          Thread.currentThread().interrupt();
-        } catch (Throwable t) {
-          ExceptionUtils.handleException(t);
-        }
-      }
-    }
+
+  @Override
+  protected void handleException(Throwable t) {
+    ExceptionUtils.handleException(t);
   }
   
   /**

--- a/src/main/java/org/threadly/concurrent/FlowControlledProcessor.java
+++ b/src/main/java/org/threadly/concurrent/FlowControlledProcessor.java
@@ -1,0 +1,258 @@
+package org.threadly.concurrent;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+import org.threadly.concurrent.future.FutureCallback;
+import org.threadly.concurrent.future.FutureUtils;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.SettableListenableFuture;
+import org.threadly.util.ArgumentVerifier;
+
+/**
+ * Abstract implementation which will do async processing, but only submit a limited number of 
+ * tasks processing concurrently.  This is different from something like an ExecutorLimiter 
+ * because it not only limits execution, but pulls for new tasks when ready.  This makes it easier 
+ * to limit how much is held in heap.  Otherwise while pools may limit execution to prevent 
+ * over utilizing resources, this will help prevent task submission to ensure that the running 
+ * processor does not over-consume its heap.
+ * <p>
+ * This object is one time use.  Once {@link #hasNext()} returns {@code false} it should be 
+ * considered done forever.  If more work needs to be processed then this object needs to be 
+ * reconstructed with a new instance.
+ * 
+ * @since 5.37
+ * @param <T> The type of result produced / accepted
+ */
+public abstract class FlowControlledProcessor<T> {
+  private final int maxRunningTasks;
+  private final SettableListenableFuture<Void> completeFuture;
+  private final ProcessingMonitor futureMonitor;
+  private boolean started = false;
+  
+  /**
+   * Construct a new processor.  You must invoke {@link #start()} once constructed to start 
+   * processing.
+   * 
+   * @param maxRunningTasks Maximum number of concurrent running tasks
+   * @param provideResultsInOrder If {@code true} completed results will be provided in the order they are submitted
+   */
+  public FlowControlledProcessor(int maxRunningTasks, boolean provideResultsInOrder) {
+    ArgumentVerifier.assertGreaterThanZero(maxRunningTasks, "maxRunningTasks");
+    
+    this.maxRunningTasks = maxRunningTasks;
+    this.completeFuture = new SettableListenableFuture<>(false);
+    this.futureMonitor = 
+        provideResultsInOrder ? new InOrderProcessingMonitor() : new ProcessingMonitor();
+  }
+  
+  /**
+   * Start processing tasks.  The returned future wont complete until task execution has completed 
+   * or unless {@link #handleFailure(Throwable)} returns {@code false} indicating an error is not 
+   * able to be handled.  In the case of an unhandled error the returned future will finish with 
+   * the error condition.
+   *   
+   * @return Future to indicate state of completion
+   */
+  public ListenableFuture<?> start() {
+    synchronized (this) {
+      if (started) {
+        throw new IllegalStateException("Already started");
+      }
+      started = true;
+    }
+    
+    futureMonitor.start();
+    
+    return completeFuture;
+  }
+  
+  /**
+   * Checked before {@link #next()} is invoked to see if there is more work to do.  If this 
+   * returns {@code true} then {@link #next()} will be invoked.  It should be expected that 
+   * this state may be checked multiple times before {@link #next()} is invoked.  Once this 
+   * returns {@code false} it should remain as completed forever.
+   * 
+   * @return {@code true} to indicate there is more to process, {@code false} to indicate completion
+   */
+  protected abstract boolean hasNext();
+  
+  /**
+   * Invoked when ready to process the next item.  This will only be invoked after 
+   * {@link #hasNext()} returns {@code true}.  This wont be invoked concurrently, so blocking on 
+   * this function can result in slowing down task execution.  Instead this should immediately 
+   * return a {@link ListenableFuture} which will complete when processing is done.  Once the 
+   * returned future completes the result will be provided to {@link #handleResult(Object)}.  If 
+   * the returned future completes in error then instead {@link #handleFailure(Throwable)} will be 
+   * invoked with the failure.
+   * 
+   * @return A non-null {@link ListenableFuture} for when the processing completes
+   * @throws Exception if thrown, delegated to {@link #handleFailure(Throwable)}
+   */
+  protected abstract ListenableFuture<? extends T> next() throws Exception;
+  
+  /**
+   * Invoked when the processing is completed.  If this class is constructed to allow out of order 
+   * completion then this may be invoked concurrently, if synchronization is necessary it must be 
+   * done in the implementing class.
+   * 
+   * @param result Result provided from future returned from {@link #next()}
+   */
+  protected abstract void handleResult(T result);
+  
+  /**
+   * Invoked when an error occurred, either from a returned future from {@link #next()} or 
+   * when one of the implemented functions throws an unexpected error.  This function should return 
+   * {@code true} if the error is expected or able to be handled, or {@code false} if it wants the 
+   * submission of new tasks to stop and instead communication the error to the future returned 
+   * from {@link #start()}.
+   * 
+   * @param t The failure thrown
+   * @return {@code true} to indicate error is handled and processing should continue
+   */
+  protected abstract boolean handleFailure(Throwable t);
+  
+  protected class ProcessingMonitor implements FutureCallback<T> {
+    private int currentRunningTasks = 0;
+    
+    public void start() {
+      List<ListenableFuture<? extends T>> futures = new ArrayList<>(maxRunningTasks); 
+      while (currentRunningTasks < maxRunningTasks && ! completeFuture.isDone() && hasNext()) {
+        currentRunningTasks++;
+        try {
+          futures.add(next());
+        } catch (Exception e) {
+          handleFailure(e);
+        }
+      }
+
+      if (currentRunningTasks == 0) { // no tasks it seems
+        completeFuture.setResult(null);
+      } else {
+        // add callback after to avoid any delays in handling results and any concurrency issues
+        for (ListenableFuture<? extends T> lf : futures) {
+          lf.callback(this);
+        }
+      }
+    }
+    
+    protected ListenableFuture<? extends T> next() throws Exception {
+      return FlowControlledProcessor.this.next();
+    }
+    
+    @Override
+    public void handleResult(T result) {
+      try {
+        FlowControlledProcessor.this.handleResult(result);
+        readyForNext();
+      } catch (Throwable t) {
+        handleFailure(t);
+      }
+    }
+
+    @Override
+    public void handleFailure(Throwable t) {
+      if (FlowControlledProcessor.this.handleFailure(t)) {
+        readyForNext();
+      } else {
+        completeFuture.setFailure(t);
+      }
+    }
+    
+    protected void readyForNext() {
+      ListenableFuture<? extends T> nextFuture; // return to avoid `null` conditions with nextFuture
+      synchronized (FlowControlledProcessor.this) {
+        try {
+          if (completeFuture.isDone() || ! hasNext()) {
+            currentRunningTasks--;
+            if (currentRunningTasks == 0) {
+              completeFuture.setResult(null);
+            }
+            return;
+          } else {
+            nextFuture = next();
+          }
+        } catch (Throwable t) {
+          handleFailure(t);
+          return;
+        }
+      }
+      
+      nextFuture.callback(this);  // add callback outside of lock
+    }
+  }
+  
+  protected class InOrderProcessingMonitor extends ProcessingMonitor {
+    protected final ReschedulingOperation futureConsumer = 
+        new ReschedulingOperation(SameThreadSubmitterExecutor.instance()) {
+          @Override
+          protected void run() {
+            ListenableFuture<? extends T> lf;
+            while ((lf = nextReadyFuture()) != null) {
+              try {
+                try {
+                  FlowControlledProcessor.this.handleResult(lf.get());
+                } catch (ExecutionException e) {
+                  handleInOrderFailure(e.getCause());
+                } catch (CancellationException e) {
+                  handleInOrderFailure(e);
+                } catch (InterruptedException e) {
+                  // not possible
+                  throw new RuntimeException(e);
+                }
+              } catch (Throwable t) {
+                handleInOrderFailure(t);
+              }
+            }
+          }
+          
+          protected ListenableFuture<? extends T> nextReadyFuture() {
+            synchronized (futureQueue) {
+              if (! futureQueue.isEmpty() && futureQueue.peek().isDone()) {
+                return futureQueue.remove();
+              }
+            }
+            return null;
+          }
+          
+          protected void handleInOrderFailure(Throwable t) {
+            if (! FlowControlledProcessor.this.handleFailure(t)) {
+              completeFuture.setFailure(t);
+            }
+          }
+        };
+    protected Queue<ListenableFuture<? extends T>> futureQueue = new ArrayDeque<>(maxRunningTasks);
+    
+    @Override
+    public void handleResult(T result) {
+      futureConsumer.signalToRun();
+      
+      readyForNext();
+    }
+
+    @Override
+    public void handleFailure(Throwable t) {
+      futureConsumer.signalToRun();
+      
+      readyForNext();
+    }
+    
+    @Override
+    protected ListenableFuture<? extends T> next() throws Exception {
+      ListenableFuture<? extends T> result;
+      try {
+        result = FlowControlledProcessor.this.next();
+      } catch (Throwable t) {
+        result = FutureUtils.immediateFailureFuture(t);
+      }
+      synchronized (futureQueue) {
+        futureQueue.add(result);
+      }
+      return result;
+    } 
+  }
+}

--- a/src/main/java/org/threadly/concurrent/processing/BlockingQueueConsumer.java
+++ b/src/main/java/org/threadly/concurrent/processing/BlockingQueueConsumer.java
@@ -1,0 +1,138 @@
+package org.threadly.concurrent.processing;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
+
+import org.threadly.util.AbstractService;
+import org.threadly.util.ArgumentVerifier;
+import org.threadly.util.ExceptionHandler;
+import org.threadly.util.ExceptionUtils;
+
+/**
+ * This class is designed for handling the threading and consumption of a high throughput 
+ * {@link BlockingQueue}.  This class will create a thread to block on for the queue, and provide 
+ * the result to the abstract {@link #accept(Object)}.  For low throughput queues, or 
+ * where you want threads shared, consider using instead 
+ * {@link org.threadly.concurrent.Poller#consumeQueue(java.util.Queue, Consumer, ExceptionHandler)}.
+ * <p>
+ * This implementation will create a single thread, serially calling to {@link #accept(Object)}, 
+ * and not attempting to consume the next item till after it returns.  If any errors happen similar 
+ * {@link #handleException(Throwable)} will block consuming the next item from the queue.
+ * <p>
+ * By implementing {@link org.threadly.util.Service} this class handles the thread lifecycle.  Item 
+ * consumption will start when {@link #start()} is invoked, and will continue until {@link #stop()} 
+ * is invoked.  When stopped, the consumer thread will be interrupted.  This is necessary to unblock 
+ * from consuming from the queue, but may impact the accepting code if it is currently handling an 
+ * item.
+ * 
+ * @since 5.37 (Former version existed at org.threadly.concurrent)
+ * @param <T> Type of items contained in the queue to be consumed
+ */
+public abstract class BlockingQueueConsumer<T> extends AbstractService {
+  /**
+   * Construct a new {@link BlockingQueueConsumer} in case an abstract implementation is not 
+   * preferred.
+   * 
+   * @param threadFactory ThreadFactory to construct new thread for consumer to run on 
+   * @param queue Queue to consume items from
+   * @param consumer Consumer to provide items from queue on
+   * @param exceptionHandler Handler to send errors to, if {@code null} {@link ExceptionUtils#handleException} is used
+   * @return A new {@link BlockingQueueConsumer} ready to {@code start()}
+   */
+  public static <T> BlockingQueueConsumer<T> makeForHandlers(ThreadFactory threadFactory, 
+                                                             BlockingQueue<? extends T> queue, 
+                                                             Consumer<T> consumer, 
+                                                             ExceptionHandler exceptionHandler) {
+    ArgumentVerifier.assertNotNull(consumer, "consumer");
+    final ExceptionHandler fExceptionHandler;
+    if (exceptionHandler == null) {
+      fExceptionHandler = ExceptionUtils::handleException;
+    } else {
+      fExceptionHandler = exceptionHandler;
+    }
+    
+    return new BlockingQueueConsumer<T>(threadFactory, queue) {
+      @Override
+      protected void accept(T next) throws Exception {
+        consumer.accept(next);
+      }
+
+      @Override
+      protected void handleException(Throwable t) {
+        fExceptionHandler.handleException(t);
+      }
+    };
+  }
+  
+  protected final ThreadFactory threadFactory;
+  protected final BlockingQueue<? extends T> queue;
+  protected volatile Thread runningThread = null;
+  
+  /**
+   * Constructs a new consumer, with a provided queue to consume from, and an acceptor to accept 
+   * items.
+   * 
+   * @param threadFactory ThreadFactory to construct new thread for consumer to run on 
+   * @param queue Queue to consume items from
+   */
+  public BlockingQueueConsumer(ThreadFactory threadFactory, BlockingQueue<? extends T> queue) {
+    ArgumentVerifier.assertNotNull(threadFactory, "threadFactory");
+    ArgumentVerifier.assertNotNull(queue, "queue");
+    
+    this.threadFactory = threadFactory;
+    this.queue = queue;
+  }
+
+  @Override
+  protected void startupService() {
+    runningThread = threadFactory.newThread(new ConsumerRunnable());
+    if (runningThread.isAlive()) {
+      throw new IllegalThreadStateException();
+    }
+    runningThread.setDaemon(true);
+    runningThread.start();
+  }
+
+  @Override
+  protected void shutdownService() {
+    Thread runningThread = this.runningThread;
+    this.runningThread = null;
+    runningThread.interrupt();
+  }
+  
+  /**
+   * This function is provided so that it can be Overridden if necessary.  One example would be if 
+   * any locking needs to happen while consuming.
+   * 
+   * @return the next consumed item
+   * @throws InterruptedException thrown if thread is interrupted while blocking for next item
+   */
+  protected T getNext() throws InterruptedException {
+    return queue.take();
+  }
+  
+  protected abstract void accept(T next) throws Exception;
+  
+  protected abstract void handleException(Throwable t);
+  
+  /**
+   * Class which represents our runnable actions for the consumer.
+   *  
+   * @since 5.37
+   */
+  protected final class ConsumerRunnable implements Runnable {
+    @Override
+    public void run() {
+      while (runningThread != null) {
+        try {
+          accept(getNext());
+        } catch (InterruptedException e) {
+          stopIfRunning();
+        } catch (Throwable t) {
+          handleException(t);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/org/threadly/concurrent/processing/FlowControlledNoFailureProcessor.java
+++ b/src/main/java/org/threadly/concurrent/processing/FlowControlledNoFailureProcessor.java
@@ -1,0 +1,26 @@
+package org.threadly.concurrent.processing;
+
+/**
+ * Implementation of {@link FlowControlledProcessor} which assumes all exceptions are unexpected.  
+ * Since this is a common condition this class can help reduce some boiler plate code.
+ *
+ * @since 5.37
+ * @param <T> The type of result produced / accepted
+ */
+public abstract class FlowControlledNoFailureProcessor<T> extends FlowControlledProcessor<T> {
+  /**
+   * Construct a new processor.  You must invoke {@link #start()} once constructed to start 
+   * processing.
+   * 
+   * @param maxRunningTasks Maximum number of concurrent running tasks
+   * @param provideResultsInOrder If {@code true} completed results will be provided in the order they are submitted
+   */
+  public FlowControlledNoFailureProcessor(int maxRunningTasks, boolean provideResultsInOrder) {
+    super(maxRunningTasks, provideResultsInOrder);
+  }
+
+  @Override
+  protected boolean handleFailure(Throwable t) {
+    return false;
+  }
+}

--- a/src/main/java/org/threadly/concurrent/processing/FlowControlledNoResultProcessor.java
+++ b/src/main/java/org/threadly/concurrent/processing/FlowControlledNoResultProcessor.java
@@ -1,0 +1,33 @@
+package org.threadly.concurrent.processing;
+
+import org.threadly.concurrent.future.ListenableFuture;
+
+/**
+ * Implementation of {@link FlowControlledProcessor} which reduces boiler plate code when no result 
+ * is expected.  Instead all logic should be done in the future returned by {@link #next()}.
+ * <p>
+ * To further minimize code this extends {@link FlowControlledNoFailureProcessor} where by default 
+ * all exceptions are considered failures.  If you want to handle some failures you can override 
+ * {@link #handleFailure(Throwable)} returning {@code true} to indicate an exception as expected.
+ *
+ * @since 5.37
+ */
+public abstract class FlowControlledNoResultProcessor extends FlowControlledNoFailureProcessor<Object> {
+  /**
+   * Construct a new processor.  You must invoke {@link #start()} once constructed to start 
+   * processing.
+   * 
+   * @param maxRunningTasks Maximum number of concurrent running tasks
+   */
+  public FlowControlledNoResultProcessor(int maxRunningTasks) {
+    super(maxRunningTasks, false);
+  }
+
+  @Override
+  protected abstract ListenableFuture<?> next();
+
+  @Override
+  protected final void handleResult(Object result) {
+    // ignored
+  }
+}

--- a/src/main/java/org/threadly/concurrent/processing/FlowControlledProcessor.java
+++ b/src/main/java/org/threadly/concurrent/processing/FlowControlledProcessor.java
@@ -1,4 +1,4 @@
-package org.threadly.concurrent;
+package org.threadly.concurrent.processing;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -7,6 +7,8 @@ import java.util.Queue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
+import org.threadly.concurrent.ReschedulingOperation;
+import org.threadly.concurrent.SameThreadSubmitterExecutor;
 import org.threadly.concurrent.future.FutureCallback;
 import org.threadly.concurrent.future.FutureUtils;
 import org.threadly.concurrent.future.ListenableFuture;
@@ -53,10 +55,14 @@ public abstract class FlowControlledProcessor<T> {
   /**
    * Start processing tasks.  The returned future wont complete until task execution has completed 
    * or unless {@link #handleFailure(Throwable)} returns {@code false} indicating an error is not 
-   * able to be handled.  In the case of an unhandled error the returned future will finish with 
-   * the error condition.
+   * able to be handled.
+   * <p>
+   * In the case of an unhandled error the returned future will finish with the error condition.  
+   * Because of that, it's important the returned futures state is checked to verify an unhandled 
+   * error did not occur.  This can be done easily with 
+   * {@link ListenableFuture#failureCallback(java.util.function.Consumer)}.
    *   
-   * @return Future to indicate state of completion
+   * @return Future to indicate state of completion.  This future's result 
    */
   public ListenableFuture<?> start() {
     synchronized (this) {

--- a/src/main/java/org/threadly/concurrent/processing/package-info.java
+++ b/src/main/java/org/threadly/concurrent/processing/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Classes that assist with processing batches or streams of data.  These are utilities for 
+ * organizing and managing execution for efficient processing.
+ */
+package org.threadly.concurrent.processing;

--- a/src/main/java/org/threadly/concurrent/wrapper/SubmitterExecutorAdapter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/SubmitterExecutorAdapter.java
@@ -3,6 +3,7 @@ package org.threadly.concurrent.wrapper;
 import java.util.concurrent.Executor;
 
 import org.threadly.concurrent.AbstractSubmitterExecutor;
+import org.threadly.concurrent.SubmitterExecutor;
 import org.threadly.util.ArgumentVerifier;
 
 /**
@@ -16,6 +17,21 @@ import org.threadly.util.ArgumentVerifier;
  * @since 4.8.0 (since 1.0.0 as org.threadly.concurrent.ExecutorWrapper)
  */
 public class SubmitterExecutorAdapter extends AbstractSubmitterExecutor {
+  /**
+   * Ensures the provided {@link Executor} is of type {@link SubmitterExecutor}, adapting it with 
+   * this class if necessary to provide the interface.
+   * 
+   * @param executor Executor to test type or wrap if necessary
+   * @return An implementation of {@link SubmitterExecutor}
+   */
+  public static SubmitterExecutor adaptExecutor(Executor executor) {
+    if (executor instanceof SubmitterExecutor) {
+      return (SubmitterExecutor) executor;
+    } else {
+      return new SubmitterExecutorAdapter(executor);
+    }
+  }
+  
   protected final Executor executor;
   
   /**

--- a/src/main/java/org/threadly/test/concurrent/AsyncVerifier.java
+++ b/src/main/java/org/threadly/test/concurrent/AsyncVerifier.java
@@ -236,11 +236,11 @@ public class AsyncVerifier {
   }
   
   /**
-   * Small exception to represent when a test failure occurs.
+   * Exception to represent a failure in a test assertion.
    * 
    * @since 1.0.0
    */
-  protected static class TestFailure extends RuntimeException {
+  public static class TestFailure extends RuntimeException {
     private static final long serialVersionUID = -4683332806581392944L;
 
     private TestFailure(String failureMsg) {

--- a/src/test/java/org/threadly/concurrent/FlowControlledProcessorTest.java
+++ b/src/test/java/org/threadly/concurrent/FlowControlledProcessorTest.java
@@ -1,0 +1,196 @@
+package org.threadly.concurrent;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.test.concurrent.AsyncVerifier;
+
+@SuppressWarnings("javadoc")
+public class FlowControlledProcessorTest {
+  private PriorityScheduler scheduler;
+  
+  @Before
+  public void setup() {
+    scheduler = new PriorityScheduler(Runtime.getRuntime().availableProcessors());
+    scheduler.prestartAllThreads();
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler.shutdownNow();
+  }
+  
+  @Test
+  public void concurrentLimitTest() throws ExecutionException, InterruptedException, TimeoutException {
+    concurrentLimitTest(false);
+  }
+  
+  @Test
+  public void concurrentLimitInOrderTest() throws ExecutionException, InterruptedException, TimeoutException {
+    concurrentLimitTest(true);
+  }
+  
+  public void concurrentLimitTest(boolean inOrder) throws ExecutionException, InterruptedException, TimeoutException {
+    final RuntimeException expectedException = new RuntimeException();
+    final int maxRunning = 2;
+    final int totalRunCount = 100;
+    AtomicInteger running = new AtomicInteger(0);
+    AsyncVerifier verifier = new AsyncVerifier();
+    
+    FlowControlledProcessor<Void> processor = new FlowControlledProcessor<Void>(maxRunning, inOrder) {
+      private int count = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Void> next() throws Exception {
+        verifier.assertTrue(running.incrementAndGet() <= maxRunning);
+        Runnable task;
+        if (count++ % 2 == 0) {
+          task = DoNothingRunnable.instance();
+        } else {
+          task = () -> { throw expectedException; };
+        }
+        ListenableFuture<Void> result = 
+            scheduler.submitScheduled(task, null, 
+                                      ThreadLocalRandom.current().nextInt(5) + 5);
+        result.listener(running::decrementAndGet);
+        return result;
+      }
+
+      @Override
+      protected void handleResult(Void result) {
+        verifier.signalComplete();
+      }
+
+      @Override
+      protected boolean handleFailure(Throwable t) {
+        if (t == expectedException) {
+          verifier.signalComplete();
+          return true;
+        } else if (! (t instanceof AsyncVerifier.TestFailure)) {
+          verifier.fail(t);
+        }
+        return false;
+      }
+    };
+    ListenableFuture<?> runFuture = processor.start();
+    
+    verifier.waitForTest(10_000, totalRunCount);
+    runFuture.get(100, TimeUnit.MILLISECONDS);
+    assertTrue(runFuture.isDone());
+  }
+  
+  @Test
+  public void inOrderCompletionTest() throws InterruptedException, TimeoutException {
+    final int maxRunning = Runtime.getRuntime().availableProcessors();
+    final int totalRunCount = 100 * maxRunning;
+    AsyncVerifier verifier = new AsyncVerifier();
+    
+    FlowControlledProcessor<Integer> processor = new FlowControlledProcessor<Integer>(maxRunning, true) {
+      private int count = 0;
+      private int last = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Integer> next() throws Exception {
+        return scheduler.submitScheduled(DoNothingRunnable.instance(), ++count, 
+                                         ThreadLocalRandom.current().nextInt(20));
+      }
+
+      @Override
+      protected void handleResult(Integer result) {
+        verifier.assertEquals(last + 1, result);
+        last = result;
+        verifier.signalComplete();
+      }
+
+      @Override
+      protected boolean handleFailure(Throwable t) {
+        if (! (t instanceof AsyncVerifier.TestFailure)) {
+          verifier.fail(t);
+        }
+        return false;
+      }
+    };
+    processor.start();
+    
+    verifier.waitForTest(10_000, totalRunCount);
+  }
+  
+  @Test
+  public void handledErrorTest() throws InterruptedException, TimeoutException {
+    handledErrorTest(false);
+  }
+  
+  @Test
+  public void handledErrorInOrderTest() throws InterruptedException, TimeoutException {
+    handledErrorTest(true);
+  }
+  
+  public void handledErrorTest(boolean inOrder) throws InterruptedException, TimeoutException {
+    final RuntimeException expectedException = new RuntimeException();
+    final int maxRunning = 2;
+    final int totalRunCount = 100;
+    AsyncVerifier verifier = new AsyncVerifier();
+    
+    FlowControlledProcessor<Void> processor = new FlowControlledProcessor<Void>(maxRunning, inOrder) {
+      private int count = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Void> next() throws Exception {
+        if (ThreadLocalRandom.current().nextBoolean()) {
+          count++;
+          throw expectedException;
+        }
+        Runnable task;
+        if (count++ % 2 == 0) {
+          task = DoNothingRunnable.instance();
+        } else {
+          task = () -> { throw expectedException; };
+        }
+        return scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5);
+      }
+
+      @Override
+      protected void handleResult(Void result) {
+        verifier.signalComplete();
+      }
+
+      @Override
+      protected boolean handleFailure(Throwable t) {
+        if (t == expectedException) {
+          verifier.signalComplete();
+          return true;
+        } else if (! (t instanceof AsyncVerifier.TestFailure)) {
+          verifier.fail(t);
+        }
+        return false;
+      }
+    };
+    processor.start();
+    
+    verifier.waitForTest(10_000, totalRunCount);
+  }
+}

--- a/src/test/java/org/threadly/concurrent/FlowControlledProcessorTest.java
+++ b/src/test/java/org/threadly/concurrent/FlowControlledProcessorTest.java
@@ -55,7 +55,7 @@ public class FlowControlledProcessorTest {
       }
 
       @Override
-      protected ListenableFuture<Void> next() throws Exception {
+      protected ListenableFuture<Void> next() {
         verifier.assertTrue(running.incrementAndGet() <= maxRunning);
         Runnable task;
         if (count++ % 2 == 0) {
@@ -109,7 +109,7 @@ public class FlowControlledProcessorTest {
       }
 
       @Override
-      protected ListenableFuture<Integer> next() throws Exception {
+      protected ListenableFuture<Integer> next() {
         return scheduler.submitScheduled(DoNothingRunnable.instance(), ++count, 
                                          ThreadLocalRandom.current().nextInt(20));
       }
@@ -159,7 +159,7 @@ public class FlowControlledProcessorTest {
       }
 
       @Override
-      protected ListenableFuture<Void> next() throws Exception {
+      protected ListenableFuture<Void> next() {
         if (ThreadLocalRandom.current().nextBoolean()) {
           count++;
           throw expectedException;

--- a/src/test/java/org/threadly/concurrent/processing/FlowControlledNoFailureProcessorTest.java
+++ b/src/test/java/org/threadly/concurrent/processing/FlowControlledNoFailureProcessorTest.java
@@ -1,0 +1,161 @@
+package org.threadly.concurrent.processing;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.DoNothingRunnable;
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.test.concurrent.AsyncVerifier;
+
+@SuppressWarnings("javadoc")
+public class FlowControlledNoFailureProcessorTest {
+  private PriorityScheduler scheduler;
+  
+  @Before
+  public void setup() {
+    scheduler = new PriorityScheduler(Runtime.getRuntime().availableProcessors());
+    scheduler.prestartAllThreads();
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler.shutdownNow();
+  }
+  
+  @Test
+  public void concurrentLimitTest() throws ExecutionException, InterruptedException, TimeoutException {
+    concurrentLimitTest(false);
+  }
+  
+  @Test
+  public void concurrentLimitInOrderTest() throws ExecutionException, InterruptedException, TimeoutException {
+    concurrentLimitTest(true);
+  }
+  
+  public void concurrentLimitTest(boolean inOrder) throws ExecutionException, InterruptedException, TimeoutException {
+    final int maxRunning = 2;
+    final int totalRunCount = 100;
+    AtomicInteger running = new AtomicInteger(0);
+    AsyncVerifier verifier = new AsyncVerifier();
+    
+    FlowControlledProcessor<Void> processor = new FlowControlledNoFailureProcessor<Void>(maxRunning, inOrder) {
+      private int count = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Void> next() {
+        count++;
+        verifier.assertTrue(running.incrementAndGet() <= maxRunning);
+        ListenableFuture<Void> result = 
+            scheduler.submitScheduled(DoNothingRunnable.instance(), null, 
+                                      ThreadLocalRandom.current().nextInt(5) + 5);
+        result.listener(running::decrementAndGet);
+        return result;
+      }
+
+      @Override
+      protected void handleResult(Void result) {
+        verifier.signalComplete();
+      }
+    };
+    ListenableFuture<?> runFuture = processor.start();
+    
+    verifier.waitForTest(10_000, totalRunCount);
+    runFuture.get(1_000, TimeUnit.MILLISECONDS);
+    assertTrue(runFuture.isDone());
+  }
+  
+  @Test
+  public void inOrderCompletionTest() throws InterruptedException, TimeoutException {
+    final int maxRunning = Runtime.getRuntime().availableProcessors();
+    final int totalRunCount = 100 * maxRunning;
+    AsyncVerifier verifier = new AsyncVerifier();
+    
+    FlowControlledProcessor<Integer> processor = new FlowControlledNoFailureProcessor<Integer>(maxRunning, true) {
+      private int count = 0;
+      private int last = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Integer> next() {
+        return scheduler.submitScheduled(DoNothingRunnable.instance(), ++count, 
+                                         ThreadLocalRandom.current().nextInt(20));
+      }
+
+      @Override
+      protected void handleResult(Integer result) {
+        verifier.assertEquals(last + 1, result);
+        last = result;
+        verifier.signalComplete();
+      }
+
+      @Override
+      protected boolean handleFailure(Throwable t) {
+        if (! (t instanceof AsyncVerifier.TestFailure)) {
+          verifier.fail(t);
+        }
+        return false;
+      }
+    };
+    processor.start();
+    
+    verifier.waitForTest(10_000, totalRunCount);
+  }
+  
+  @Test
+  public void unhandledErrorTest() throws InterruptedException, TimeoutException {
+    final RuntimeException expectedException = new RuntimeException();
+    final int totalRunCount = 100;
+    
+    FlowControlledProcessor<Void> processor = new FlowControlledNoFailureProcessor<Void>(2, false) {
+      private int count = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Void> next() {
+        Runnable task;
+        if (count++ == 1) {
+          task = () -> { throw expectedException; };
+        } else {
+          task = DoNothingRunnable.instance();
+        }
+        return scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5);
+      }
+
+      @Override
+      protected void handleResult(Void result) {
+        // ignored
+      }
+    };
+    ListenableFuture<?> runFuture = processor.start();
+    
+    try {
+      runFuture.get(10_000, TimeUnit.MILLISECONDS);
+      fail("Exception should have thrown");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() == expectedException);
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/processing/FlowControlledNoResultProcessorTest.java
+++ b/src/test/java/org/threadly/concurrent/processing/FlowControlledNoResultProcessorTest.java
@@ -1,6 +1,7 @@
-package org.threadly.concurrent;
+package org.threadly.concurrent.processing;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
@@ -11,11 +12,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.threadly.concurrent.DoNothingRunnable;
+import org.threadly.concurrent.PriorityScheduler;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.test.concurrent.AsyncVerifier;
 
 @SuppressWarnings("javadoc")
-public class FlowControlledProcessorTest {
+public class FlowControlledNoResultProcessorTest {
   private PriorityScheduler scheduler;
   
   @Before
@@ -31,22 +34,13 @@ public class FlowControlledProcessorTest {
   
   @Test
   public void concurrentLimitTest() throws ExecutionException, InterruptedException, TimeoutException {
-    concurrentLimitTest(false);
-  }
-  
-  @Test
-  public void concurrentLimitInOrderTest() throws ExecutionException, InterruptedException, TimeoutException {
-    concurrentLimitTest(true);
-  }
-  
-  public void concurrentLimitTest(boolean inOrder) throws ExecutionException, InterruptedException, TimeoutException {
     final RuntimeException expectedException = new RuntimeException();
     final int maxRunning = 2;
     final int totalRunCount = 100;
     AtomicInteger running = new AtomicInteger(0);
     AsyncVerifier verifier = new AsyncVerifier();
     
-    FlowControlledProcessor<Void> processor = new FlowControlledProcessor<Void>(maxRunning, inOrder) {
+    FlowControlledProcessor<?> processor = new FlowControlledNoResultProcessor(maxRunning) {
       private int count = 0;
       
       @Override
@@ -64,15 +58,10 @@ public class FlowControlledProcessorTest {
           task = () -> { throw expectedException; };
         }
         ListenableFuture<Void> result = 
-            scheduler.submitScheduled(task, null, 
-                                      ThreadLocalRandom.current().nextInt(5) + 5);
+            scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5);
         result.listener(running::decrementAndGet);
+        result.listener(verifier::signalComplete);
         return result;
-      }
-
-      @Override
-      protected void handleResult(Void result) {
-        verifier.signalComplete();
       }
 
       @Override
@@ -89,68 +78,17 @@ public class FlowControlledProcessorTest {
     ListenableFuture<?> runFuture = processor.start();
     
     verifier.waitForTest(10_000, totalRunCount);
-    runFuture.get(100, TimeUnit.MILLISECONDS);
-    assertTrue(runFuture.isDone());
+    runFuture.get(1_000, TimeUnit.MILLISECONDS);
   }
   
   @Test
-  public void inOrderCompletionTest() throws InterruptedException, TimeoutException {
-    final int maxRunning = Runtime.getRuntime().availableProcessors();
-    final int totalRunCount = 100 * maxRunning;
-    AsyncVerifier verifier = new AsyncVerifier();
-    
-    FlowControlledProcessor<Integer> processor = new FlowControlledProcessor<Integer>(maxRunning, true) {
-      private int count = 0;
-      private int last = 0;
-      
-      @Override
-      protected boolean hasNext() {
-        return count < totalRunCount;
-      }
-
-      @Override
-      protected ListenableFuture<Integer> next() {
-        return scheduler.submitScheduled(DoNothingRunnable.instance(), ++count, 
-                                         ThreadLocalRandom.current().nextInt(20));
-      }
-
-      @Override
-      protected void handleResult(Integer result) {
-        verifier.assertEquals(last + 1, result);
-        last = result;
-        verifier.signalComplete();
-      }
-
-      @Override
-      protected boolean handleFailure(Throwable t) {
-        if (! (t instanceof AsyncVerifier.TestFailure)) {
-          verifier.fail(t);
-        }
-        return false;
-      }
-    };
-    processor.start();
-    
-    verifier.waitForTest(10_000, totalRunCount);
-  }
-  
-  @Test
-  public void handledErrorTest() throws InterruptedException, TimeoutException {
-    handledErrorTest(false);
-  }
-  
-  @Test
-  public void handledErrorInOrderTest() throws InterruptedException, TimeoutException {
-    handledErrorTest(true);
-  }
-  
-  public void handledErrorTest(boolean inOrder) throws InterruptedException, TimeoutException {
+  public void handledErrorTest() throws ExecutionException, InterruptedException, TimeoutException {
     final RuntimeException expectedException = new RuntimeException();
     final int maxRunning = 2;
     final int totalRunCount = 100;
     AsyncVerifier verifier = new AsyncVerifier();
     
-    FlowControlledProcessor<Void> processor = new FlowControlledProcessor<Void>(maxRunning, inOrder) {
+    FlowControlledProcessor<?> processor = new FlowControlledNoResultProcessor(maxRunning) {
       private int count = 0;
       
       @Override
@@ -159,7 +97,7 @@ public class FlowControlledProcessorTest {
       }
 
       @Override
-      protected ListenableFuture<Void> next() {
+      protected ListenableFuture<?> next() {
         if (ThreadLocalRandom.current().nextBoolean()) {
           count++;
           throw expectedException;
@@ -170,12 +108,8 @@ public class FlowControlledProcessorTest {
         } else {
           task = () -> { throw expectedException; };
         }
-        return scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5);
-      }
-
-      @Override
-      protected void handleResult(Void result) {
-        verifier.signalComplete();
+        return scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5)
+                        .listener(verifier::signalComplete);
       }
 
       @Override
@@ -189,8 +123,43 @@ public class FlowControlledProcessorTest {
         return false;
       }
     };
-    processor.start();
+    ListenableFuture<?> runFuture = processor.start();
     
     verifier.waitForTest(10_000, totalRunCount);
+    runFuture.get(1_000, TimeUnit.MILLISECONDS);
+  }
+  
+  @Test
+  public void unhandledErrorTest() throws InterruptedException, TimeoutException {
+    final RuntimeException expectedException = new RuntimeException();
+    final int totalRunCount = 100;
+    
+    FlowControlledProcessor<?> processor = new FlowControlledNoResultProcessor(2) {
+      private int count = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Void> next() {
+        Runnable task;
+        if (count++ == 1) {
+          task = () -> { throw expectedException; };
+        } else {
+          task = DoNothingRunnable.instance();
+        }
+        return scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5);
+      }
+    };
+    ListenableFuture<?> runFuture = processor.start();
+    
+    try {
+      runFuture.get(10_000, TimeUnit.MILLISECONDS);
+      fail("Exception should have thrown");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() == expectedException);
+    }
   }
 }

--- a/src/test/java/org/threadly/concurrent/processing/FlowControlledProcessorTest.java
+++ b/src/test/java/org/threadly/concurrent/processing/FlowControlledProcessorTest.java
@@ -1,0 +1,243 @@
+package org.threadly.concurrent.processing;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.DoNothingRunnable;
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.processing.FlowControlledProcessor;
+import org.threadly.test.concurrent.AsyncVerifier;
+
+@SuppressWarnings("javadoc")
+public class FlowControlledProcessorTest {
+  private PriorityScheduler scheduler;
+  
+  @Before
+  public void setup() {
+    scheduler = new PriorityScheduler(Runtime.getRuntime().availableProcessors());
+    scheduler.prestartAllThreads();
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler.shutdownNow();
+  }
+  
+  @Test
+  public void concurrentLimitTest() throws ExecutionException, InterruptedException, TimeoutException {
+    concurrentLimitTest(false);
+  }
+  
+  @Test
+  public void concurrentLimitInOrderTest() throws ExecutionException, InterruptedException, TimeoutException {
+    concurrentLimitTest(true);
+  }
+  
+  public void concurrentLimitTest(boolean inOrder) throws ExecutionException, InterruptedException, TimeoutException {
+    final RuntimeException expectedException = new RuntimeException();
+    final int maxRunning = 2;
+    final int totalRunCount = 100;
+    AtomicInteger running = new AtomicInteger(0);
+    AsyncVerifier verifier = new AsyncVerifier();
+    
+    FlowControlledProcessor<Void> processor = new FlowControlledProcessor<Void>(maxRunning, inOrder) {
+      private int count = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Void> next() {
+        verifier.assertTrue(running.incrementAndGet() <= maxRunning);
+        Runnable task;
+        if (count++ % 2 == 0) {
+          task = DoNothingRunnable.instance();
+        } else {
+          task = () -> { throw expectedException; };
+        }
+        ListenableFuture<Void> result = 
+            scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5);
+        result.listener(running::decrementAndGet);
+        return result;
+      }
+
+      @Override
+      protected void handleResult(Void result) {
+        verifier.signalComplete();
+      }
+
+      @Override
+      protected boolean handleFailure(Throwable t) {
+        if (t == expectedException) {
+          verifier.signalComplete();
+          return true;
+        } else if (! (t instanceof AsyncVerifier.TestFailure)) {
+          verifier.fail(t);
+        }
+        return false;
+      }
+    };
+    ListenableFuture<?> runFuture = processor.start();
+    
+    verifier.waitForTest(10_000, totalRunCount);
+    runFuture.get(100, TimeUnit.MILLISECONDS);
+    assertTrue(runFuture.isDone());
+  }
+  
+  @Test
+  public void inOrderCompletionTest() throws InterruptedException, TimeoutException {
+    final int maxRunning = Runtime.getRuntime().availableProcessors();
+    final int totalRunCount = 100 * maxRunning;
+    AsyncVerifier verifier = new AsyncVerifier();
+    
+    FlowControlledProcessor<Integer> processor = new FlowControlledProcessor<Integer>(maxRunning, true) {
+      private int count = 0;
+      private int last = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Integer> next() {
+        return scheduler.submitScheduled(DoNothingRunnable.instance(), ++count, 
+                                         ThreadLocalRandom.current().nextInt(20));
+      }
+
+      @Override
+      protected void handleResult(Integer result) {
+        verifier.assertEquals(last + 1, result);
+        last = result;
+        verifier.signalComplete();
+      }
+
+      @Override
+      protected boolean handleFailure(Throwable t) {
+        if (! (t instanceof AsyncVerifier.TestFailure)) {
+          verifier.fail(t);
+        }
+        return false;
+      }
+    };
+    processor.start();
+    
+    verifier.waitForTest(10_000, totalRunCount);
+  }
+  
+  @Test
+  public void handledErrorTest() throws ExecutionException, InterruptedException, TimeoutException {
+    handledErrorTest(false);
+  }
+  
+  @Test
+  public void handledErrorInOrderTest() throws ExecutionException, InterruptedException, TimeoutException {
+    handledErrorTest(true);
+  }
+  
+  public void handledErrorTest(boolean inOrder) throws ExecutionException, InterruptedException, TimeoutException {
+    final RuntimeException expectedException = new RuntimeException();
+    final int maxRunning = 2;
+    final int totalRunCount = 100;
+    AsyncVerifier verifier = new AsyncVerifier();
+    
+    FlowControlledProcessor<Void> processor = new FlowControlledProcessor<Void>(maxRunning, inOrder) {
+      private int count = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Void> next() {
+        if (ThreadLocalRandom.current().nextBoolean()) {
+          count++;
+          throw expectedException;
+        }
+        Runnable task;
+        if (count++ % 2 == 0) {
+          task = DoNothingRunnable.instance();
+        } else {
+          task = () -> { throw expectedException; };
+        }
+        return scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5);
+      }
+
+      @Override
+      protected void handleResult(Void result) {
+        verifier.signalComplete();
+      }
+
+      @Override
+      protected boolean handleFailure(Throwable t) {
+        if (t == expectedException) {
+          verifier.signalComplete();
+          return true;
+        } else if (! (t instanceof AsyncVerifier.TestFailure)) {
+          verifier.fail(t);
+        }
+        return false;
+      }
+    };
+    ListenableFuture<?> runFuture = processor.start();
+    
+    verifier.waitForTest(10_000, totalRunCount);
+    runFuture.get(1_000, TimeUnit.MILLISECONDS);
+  }
+  
+  @Test
+  public void unhandledErrorTest() throws InterruptedException, TimeoutException {
+    final RuntimeException expectedException = new RuntimeException();
+    final int totalRunCount = 100;
+    
+    FlowControlledProcessor<Void> processor = new FlowControlledProcessor<Void>(2, false) {
+      private int count = 0;
+      
+      @Override
+      protected boolean hasNext() {
+        return count < totalRunCount;
+      }
+
+      @Override
+      protected ListenableFuture<Void> next() {
+        Runnable task;
+        if (count++ == 1) {
+          task = () -> { throw expectedException; };
+        } else {
+          task = DoNothingRunnable.instance();
+        }
+        return scheduler.submitScheduled(task, null, ThreadLocalRandom.current().nextInt(5) + 5);
+      }
+
+      @Override
+      protected void handleResult(Void result) {
+        // ignored
+      }
+
+      @Override
+      protected boolean handleFailure(Throwable t) {
+        return false;
+      }
+    };
+    ListenableFuture<?> runFuture = processor.start();
+    
+    try {
+      runFuture.get(10_000, TimeUnit.MILLISECONDS);
+      fail("Exception should have thrown");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() == expectedException);
+    }
+  }
+}


### PR DESCRIPTION
This is a type of limiter, but not in the form of a pool wrapper.  Instead this abstract class will pull for tasks when it is ready to accept more.
This is to make it easy to do processing which loads data (for example reading from a file).

The class will invoke `hasNext()` to check if the class has more work to execute.  Assuming it does, and assuming there is capacity to execute it, the class will then invoke `next` to start execution.
As tasks complete the relevant `handleResult` or `handleFailure` will be invoked, providing the results of the execution (in order if desired).

Possibly the most awkward aspect of this implementation is when things will be called concurrently vs not.  `next()` wont be called concurrently due to the need to check for execution before invoking.  But `handleResult` / `handleFailure` may be called concurrently (unless in-order processing is specified).

@lwahlmeier Any suggestions on the API of this class or otherwise?