### PR TITLE
Lazy ExceptionUtils.handleException StackOverflowError reporting

### DIFF
--- a/src/main/java/org/threadly/concurrent/CentralThreadlyPool.java
+++ b/src/main/java/org/threadly/concurrent/CentralThreadlyPool.java
@@ -540,8 +540,10 @@ public class CentralThreadlyPool {
       result = MASTER_SCHEDULER;
     } else if (defaultPriority ==  TaskPriority.Low) {
       result = LOW_PRIORITY_MASTER_SCHEDULER;
-    } else {
+    } else if (defaultPriority == TaskPriority.Starvable) {
       result = STARVABLE_PRIORITY_MASTER_SCHEDULER;
+    } else {
+      throw new IllegalArgumentException("Unknown TaskPriority: " + defaultPriority);
     }
     if (StringUtils.isNullOrEmpty(threadName)) {
       return result;

--- a/src/main/java/org/threadly/concurrent/future/CancelDebuggingListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/CancelDebuggingListenableFuture.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.ExceptionUtils;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 /**
  * Wrapper for a {@link ListenableFuture} to provide enhanced features for debugging the state at 
@@ -104,7 +104,7 @@ public class CancelDebuggingListenableFuture<T> implements ListenableFuture<T> {
    * Throwable that is not thrown, but instead added as a cause to indicate the processing stack 
    * trace at the time of cancellation.
    */
-  public static class FutureProcessingStack extends SuppressedStackRuntimeException {
+  public static class FutureProcessingStack extends StackSuppressedRuntimeException {
     private static final long serialVersionUID = 5326874345871027481L;
 
     protected FutureProcessingStack(StackTraceElement[] cancelStack) {

--- a/src/main/java/org/threadly/concurrent/future/InternalFutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/InternalFutureUtils.java
@@ -18,7 +18,7 @@ import java.util.function.Supplier;
 import org.threadly.concurrent.SameThreadSubmitterExecutor;
 import org.threadly.concurrent.future.ListenableFuture.ListenerOptimizationStrategy;
 import org.threadly.util.ExceptionUtils;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 /**
  * Package protected utility classes and functions for operating on Futures.  Implementation 
@@ -368,7 +368,7 @@ class InternalFutureUtils {
      * The instance of the only exception which this callback will not propagate.  It must be the 
      * exact exception, and can not be hidden inside a cause chain.
      */
-    protected static final RuntimeException IGNORED_FAILURE = new SuppressedStackRuntimeException();
+    protected static final RuntimeException IGNORED_FAILURE = new StackSuppressedRuntimeException();
     
     private final SettableListenableFuture<?> settableFuture;
     

--- a/src/main/java/org/threadly/concurrent/future/ListenableFutureAdapterTask.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFutureAdapterTask.java
@@ -4,7 +4,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 /**
  * Adapter from java's {@link Future} to threadly's {@link ListenableFuture}.  This transfers the 
@@ -41,7 +41,7 @@ public class ListenableFutureAdapterTask<T> extends ListenableFutureTask<T> {
           if (cause instanceof Exception) {
             throw (Exception)cause;
           } else {
-            throw new SuppressedStackRuntimeException(cause);
+            throw new StackSuppressedRuntimeException(cause);
           }
         }
       }

--- a/src/main/java/org/threadly/concurrent/future/ListenableFutureTask.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFutureTask.java
@@ -9,7 +9,7 @@ import org.threadly.concurrent.CallableContainer;
 import org.threadly.concurrent.RunnableCallableAdapter;
 import org.threadly.concurrent.event.RunnableListenerHelper;
 import org.threadly.util.ExceptionUtils;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 import org.threadly.util.UnsafeAccess;
 
 /**
@@ -173,7 +173,7 @@ public class ListenableFutureTask<T> extends FutureTask<T>
       }
     } catch (RuntimeException | IllegalAccessException  e) {
       ExceptionUtils.handleException(
-          new SuppressedStackRuntimeException("Stack access not supported, returning null" + 
+          new StackSuppressedRuntimeException("Stack access not supported, returning null" + 
                                                 "...Please see first exception for more details", e));
       return null;
     }

--- a/src/main/java/org/threadly/test/concurrent/AsyncVerifier.java
+++ b/src/main/java/org/threadly/test/concurrent/AsyncVerifier.java
@@ -15,7 +15,7 @@ import org.threadly.util.Clock;
  * @since 1.0.0
  */
 public class AsyncVerifier {
-  protected static final int DEFAULT_TIMEOUT = 1000 * 10;
+  protected static final int DEFAULT_TIMEOUT = 10_000;
   
   protected final Object notifyLock;
   private int signalCount;

--- a/src/main/java/org/threadly/util/StackSuppressedRuntimeException.java
+++ b/src/main/java/org/threadly/util/StackSuppressedRuntimeException.java
@@ -1,0 +1,83 @@
+package org.threadly.util;
+
+/**
+ * Type of {@link RuntimeException} which does not generate a stack at it's point of creation.  
+ * Generating a stack trace in java is very expensive, and does not always further the understanding 
+ * of the type of error (particularly when the exception is wrapping another exception, or is a 
+ * communication of state).  In those select conditions using or extending this type of exception 
+ * can provide a significant performance gain.
+ * 
+ * @since 5.39 (Existed since 4.8 as SuppressedStackRuntimeException)
+ */
+public class StackSuppressedRuntimeException extends RuntimeException {
+  private static final long serialVersionUID = -3253477627669379892L;
+  
+  protected static final StackTraceElement[] STATIC_STACK;
+
+  static {
+    STATIC_STACK = new StackTraceElement[] {
+        new StackTraceElement(StackSuppressedRuntimeException.class.getName(), "suppressedStack",
+                              StackSuppressedRuntimeException.class.getSimpleName() + ".java", 0)};
+  }
+
+  /**
+   * Construct a new exception with no message or cause.  The cause is not initialized, and may 
+   * subsequently be initialized by invoking {@link #initCause}.
+   */
+  public StackSuppressedRuntimeException() {
+    super();
+  }
+
+  /**
+   * Construct a new exception with a provided message and no cause.
+   * 
+   * @param msg The message which can later be retrieved by {@link #getMessage()}
+   */
+  public StackSuppressedRuntimeException(String msg) {
+    super(msg);
+  }
+
+  /**
+   * Construct a new exception with a provided cause.  The message will be defaulted from the cause 
+   * provided.
+   * 
+   * @param cause The cause which contributed to this exception
+   */
+  public StackSuppressedRuntimeException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * Construct a new exception providing both a unique message and cause.
+   * 
+   * @param msg The message which can later be retrieved by {@link #getMessage()}
+   * @param cause The cause which contributed to this exception
+   */
+  public StackSuppressedRuntimeException(String msg, Throwable cause) {
+    super(msg, cause);
+  }
+
+  /**
+   * Checked at construction if a true stack should be provided or not.  This can overridden to
+   * provide {@code false} result so that the real stack trace can be reported.  Otherwise this will
+   * default to doing what this class is designed to do (avoid stack generation).  
+   * <p>
+   * If overriding be aware that this is checked very early on, before any dynamic class values can 
+   * be set, and thus should be referencing a constant (static) value.
+   *
+   * @return {@code true} to indicate that the suppressed stack should be used
+   */
+  protected boolean suppressStackGeneration() {
+    return true;
+  }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    if (suppressStackGeneration()) {
+      this.setStackTrace(STATIC_STACK);
+      return this;
+    } else {
+      return super.fillInStackTrace();
+    }
+  }
+}

--- a/src/main/java/org/threadly/util/SuppressedStackRuntimeException.java
+++ b/src/main/java/org/threadly/util/SuppressedStackRuntimeException.java
@@ -7,19 +7,14 @@ package org.threadly.util;
  * communication of state).  In those select conditions using or extending this type of exception 
  * can provide a significant performance gain.
  * 
+ * @deprecated Renamed to {@link StackSuppressedRuntimeException}
+ * 
  * @since 4.8.0
  */
-public class SuppressedStackRuntimeException extends RuntimeException {
+@Deprecated
+public class SuppressedStackRuntimeException extends StackSuppressedRuntimeException {
   private static final long serialVersionUID = -3253477627669379892L;
   
-  protected static final StackTraceElement[] STATIC_STACK;
-
-  static {
-    STATIC_STACK = new StackTraceElement[] {
-        new StackTraceElement(SuppressedStackRuntimeException.class.getName(), "suppressedStack",
-                              SuppressedStackRuntimeException.class.getSimpleName() + ".java", 0)};
-  }
-
   /**
    * Construct a new exception with no message or cause.  The cause is not initialized, and may 
    * subsequently be initialized by invoking {@link #initCause}.
@@ -55,29 +50,5 @@ public class SuppressedStackRuntimeException extends RuntimeException {
    */
   public SuppressedStackRuntimeException(String msg, Throwable cause) {
     super(msg, cause);
-  }
-
-  /**
-   * Checked at construction if a true stack should be provided or not.  This can overridden to
-   * provide {@code false} result so that the real stack trace can be reported.  Otherwise this will
-   * default to doing what this class is designed to do (avoid stack generation).  
-   * <p>
-   * If overriding be aware that this is checked very early on, before any dynamic class values can 
-   * be set, and thus should be referencing a constant (static) value.
-   *
-   * @return {@code true} to indicate that the suppressed stack should be used
-   */
-  protected boolean suppressStackGeneration() {
-    return true;
-  }
-
-  @Override
-  public Throwable fillInStackTrace() {
-    if (suppressStackGeneration()) {
-      this.setStackTrace(STATIC_STACK);
-      return this;
-    } else {
-      return super.fillInStackTrace();
-    }
   }
 }

--- a/src/test/java/org/threadly/concurrent/CentralThreadlyPoolTest.java
+++ b/src/test/java/org/threadly/concurrent/CentralThreadlyPoolTest.java
@@ -90,6 +90,11 @@ public class CentralThreadlyPoolTest extends ThreadlyTester {
     av.waitForTest();
   }
   
+  @Test (expected = IllegalArgumentException.class)
+  public void rangedThreadPoolNullPriorityFail() {
+    CentralThreadlyPool.rangedThreadPool((TaskPriority)null, 0, 2, null);
+  }
+  
   @Test
   public void lowPrioritySingleThreadExecuteTest() throws InterruptedException, TimeoutException {
     AsyncVerifier av = new AsyncVerifier();
@@ -180,6 +185,11 @@ public class CentralThreadlyPoolTest extends ThreadlyTester {
       av.signalComplete();
     });
     av.waitForTest();
+  }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void threadPoolNullPriorityFail() {
+    CentralThreadlyPool.threadPool((TaskPriority)null, 2, null);
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/NoThreadSchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/NoThreadSchedulerTest.java
@@ -21,7 +21,7 @@ import org.threadly.test.concurrent.AsyncVerifier;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.util.Clock;
 import org.threadly.util.ExceptionHandler;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class NoThreadSchedulerTest extends ThreadlyTester {
@@ -62,7 +62,7 @@ public class NoThreadSchedulerTest extends ThreadlyTester {
   
   @Test
   public void tickWithoutHandlerThrowsRuntimeExceptionTest() {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     scheduler.execute(new TestRuntimeFailureRunnable(failure));
     
     try {
@@ -75,7 +75,7 @@ public class NoThreadSchedulerTest extends ThreadlyTester {
   
   @Test
   public void tickHandlesRuntimeExceptionTest() {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     final AtomicReference<Throwable> handledException = new AtomicReference<>(null);
     scheduler.execute(new TestRuntimeFailureRunnable(failure));
     

--- a/src/test/java/org/threadly/concurrent/RunnableChainTest.java
+++ b/src/test/java/org/threadly/concurrent/RunnableChainTest.java
@@ -9,7 +9,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
 import org.threadly.test.concurrent.TestRunnable;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class RunnableChainTest extends ThreadlyTester {
@@ -80,7 +80,7 @@ public class RunnableChainTest extends ThreadlyTester {
     @Override
     public void handleRunStart() {
       if (fail) {
-        throw new SuppressedStackRuntimeException("Test failure exception");
+        throw new StackSuppressedRuntimeException("Test failure exception");
       }
     }
   }

--- a/src/test/java/org/threadly/concurrent/SubmitterExecutorInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/SubmitterExecutorInterfaceTest.java
@@ -17,7 +17,7 @@ import org.threadly.ThreadlyTester;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.test.concurrent.AsyncVerifier;
 import org.threadly.test.concurrent.TestRunnable;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public abstract class SubmitterExecutorInterfaceTest extends ThreadlyTester {
@@ -205,7 +205,7 @@ public abstract class SubmitterExecutorInterfaceTest extends ThreadlyTester {
     try {
       SubmitterExecutor executor = factory.makeSubmitterExecutor(TEST_QTY, false);
       
-      RuntimeException failure = new SuppressedStackRuntimeException();
+      RuntimeException failure = new StackSuppressedRuntimeException();
       TestRuntimeFailureRunnable tr = new TestRuntimeFailureRunnable(failure);
       ListenableFuture<?> future = executor.submit(tr);
       // no exception should propagate
@@ -279,7 +279,7 @@ public abstract class SubmitterExecutorInterfaceTest extends ThreadlyTester {
     try {
       SubmitterExecutor executor = factory.makeSubmitterExecutor(TEST_QTY, false);
       
-      RuntimeException failure = new SuppressedStackRuntimeException();
+      RuntimeException failure = new StackSuppressedRuntimeException();
       TestRuntimeFailureRunnable tr = new TestRuntimeFailureRunnable(failure);
       ListenableFuture<?> future = executor.submit(tr, new Object());
       // no exception should propagate
@@ -342,7 +342,7 @@ public abstract class SubmitterExecutorInterfaceTest extends ThreadlyTester {
     try {
       SubmitterExecutor executor = factory.makeSubmitterExecutor(TEST_QTY, false);
       
-      final RuntimeException failure = new SuppressedStackRuntimeException();
+      final RuntimeException failure = new StackSuppressedRuntimeException();
       ListenableFuture<?> future = executor.submit(new Callable<Void>() {
         @Override
         public Void call() throws Exception {

--- a/src/test/java/org/threadly/concurrent/TestRuntimeFailureRunnable.java
+++ b/src/test/java/org/threadly/concurrent/TestRuntimeFailureRunnable.java
@@ -1,7 +1,7 @@
 package org.threadly.concurrent;
 
 import org.threadly.test.concurrent.TestRunnable;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class TestRuntimeFailureRunnable extends TestRunnable {
@@ -30,7 +30,7 @@ public class TestRuntimeFailureRunnable extends TestRunnable {
     if (toThrowException != null) {
       throw toThrowException;
     } else {
-      throw new SuppressedStackRuntimeException();
+      throw new StackSuppressedRuntimeException();
     }
   }
 }

--- a/src/test/java/org/threadly/concurrent/event/InvocationTeeTest.java
+++ b/src/test/java/org/threadly/concurrent/event/InvocationTeeTest.java
@@ -8,7 +8,7 @@ import org.threadly.ThreadlyTester;
 import org.threadly.concurrent.SameThreadSubmitterExecutor;
 import org.threadly.concurrent.TestRuntimeFailureRunnable;
 import org.threadly.test.concurrent.TestRunnable;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class InvocationTeeTest extends ThreadlyTester {
@@ -67,7 +67,7 @@ public class InvocationTeeTest extends ThreadlyTester {
   
   @Test
   public void invokeWithExceptionThrowingListenerExceptionTest() {
-    RuntimeException thrown = new SuppressedStackRuntimeException();
+    RuntimeException thrown = new StackSuppressedRuntimeException();
     TestRunnable tr = new TestRuntimeFailureRunnable(thrown);
     Runnable r = InvocationTee.teeWithExceptionThrowing(Runnable.class, null, tr);
     try {

--- a/src/test/java/org/threadly/concurrent/event/ListenerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/event/ListenerHelperTest.java
@@ -13,7 +13,7 @@ import org.threadly.concurrent.SameThreadSubmitterExecutor;
 import org.threadly.util.ExceptionUtils;
 import org.threadly.util.Pair;
 import org.threadly.util.StringUtils;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 import org.threadly.util.TestExceptionHandler;
 
 @SuppressWarnings("javadoc")
@@ -321,7 +321,7 @@ public class ListenerHelperTest extends ThreadlyTester {
     String testStr = StringUtils.makeRandomString(10);
     TestExceptionHandler teh = new TestExceptionHandler();
     ExceptionUtils.setThreadExceptionHandler(teh);
-    final RuntimeException e = new SuppressedStackRuntimeException();
+    final RuntimeException e = new StackSuppressedRuntimeException();
     ListenerHelper<TestInterface> ch = makeListenerHelper(TestInterface.class);
     ch.addListener(new TestInterface() {
       @Override

--- a/src/test/java/org/threadly/concurrent/event/RunnableListenerHelperTest.java
+++ b/src/test/java/org/threadly/concurrent/event/RunnableListenerHelperTest.java
@@ -14,7 +14,7 @@ import org.threadly.concurrent.PriorityScheduler;
 import org.threadly.concurrent.SameThreadSubmitterExecutor;
 import org.threadly.concurrent.StrictPriorityScheduler;
 import org.threadly.concurrent.TestRuntimeFailureRunnable;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class RunnableListenerHelperTest extends ThreadlyTester {
@@ -110,7 +110,7 @@ public class RunnableListenerHelperTest extends ThreadlyTester {
     TestRunnable tr = new TestRunnable() {
       @Override
       public void handleRunFinish() {
-        throw new SuppressedStackRuntimeException();
+        throw new StackSuppressedRuntimeException();
       }
     };
     onceHelper.addListener(tr);
@@ -125,7 +125,7 @@ public class RunnableListenerHelperTest extends ThreadlyTester {
     TestRunnable tr = new TestRunnable() {
       @Override
       public void handleRunFinish() {
-        throw new SuppressedStackRuntimeException();
+        throw new StackSuppressedRuntimeException();
       }
     };
     onceHelper.addListener(tr);

--- a/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
+++ b/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
@@ -23,7 +23,7 @@ import org.threadly.test.concurrent.AsyncVerifier;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.test.concurrent.TestableScheduler;
 import org.threadly.util.StringUtils;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class FutureUtilsTest extends ThreadlyTester {
@@ -1351,7 +1351,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void scheduleWhileTaskResultNullTaskFailureInThreadTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     @SuppressWarnings("deprecation")
     ListenableFuture<?> f = 
         FutureUtils.scheduleWhileTaskResultNull(scheduler, 10, false, () -> { throw failure; });
@@ -1368,7 +1368,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void scheduleWhileTaskResultNullTaskFailureOnSchedulerTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     @SuppressWarnings("deprecation")
     ListenableFuture<?> f = 
         FutureUtils.scheduleWhileTaskResultNull(scheduler, 10, true, () -> { throw failure; });
@@ -1474,7 +1474,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void scheduleWhileTaskFailureInThreadTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> f = 
         FutureUtils.scheduleWhile(scheduler, 10, false, () -> { throw failure; }, (o) -> false);
     
@@ -1490,7 +1490,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void scheduleWhileTaskFailureOnSchedulerTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> f = 
         FutureUtils.scheduleWhile(scheduler, 10, true, () -> { throw failure; }, (o) -> false);
 
@@ -1542,7 +1542,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void scheduleWhilePredicateThrowsInThreadTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<Object> f = 
         FutureUtils.scheduleWhile(scheduler, 2, false, () -> null, (o) -> { throw failure; });
     
@@ -1558,7 +1558,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void scheduleWhilePredicateThrowsOnSchedulerTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<Object> f = 
         FutureUtils.scheduleWhile(scheduler, 2, true, () -> null, (o) -> { throw failure; });
 
@@ -1588,7 +1588,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void scheduleWhileAlreadyDoneWithFailureTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<Object> f = 
         FutureUtils.scheduleWhile(scheduler, 2, FutureUtils.immediateFailureFuture(failure), 
                                   () -> null, (o) -> false);
@@ -1666,7 +1666,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void runnableScheduleWhileTaskFailureInThreadTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> f = 
         FutureUtils.scheduleWhile(scheduler, 10, false, () -> { throw failure; }, () -> false);
     
@@ -1682,7 +1682,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void runnableScheduleWhileTaskFailureOnSchedulerTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> f = 
         FutureUtils.scheduleWhile(scheduler, 10, true, () -> { throw failure; }, () -> false);
 
@@ -1720,7 +1720,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void runnableScheduleWhilePredicateThrowsInThreadTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> f = 
         FutureUtils.scheduleWhile(scheduler, 2, false, DoNothingRunnable.instance(), () -> { throw failure; });
     
@@ -1736,7 +1736,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   @Test
   public void runnableScheduleWhilePredicateThrowsOnSchedulerTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> f = 
         FutureUtils.scheduleWhile(scheduler, 2, true, DoNothingRunnable.instance(), () -> { throw failure; });
 
@@ -1803,7 +1803,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   
   @Test
   public void executeWhileTaskFailureTest() throws InterruptedException {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> f = 
         FutureUtils.executeWhile(FutureUtils.immediateResultFuture(null), 
                                  () -> { throw failure; }, 
@@ -1844,7 +1844,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   
   @Test
   public void executeWhilePredicateThrowsTest() throws InterruptedException {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<Object> f = 
         FutureUtils.executeWhile(() -> FutureUtils.immediateResultFuture(null), (o) -> { throw failure; });
     

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureInterfaceTest.java
@@ -22,7 +22,7 @@ import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.test.concurrent.TestableScheduler;
 import org.threadly.util.ExceptionUtils;
 import org.threadly.util.StringUtils;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 import org.threadly.util.TestExceptionHandler;
 
 @SuppressWarnings("javadoc")
@@ -238,7 +238,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
   public void mapAlreadyDoneMapperThrowExceptionTest() throws InterruptedException {
     TestExceptionHandler teh = new TestExceptionHandler();
     ExceptionUtils.setDefaultExceptionHandler(teh);
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);
     ListenableFuture<Void> mappedLF = lf.map((o) -> { throw failure; });
 
@@ -306,7 +306,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
     TestExceptionHandler teh = new TestExceptionHandler();
     ExceptionUtils.setDefaultExceptionHandler(teh);
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);
     ListenableFuture<Void> mappedLF = lf.map((o) -> { throw failure; }, scheduler);
   
@@ -417,7 +417,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
   public void throwMapAlreadyDoneMapperThrowExceptionTest() throws InterruptedException {
     TestExceptionHandler teh = new TestExceptionHandler();
     ExceptionUtils.setDefaultExceptionHandler(teh);
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);
     ListenableFuture<Void> mappedLF = lf.throwMap((o) -> { throw failure; });
 
@@ -485,7 +485,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
     TestExceptionHandler teh = new TestExceptionHandler();
     ExceptionUtils.setDefaultExceptionHandler(teh);
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);
     ListenableFuture<Void> mappedLF = lf.throwMap((o) -> { throw failure; }, scheduler);
   
@@ -543,7 +543,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
   
   @Test
   public void flatMapAlreadyDoneMapperThrowExceptionTest() throws InterruptedException {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);
     ListenableFuture<Void> mappedLF = lf.flatMap((o) -> { throw failure; });
 
@@ -553,7 +553,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
   
   @Test
   public void flatMapAlreadyDoneMapperReturnFailedFutureTest() throws InterruptedException {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);
     ListenableFuture<Void> mappedLF = lf.flatMap((o) -> FutureUtils.immediateFailureFuture(failure));
 
@@ -684,7 +684,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
   @Test
   public void flatMapWithExecutorAlreadyDoneMapperThrowExceptionTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);
     ListenableFuture<Void> mappedLF = lf.flatMap((o) -> { throw failure; }, scheduler);
   
@@ -697,7 +697,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
   @Test
   public void flatMapWithExecutorAlreadyDoneMapperReturnFailedFutureTest() throws InterruptedException {
     TestableScheduler scheduler = new TestableScheduler();
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFuture<?> lf = makeListenableFutureFactory().makeWithResult(null);
     ListenableFuture<Void> mappedLF = lf.flatMap((o) -> FutureUtils.immediateFailureFuture(failure), scheduler);
   

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -22,7 +22,7 @@ import org.threadly.concurrent.TestRuntimeFailureRunnable;
 import org.threadly.concurrent.future.ListenableFuture.ListenerOptimizationStrategy;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.test.concurrent.TestableScheduler;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceTest {
@@ -168,7 +168,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   
   @Test
   public void callbackExecutionExceptionTest() {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFutureTask<Object> future = makeFutureTask(new TestRuntimeFailureRunnable(failure), null);
     TestFutureCallback tfc = new TestFutureCallback();
     future.callback(tfc);
@@ -183,7 +183,7 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
   
   @Test
   public void failureCallbackExecutionExceptionTest() {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     ListenableFutureTask<Object> future = makeFutureTask(new TestRuntimeFailureRunnable(failure), null);
     TestFutureCallback tfc = new TestFutureCallback();
     future.failureCallback(tfc::handleFailure);

--- a/src/test/java/org/threadly/concurrent/future/ScheduledFutureDelegateTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ScheduledFutureDelegateTest.java
@@ -11,7 +11,7 @@ import org.threadly.ThreadlyTester;
 import org.threadly.concurrent.SameThreadSubmitterExecutor;
 import org.threadly.concurrent.TestDelayed;
 import org.threadly.test.concurrent.TestRunnable;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings({"javadoc", "deprecation"})
 public class ScheduledFutureDelegateTest extends ThreadlyTester {
@@ -109,7 +109,7 @@ public class ScheduledFutureDelegateTest extends ThreadlyTester {
     TestFutureImp future = new TestFutureImp(false) {
       @Override
       public Object get() throws ExecutionException {
-        throw new ExecutionException(new SuppressedStackRuntimeException());
+        throw new ExecutionException(new StackSuppressedRuntimeException());
       }
     };
     ScheduledFutureDelegate<?> testItem = new ScheduledFutureDelegate<>(future, null);

--- a/src/test/java/org/threadly/concurrent/wrapper/KeyDistributedExecutorTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/KeyDistributedExecutorTest.java
@@ -31,7 +31,7 @@ import org.threadly.test.concurrent.TestCondition;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.test.concurrent.TestUtils;
 import org.threadly.util.ExceptionUtils;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 import org.threadly.util.TestExceptionHandler;
 
 @SuppressWarnings("javadoc")
@@ -328,7 +328,7 @@ public class KeyDistributedExecutorTest extends ThreadlyTester {
   public void taskExceptionTest() {
     Integer key = 1;
     TestExceptionHandler teh = new TestExceptionHandler();
-    final RuntimeException testException = new SuppressedStackRuntimeException();
+    final RuntimeException testException = new StackSuppressedRuntimeException();
     ExceptionUtils.setDefaultExceptionHandler(teh);
     TestRunnable exceptionRunnable = new TestRuntimeFailureRunnable(testException);
     TestRunnable followRunnable = new TestRunnable();

--- a/src/test/java/org/threadly/concurrent/wrapper/ThrowableSuppressingRunnableTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/ThrowableSuppressingRunnableTest.java
@@ -7,7 +7,7 @@ import org.threadly.ThreadlyTester;
 import org.threadly.concurrent.TestRuntimeFailureRunnable;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.util.ExceptionUtils;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 import org.threadly.util.TestExceptionHandler;
 
 @SuppressWarnings("javadoc")
@@ -41,7 +41,7 @@ public class ThrowableSuppressingRunnableTest extends ThreadlyTester {
   @Test
   public void runExceptionTest() {
     TestExceptionHandler teh = new TestExceptionHandler();
-    final RuntimeException testException = new SuppressedStackRuntimeException();
+    final RuntimeException testException = new StackSuppressedRuntimeException();
     ExceptionUtils.setThreadExceptionHandler(teh);
     TestRunnable exceptionRunnable = new TestRuntimeFailureRunnable(testException);
     Runnable tsr = new ThrowableSuppressingRunnable(exceptionRunnable);

--- a/src/test/java/org/threadly/concurrent/wrapper/compatibility/ScheduledExecutorServiceTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/compatibility/ScheduledExecutorServiceTest.java
@@ -27,7 +27,7 @@ import org.threadly.test.concurrent.TestCondition;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.test.concurrent.TestUtils;
 import org.threadly.util.Clock;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public abstract class ScheduledExecutorServiceTest extends ThreadlyTester {
@@ -334,7 +334,7 @@ public abstract class ScheduledExecutorServiceTest extends ThreadlyTester {
         @Override
         public void handleRunFinish() {
           if (this.getRunCount() >= runCountTillException) {
-            throw new SuppressedStackRuntimeException();
+            throw new StackSuppressedRuntimeException();
           }
         }
       };
@@ -484,7 +484,7 @@ public abstract class ScheduledExecutorServiceTest extends ThreadlyTester {
           tc = new TestCallable(0) {
             @Override
             protected void handleCallStart() {
-              throw new SuppressedStackRuntimeException();
+              throw new StackSuppressedRuntimeException();
             }
           };
         } else {

--- a/src/test/java/org/threadly/concurrent/wrapper/compatibility/ScheduledFutureDelegateTest.java
+++ b/src/test/java/org/threadly/concurrent/wrapper/compatibility/ScheduledFutureDelegateTest.java
@@ -14,7 +14,7 @@ import org.threadly.concurrent.future.TestFutureCallback;
 import org.threadly.concurrent.future.TestFutureImp;
 import org.threadly.concurrent.wrapper.compatibility.AbstractExecutorServiceWrapper.ScheduledFutureDelegate;
 import org.threadly.test.concurrent.TestRunnable;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class ScheduledFutureDelegateTest extends ThreadlyTester {
@@ -112,7 +112,7 @@ public class ScheduledFutureDelegateTest extends ThreadlyTester {
     TestFutureImp future = new TestFutureImp(false) {
       @Override
       public Object get() throws ExecutionException {
-        throw new ExecutionException(new SuppressedStackRuntimeException());
+        throw new ExecutionException(new StackSuppressedRuntimeException());
       }
     };
     ScheduledFutureDelegate<?> testItem = new ScheduledFutureDelegate<>(future, null);

--- a/src/test/java/org/threadly/test/concurrent/TestableSchedulerTest.java
+++ b/src/test/java/org/threadly/test/concurrent/TestableSchedulerTest.java
@@ -19,7 +19,7 @@ import org.threadly.concurrent.TestCallable;
 import org.threadly.concurrent.TestRuntimeFailureRunnable;
 import org.threadly.util.Clock;
 import org.threadly.util.ExceptionHandler;
-import org.threadly.util.SuppressedStackRuntimeException;
+import org.threadly.util.StackSuppressedRuntimeException;
 
 @SuppressWarnings("javadoc")
 public class TestableSchedulerTest extends ThreadlyTester {
@@ -69,7 +69,7 @@ public class TestableSchedulerTest extends ThreadlyTester {
   
   @Test
   public void advanceWithoutHandlerThrowsRuntimeExceptionTest() {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     scheduler.execute(new TestRuntimeFailureRunnable(failure));
     
     try {
@@ -82,7 +82,7 @@ public class TestableSchedulerTest extends ThreadlyTester {
   
   @Test
   public void advanceHandlesRuntimeExceptionTest() {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     final AtomicReference<Throwable> handledException = new AtomicReference<>(null);
     scheduler.execute(new TestRuntimeFailureRunnable(failure));
     
@@ -99,7 +99,7 @@ public class TestableSchedulerTest extends ThreadlyTester {
   
   @Test
   public void tickWithoutHandlerThrowsRuntimeExceptionTest() {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     scheduler.execute(new TestRuntimeFailureRunnable(failure));
     
     try {
@@ -112,7 +112,7 @@ public class TestableSchedulerTest extends ThreadlyTester {
   
   @Test
   public void tickHandlesRuntimeExceptionTest() {
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     final AtomicReference<Throwable> handledException = new AtomicReference<>(null);
     scheduler.execute(new TestRuntimeFailureRunnable(failure));
     

--- a/src/test/java/org/threadly/util/AbstractServiceTest.java
+++ b/src/test/java/org/threadly/util/AbstractServiceTest.java
@@ -107,14 +107,14 @@ public class AbstractServiceTest extends ThreadlyTester {
     @Override
     protected void startupService() {
       if (! startCalled.compareAndSet(false, true)) {
-        throw new SuppressedStackRuntimeException();
+        throw new StackSuppressedRuntimeException();
       }
     }
 
     @Override
     protected void shutdownService() {
       if (! stopCalled.compareAndSet(false, true)) {
-        throw new SuppressedStackRuntimeException();
+        throw new StackSuppressedRuntimeException();
       }
     }
   }

--- a/src/test/java/org/threadly/util/ExceptionUtilsTest.java
+++ b/src/test/java/org/threadly/util/ExceptionUtilsTest.java
@@ -43,7 +43,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   public void runRunnableThrownTest() {
     TestExceptionHandler exceptionHandler = new TestExceptionHandler();
     ExceptionUtils.setThreadExceptionHandler(exceptionHandler);
-    RuntimeException failure = new SuppressedStackRuntimeException();
+    RuntimeException failure = new StackSuppressedRuntimeException();
     TestRuntimeFailureRunnable runnable = new TestRuntimeFailureRunnable(failure);
     
     ExceptionUtils.runRunnable(runnable);
@@ -114,7 +114,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   @Test
   @SuppressWarnings("resource")
   public void handleExceptionThrowExceptionTest() {
-    final RuntimeException thrownException = new SuppressedStackRuntimeException();
+    final RuntimeException thrownException = new StackSuppressedRuntimeException();
     // set handler that will throw exception
     ExceptionUtils.setThreadExceptionHandler(new ExceptionHandler() {
       @Override
@@ -343,15 +343,15 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   }
   
   private static Exception makeCycle(Exception rootCause) {
-    Exception e1 = new SuppressedStackRuntimeException(rootCause);
-    Exception e2 = new SuppressedStackRuntimeException(e1);
+    Exception e1 = new StackSuppressedRuntimeException(rootCause);
+    Exception e2 = new StackSuppressedRuntimeException(e1);
     rootCause.initCause(e2);
     return e2;
   }
   
   @Test
   public void getRootCauseStartCycleTest() {
-    Exception rootCause = new SuppressedStackRuntimeException();
+    Exception rootCause = new StackSuppressedRuntimeException();
     Exception e = makeCycle(rootCause);
     
     assertTrue(ExceptionUtils.getRootCause(e) == rootCause);
@@ -359,23 +359,23 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void getRootCauseMidCycleTest() {
-    Exception rootCause = new SuppressedStackRuntimeException();
-    Exception e = new SuppressedStackRuntimeException(makeCycle(rootCause));
+    Exception rootCause = new StackSuppressedRuntimeException();
+    Exception e = new StackSuppressedRuntimeException(makeCycle(rootCause));
     
     assertTrue(ExceptionUtils.getRootCause(e) == rootCause);
   }
   
   private static Exception makeLongChainException(Exception rootCause) {
-    Exception e = new SuppressedStackRuntimeException(rootCause);
+    Exception e = new StackSuppressedRuntimeException(rootCause);
     for (int i = 0; i < ExceptionUtils.CAUSE_CYCLE_DEPTH_TRIGGER * 2; i++) {
-      e = new SuppressedStackRuntimeException(e);
+      e = new StackSuppressedRuntimeException(e);
     }
     return e;
   }
   
   @Test
   public void getRootCauseLongChainNoCycleTest() {
-    Exception rootCause = new SuppressedStackRuntimeException();
+    Exception rootCause = new StackSuppressedRuntimeException();
     Exception e = makeLongChainException(rootCause);
     
     assertTrue(ExceptionUtils.getRootCause(e) == rootCause);
@@ -388,7 +388,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void getCauseOfTypeMissingTest() {
-    Exception e = new Exception(new SuppressedStackRuntimeException(new SuppressedStackRuntimeException()));
+    Exception e = new Exception(new StackSuppressedRuntimeException(new StackSuppressedRuntimeException()));
     
     assertNull(ExceptionUtils.getCauseOfType(e, IllegalArgumentException.class));
   }
@@ -413,7 +413,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   @Test
   public void getCauseOfTypeMidCycleTest() {
     IllegalArgumentException rootCause = new IllegalArgumentException();
-    Exception e = new SuppressedStackRuntimeException(makeCycle(rootCause));
+    Exception e = new StackSuppressedRuntimeException(makeCycle(rootCause));
     
     assertNull(ExceptionUtils.getCauseOfType(e, UnsupportedOperationException.class));
     assertTrue(rootCause == ExceptionUtils.getCauseOfType(e, IllegalArgumentException.class));
@@ -421,7 +421,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void getCauseOfTypeLongChainNoCycleTest() {
-    IllegalArgumentException expected = new IllegalArgumentException(new SuppressedStackRuntimeException());
+    IllegalArgumentException expected = new IllegalArgumentException(new StackSuppressedRuntimeException());
     Exception e = makeLongChainException(expected);
     
     assertTrue(expected == ExceptionUtils.getCauseOfType(e, IllegalArgumentException.class));
@@ -434,7 +434,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void hasCauseOfTypeMissingTest() {
-    Exception e = new Exception(new SuppressedStackRuntimeException(new SuppressedStackRuntimeException()));
+    Exception e = new Exception(new StackSuppressedRuntimeException(new StackSuppressedRuntimeException()));
     assertFalse(ExceptionUtils.hasCauseOfType(e, IllegalArgumentException.class));
   }
   
@@ -456,7 +456,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   @Test
   public void hasCauseOfTypeMidCycleTest() {
     IllegalArgumentException rootCause = new IllegalArgumentException();
-    Exception e = new SuppressedStackRuntimeException(makeCycle(rootCause));
+    Exception e = new StackSuppressedRuntimeException(makeCycle(rootCause));
 
     assertFalse(ExceptionUtils.hasCauseOfType(e, UnsupportedOperationException.class));
     assertTrue(ExceptionUtils.hasCauseOfType(e, IllegalArgumentException.class));
@@ -464,7 +464,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void hasCauseOfTypeLongChainNoCycleTest() {
-    IllegalArgumentException expected = new IllegalArgumentException(new SuppressedStackRuntimeException());
+    IllegalArgumentException expected = new IllegalArgumentException(new StackSuppressedRuntimeException());
     Exception e = makeLongChainException(expected);
 
     assertFalse(ExceptionUtils.hasCauseOfType(e, UnsupportedOperationException.class));
@@ -478,7 +478,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void getCauseOfTypesMissingTest() {
-    Exception e = new Exception(new SuppressedStackRuntimeException(new SuppressedStackRuntimeException()));
+    Exception e = new Exception(new StackSuppressedRuntimeException(new StackSuppressedRuntimeException()));
     assertNull(ExceptionUtils.getCauseOfTypes(e, Collections.singletonList(IllegalArgumentException.class)));
   }
   
@@ -501,7 +501,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   @Test
   public void getCauseOfTypesMidCycleTest() {
     IllegalArgumentException rootCause = new IllegalArgumentException();
-    Exception e = new SuppressedStackRuntimeException(makeCycle(rootCause));
+    Exception e = new StackSuppressedRuntimeException(makeCycle(rootCause));
     
     assertNull(ExceptionUtils.getCauseOfTypes(e, Collections.singleton(UnsupportedOperationException.class)));
     assertTrue(rootCause == ExceptionUtils.getCauseOfTypes(e, Collections.singleton(IllegalArgumentException.class)));
@@ -509,7 +509,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void getCauseOfTypesLongChainNoCycleTest() {
-    IllegalArgumentException expected = new IllegalArgumentException(new SuppressedStackRuntimeException());
+    IllegalArgumentException expected = new IllegalArgumentException(new StackSuppressedRuntimeException());
     Exception e = makeLongChainException(expected);
     
     assertTrue(expected == ExceptionUtils.getCauseOfTypes(e, Collections.singleton(IllegalArgumentException.class)));
@@ -522,7 +522,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void hasCauseOfTypesMissingTest() {
-    Exception e = new Exception(new SuppressedStackRuntimeException(new SuppressedStackRuntimeException()));
+    Exception e = new Exception(new StackSuppressedRuntimeException(new StackSuppressedRuntimeException()));
     assertFalse(ExceptionUtils.hasCauseOfTypes(e, Collections.singletonList(IllegalArgumentException.class)));
   }
   
@@ -544,7 +544,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   @Test
   public void hasCauseOfTypesMidCycleTest() {
     IllegalArgumentException rootCause = new IllegalArgumentException();
-    Exception e = new SuppressedStackRuntimeException(makeCycle(rootCause));
+    Exception e = new StackSuppressedRuntimeException(makeCycle(rootCause));
 
     assertFalse(ExceptionUtils.hasCauseOfTypes(e, Collections.singleton(UnsupportedOperationException.class)));
     assertTrue(ExceptionUtils.hasCauseOfTypes(e, Collections.singleton(IllegalArgumentException.class)));
@@ -552,7 +552,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void hasCauseOfTypesLongChainNoCycleTest() {
-    IllegalArgumentException expected = new IllegalArgumentException(new SuppressedStackRuntimeException());
+    IllegalArgumentException expected = new IllegalArgumentException(new StackSuppressedRuntimeException());
     Exception e = makeLongChainException(expected);
 
     assertFalse(ExceptionUtils.hasCauseOfTypes(e, Collections.singleton(UnsupportedOperationException.class)));
@@ -561,7 +561,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void makeRuntimeWithRuntimeTest() {
-    RuntimeException testException = new SuppressedStackRuntimeException();
+    RuntimeException testException = new StackSuppressedRuntimeException();
 
     RuntimeException resultException = ExceptionUtils.makeRuntime(testException);
     assertNotNull(resultException);
@@ -605,7 +605,7 @@ public class ExceptionUtilsTest extends ThreadlyTester {
   
   @Test
   public void makeRuntimeBooleanWithRuntimeTest() {
-    RuntimeException testException = new SuppressedStackRuntimeException();
+    RuntimeException testException = new StackSuppressedRuntimeException();
 
     RuntimeException resultException = ExceptionUtils.makeRuntime(testException, false);
     assertNotNull(resultException);

--- a/src/test/java/org/threadly/util/StackSuppressedRuntimeExceptionTest.java
+++ b/src/test/java/org/threadly/util/StackSuppressedRuntimeExceptionTest.java
@@ -1,0 +1,38 @@
+package org.threadly.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.threadly.ThreadlyTester;
+
+@SuppressWarnings("javadoc")
+public class StackSuppressedRuntimeExceptionTest extends ThreadlyTester {
+  @Test
+  public void suppressTest() {
+    assertSuppressed(new StackSuppressedRuntimeException());
+    assertSuppressed(new StackSuppressedRuntimeException("foo"));
+    assertSuppressed(new StackSuppressedRuntimeException(new StackSuppressedRuntimeException()));
+    assertSuppressed(new StackSuppressedRuntimeException("foo", new StackSuppressedRuntimeException()));
+  }
+  
+  private static void assertSuppressed(StackSuppressedRuntimeException e) {
+    StackTraceElement[] stack = e.getStackTrace();
+    for (StackTraceElement ste : stack) {
+      assertFalse(ste.getClassName().equals(StackSuppressedRuntimeExceptionTest.class.getName()));
+    }
+  }
+  
+  @Test
+  public void unsuppressTest() {
+    assertTrue(ExceptionUtils.stackToString(new UnsppressedTestException())
+                             .contains("StackSuppressedRuntimeExceptionTest"));
+  }
+  
+  @SuppressWarnings("serial")
+  private static class UnsppressedTestException extends StackSuppressedRuntimeException {
+    @Override
+    protected boolean suppressStackGeneration() {
+      return false;
+    }
+  }
+}

--- a/src/test/java/org/threadly/util/SuppressedStackRuntimeExceptionTest.java
+++ b/src/test/java/org/threadly/util/SuppressedStackRuntimeExceptionTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class SuppressedStackRuntimeExceptionTest extends ThreadlyTester {
   @Test
   public void suppressTest() {


### PR DESCRIPTION
This is a possible solution to resolve #237 .  First commit includes a minor rename that seems to keep tripping me up, while the second commit outlines the meat of this implementation.  From that commit:

It's important that `handleException` never throws an exception, however due to StackOverflow's making it hard to even log, that may result in the exception / problem being swallowed.
Setting a volatile does not expand the stack, so we can pull to see if any occured.  This may result in some exceptions being lost, however is better than getting no indication at all.

We have seen this before produce hard to debug problems.  @lwahlmeier What do you think about this?  Worth the minor overhead to improve the library safety?