### PR TITLE
Watchdog changes

### DIFF
--- a/src/main/java/org/threadly/concurrent/Poller.java
+++ b/src/main/java/org/threadly/concurrent/Poller.java
@@ -18,7 +18,7 @@ import org.threadly.concurrent.future.ListenableFutureAdapterTask;
 import org.threadly.concurrent.future.ListenableFutureTask;
 import org.threadly.concurrent.future.ListenableRunnableFuture;
 import org.threadly.concurrent.future.SettableListenableFuture;
-import org.threadly.concurrent.future.Watchdog;
+import org.threadly.concurrent.future.watchdog.ConstantTimeWatchdog;
 import org.threadly.util.ExceptionHandler;
 import org.threadly.util.ExceptionUtils;
 import org.threadly.util.Pair;
@@ -43,7 +43,7 @@ import org.threadly.util.Pair;
  */
 public class Poller {
   protected final SubmitterScheduler scheduler;
-  private final Watchdog futureWatchdog;
+  private final ConstantTimeWatchdog futureWatchdog;
   private final PollRunner runner;
 
   /**
@@ -72,7 +72,7 @@ public class Poller {
   public Poller(SubmitterScheduler scheduler, long pollFrequency, long maxWaitTime) {
     this.scheduler = scheduler;
     if (maxWaitTime > 0 && maxWaitTime != Long.MAX_VALUE) {
-      futureWatchdog = new Watchdog(scheduler, maxWaitTime, false);
+      futureWatchdog = new ConstantTimeWatchdog(scheduler, maxWaitTime, false);
     } else {
       futureWatchdog = null;
     }

--- a/src/main/java/org/threadly/concurrent/future/Watchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/Watchdog.java
@@ -1,16 +1,8 @@
 package org.threadly.concurrent.future;
 
-import java.util.Iterator;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.threadly.concurrent.CentralThreadlyPool;
-import org.threadly.concurrent.ReschedulingOperation;
-import org.threadly.concurrent.SameThreadSubmitterExecutor;
 import org.threadly.concurrent.SubmitterScheduler;
-import org.threadly.util.ArgumentVerifier;
-import org.threadly.util.Clock;
+import org.threadly.concurrent.future.watchdog.ConstantTimeWatchdog;
 
 /**
  * This class is to guarantee that a given {@link ListenableFuture} is completed within a 
@@ -21,27 +13,12 @@ import org.threadly.util.Clock;
  * Using {@link CancelDebuggingListenableFuture} to wrap the futures before providing to this class 
  * can provide an easier understanding of the state of a Future when it was timed out by this class.
  * 
+ * @deprecated Moved and renamed to {@link ConstantTimeWatchdog}
+ * 
  * @since 4.0.0
  */
-public class Watchdog {
-  private static final AtomicReference<SubmitterScheduler> STATIC_SCHEDULER = 
-      new AtomicReference<>();
-  
-  protected static final SubmitterScheduler getStaticScheduler() {
-    SubmitterScheduler ss = STATIC_SCHEDULER.get();
-    if (ss == null) {
-      STATIC_SCHEDULER.compareAndSet(null, CentralThreadlyPool.threadPool(2, "WatchdogDefaultScheduler"));
-      ss = STATIC_SCHEDULER.get();
-    }
-    
-    return ss;
-  }
-  
-  protected final long timeoutInMillis;
-  protected final boolean sendInterruptToTrackedThreads;
-  protected final CheckRunner checkRunner;
-  protected final Queue<FutureWrapper> futures;
-  
+@Deprecated
+public class Watchdog extends ConstantTimeWatchdog {
   /**
    * Constructs a new {@link Watchdog}.  This constructor will use a default static scheduler 
    * (which is lazily constructed).  This should be fine in most cases, but you can provide your 
@@ -53,7 +30,7 @@ public class Watchdog {
    *                                      an interrupt will be sent on timeout
    */
   public Watchdog(long timeoutInMillis, boolean sendInterruptOnFutureCancel) {
-    this(getStaticScheduler(), timeoutInMillis, sendInterruptOnFutureCancel);
+    super(timeoutInMillis, sendInterruptOnFutureCancel);
   }
   
   /**
@@ -69,133 +46,6 @@ public class Watchdog {
    */
   public Watchdog(SubmitterScheduler scheduler, long timeoutInMillis, 
                   boolean sendInterruptOnFutureCancel) {
-    // scheduler not null verified in CheckRunner
-    ArgumentVerifier.assertGreaterThanZero(timeoutInMillis, "timeoutInMillis");
-    
-    this.timeoutInMillis = timeoutInMillis;
-    this.sendInterruptToTrackedThreads = sendInterruptOnFutureCancel;
-    this.checkRunner = new CheckRunner(scheduler, timeoutInMillis);
-    this.futures = new ConcurrentLinkedQueue<>();
-  }
-  
-  /**
-   * Request the timeout in milliseconds until futures that have not completed are canceled.  This 
-   * is the timeout that the class was constructed with (since it can not be changed after 
-   * construction).
-   * 
-   * @return Time in milliseconds till incomplete futures have {@link ListenableFuture#cancel(boolean)} invoked
-   */
-  public long getTimeoutInMillis() {
-    return timeoutInMillis;
-  }
-  
-  /**
-   * Checks to see if this watchdog is currently active.  Meaning there are futures on it which 
-   * either have not been completed yet, or have not been inspected for completion.  If this 
-   * returns false, it means that there are no futures waiting to complete, and no scheduled tasks 
-   * currently scheduled to inspect them.
-   * 
-   * @return {@code true} if this watchdog is currently in use
-   */
-  public boolean isActive() {
-    return checkRunner.isActive() || ! futures.isEmpty();
-  }
-  
-  /**
-   * Watch a given {@link ListenableFuture} to ensure that it completes within the constructed 
-   * time limit.  If the future is not marked as done by the time limit then it will be completed 
-   * by invoking {@link ListenableFuture#cancel(boolean)}.  Weather a {@code true} or 
-   * {@code false} will be provided to interrupt the running thread is dependent on how this 
-   * {@link Watchdog} was constructed.
-   * 
-   * @param future Future to inspect to ensure completion
-   */
-  public void watch(ListenableFuture<?> future) {
-    if (future == null || future.isDone()) {
-      return;
-    }
-    
-    final FutureWrapper fw = new FutureWrapper(future);
-    futures.add(fw);
-    // we attempt to remove the future on completion to reduce inspection needed
-    future.listener(new WrapperRemover(fw), SameThreadSubmitterExecutor.instance());
-    
-    checkRunner.signalToRun();
-  }
-
-  /**
-   * Just a simple wrapper class so we can hold not just the future, but what time the future will 
-   * expire at.
-   * 
-   * @since 4.0.0
-   */
-  private class FutureWrapper {
-    public final long expireTime;
-    private final ListenableFuture<?> future;
-
-    public FutureWrapper(ListenableFuture<?> future) {
-      this.expireTime = Clock.accurateForwardProgressingMillis() + timeoutInMillis;
-      this.future = future;
-    }
-  }
-  
-  /**
-   * Listener implementation for removing the wrapper from the queue when it completes (and thus 
-   * invokes this).
-   * 
-   * @since 5.20
-   */
-  private class WrapperRemover implements Runnable {
-    private final FutureWrapper fw;
-    
-    protected WrapperRemover(FutureWrapper fw) {
-      this.fw = fw;
-    }
-    
-    @Override
-    public void run() {
-      futures.remove(fw);
-    }
-  }
-
-  /**
-   * This runnable inspects over the queue looking for futures which have expired and need to be 
-   * canceled.  It may reschedule itself if it is not able to fully examine the queue (because not 
-   * all items are currently ready for inspection).
-   * 
-   * @since 4.0.0
-   */
-  protected class CheckRunner extends ReschedulingOperation {
-    public CheckRunner(SubmitterScheduler scheduler, long scheduleDelay) {
-      super(scheduler, scheduleDelay);
-    }
-
-    @Override
-    protected void run() {
-      long now = Clock.accurateForwardProgressingMillis();
-      Iterator<FutureWrapper> it = futures.iterator();
-      FutureWrapper fw = null;
-      while (it.hasNext()) {
-        fw = it.next();
-        if (now >= fw.expireTime || (now = Clock.accurateForwardProgressingMillis()) >= fw.expireTime) {
-          it.remove();
-          fw.future.cancel(sendInterruptToTrackedThreads);
-          fw = null;
-        } else {
-          /* since futures are added in order of expiration, 
-          we know at this point we don't need to inspect any more items*/
-          break;
-        }
-      }
-      
-      if (fw != null) {
-        // update our execution time to when the next expiration will occur
-        setScheduleDelay(fw.expireTime - now);
-        signalToRun();  // notify we still have work to do
-      } else {
-        // ensure schedule delay is set correctly
-        setScheduleDelay(timeoutInMillis);
-      }
-    }
+    super(scheduler, timeoutInMillis, sendInterruptOnFutureCancel);
   }
 }

--- a/src/main/java/org/threadly/concurrent/future/watchdog/AbstractWatchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/watchdog/AbstractWatchdog.java
@@ -1,0 +1,89 @@
+package org.threadly.concurrent.future.watchdog;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.threadly.concurrent.CentralThreadlyPool;
+import org.threadly.concurrent.ReschedulingOperation;
+import org.threadly.concurrent.SameThreadSubmitterExecutor;
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.future.ListenableFuture;
+
+/**
+ * Abstract implementation for Watchdog.  Providing a global thread pool that watchdogs can default 
+ * to, as well as some minor code duplication reductions.
+ * 
+ * @since 5.40
+ */
+class AbstractWatchdog {
+  private static final AtomicReference<SubmitterScheduler> STATIC_SCHEDULER = 
+      new AtomicReference<>();
+  
+  protected static final SubmitterScheduler getStaticScheduler() {
+    SubmitterScheduler ss = STATIC_SCHEDULER.get();
+    if (ss == null) {
+      STATIC_SCHEDULER.compareAndSet(null, CentralThreadlyPool.threadPool(2, "WatchdogDefaultScheduler"));
+      ss = STATIC_SCHEDULER.get();
+    }
+    
+    return ss;
+  }
+
+  protected final Collection<Object> futures;
+  protected final ReschedulingOperation checkRunner;
+  
+  protected AbstractWatchdog(Function<Collection<?>, ReschedulingOperation> checkFactory) {
+    this.futures = new ConcurrentLinkedQueue<>();
+    this.checkRunner = checkFactory.apply(futures);
+  }
+  
+  /**
+   * Checks to see if this watchdog is currently active.  Meaning there are futures on it which 
+   * either have not been completed yet, or have not been inspected for completion.  If this 
+   * returns false, it means that there are no futures waiting to complete, and no scheduled tasks 
+   * currently scheduled to inspect them.
+   * 
+   * @return {@code true} if this watchdog is currently in use
+   */
+  public boolean isActive() {
+    return checkRunner.isActive() || ! futures.isEmpty();
+  }
+  
+  /**
+   * Check how many futures are currently being monitored for completion.
+   * 
+   * @return The number of futures being monitored
+   */
+  public int getWatchingCount() {
+    return futures.size();
+  }
+  
+  protected void watchWrapper(Object fw, ListenableFuture<?> future) {
+    futures.add(fw);
+    // we attempt to remove the future on completion to reduce inspection needed
+    future.listener(new WrapperRemover(fw), SameThreadSubmitterExecutor.instance());
+    
+    checkRunner.signalToRun();
+  }
+  
+  /**
+   * Listener implementation for removing the wrapper from the queue when it completes (and thus 
+   * invokes this).
+   * 
+   * @since 5.40
+   */
+  protected class WrapperRemover implements Runnable {
+    private final Object fw;
+    
+    protected WrapperRemover(Object fw) {
+      this.fw = fw;
+    }
+    
+    @Override
+    public void run() {
+      futures.remove(fw);
+    }
+  }
+}

--- a/src/main/java/org/threadly/concurrent/future/watchdog/ConstantTimeWatchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/watchdog/ConstantTimeWatchdog.java
@@ -1,0 +1,160 @@
+package org.threadly.concurrent.future.watchdog;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.threadly.concurrent.CentralThreadlyPool;
+import org.threadly.concurrent.ReschedulingOperation;
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.util.ArgumentVerifier;
+import org.threadly.util.Clock;
+
+/**
+ * This class is to guarantee that a given {@link ListenableFuture} is completed within a 
+ * timeout.  Once the timeout is reached, if the future has not already completed this will 
+ * attempt to invoke {@link ListenableFuture#cancel(boolean)}.  The future should then throw a 
+ * {@link java.util.concurrent.CancellationException} on a {@link ListenableFuture#get()} call.
+ * <p>
+ * Using {@link org.threadly.concurrent.future.CancelDebuggingListenableFuture} to wrap the futures 
+ * before providing to this class can provide an easier understanding of the state of a Future when 
+ * it was timed out by this class.
+ * 
+ * @since 5.40 (existed since 4.0.0 as org.threadly.concurrent.future.Watchdog)
+ */
+public class ConstantTimeWatchdog extends AbstractWatchdog {
+  protected final long timeoutInMillis;
+  
+  /**
+   * Constructs a new {@link ConstantTimeWatchdog}.  This constructor will use a default static scheduler 
+   * (which is lazily constructed).  This should be fine in most cases, but you can provide your 
+   * own scheduler if you have specific needs where the {@link CentralThreadlyPool} default is not 
+   * a good option.
+   * 
+   * @param timeoutInMillis Time in milliseconds that futures will be set to error if they are not done
+   * @param sendInterruptOnFutureCancel If {@code true}, and a thread is provided with the future, 
+   *                                      an interrupt will be sent on timeout
+   */
+  public ConstantTimeWatchdog(long timeoutInMillis, boolean sendInterruptOnFutureCancel) {
+    this(getStaticScheduler(), timeoutInMillis, sendInterruptOnFutureCancel);
+  }
+  
+  /**
+   * Constructs a new {@link ConstantTimeWatchdog} with a scheduler of your choosing.  It is critical that 
+   * this scheduler has a free thread available to inspect futures which may not have completed in 
+   * the given timeout.  You may want to use a org.threadly.concurrent.limiter to ensure that 
+   * there are threads available.
+   * 
+   * @param scheduler Scheduler to schedule task to look for expired futures
+   * @param timeoutInMillis Time in milliseconds that futures will be set to error if they are not done
+   * @param sendInterruptOnFutureCancel If {@code true}, and a thread is provided with the future, 
+   *                                      an interrupt will be sent on timeout
+   */
+  @SuppressWarnings("unchecked")
+  public ConstantTimeWatchdog(SubmitterScheduler scheduler, long timeoutInMillis, 
+                              boolean sendInterruptOnFutureCancel) {
+    super((futures) -> new CheckRunner(scheduler, timeoutInMillis, 
+                                       sendInterruptOnFutureCancel, 
+                                       (Collection<TimeoutFutureWrapper>) futures));
+    
+    // scheduler not null verified in CheckRunner
+    ArgumentVerifier.assertGreaterThanZero(timeoutInMillis, "timeoutInMillis");
+    
+    this.timeoutInMillis = timeoutInMillis;
+  }
+  
+  /**
+   * Request the timeout in milliseconds until futures that have not completed are canceled.  This 
+   * is the timeout that the class was constructed with (since it can not be changed after 
+   * construction).
+   * 
+   * @return Time in milliseconds till incomplete futures have {@link ListenableFuture#cancel(boolean)} invoked
+   */
+  public long getTimeoutInMillis() {
+    return timeoutInMillis;
+  }
+  
+  /**
+   * Watch a given {@link ListenableFuture} to ensure that it completes within the constructed 
+   * time limit.  If the future is not marked as done by the time limit then it will be completed 
+   * by invoking {@link ListenableFuture#cancel(boolean)}.  Weather a {@code true} or 
+   * {@code false} will be provided to interrupt the running thread is dependent on how this 
+   * {@link ConstantTimeWatchdog} was constructed.
+   * 
+   * @param future Future to inspect to ensure completion
+   */
+  public void watch(ListenableFuture<?> future) {
+    if (future == null || future.isDone()) {
+      return;
+    }
+
+    watchWrapper(new TimeoutFutureWrapper(future), future);
+  }
+
+  /**
+   * Just a simple wrapper class so we can hold not just the future, but what time the future will 
+   * expire at.
+   * 
+   * @since 5,40
+   */
+  protected class TimeoutFutureWrapper {
+    public final long expireTime;
+    protected final ListenableFuture<?> future;
+
+    public TimeoutFutureWrapper(ListenableFuture<?> future) {
+      this.expireTime = Clock.accurateForwardProgressingMillis() + timeoutInMillis;
+      this.future = future;
+    }
+  }
+
+  /**
+   * This runnable inspects over the queue looking for futures which have expired and need to be 
+   * canceled.  It may reschedule itself if it is not able to fully examine the queue (because not 
+   * all items are currently ready for inspection).
+   * 
+   * @since 5.40
+   */
+  protected static class CheckRunner extends ReschedulingOperation {
+    protected final long timeoutInMillis;
+    protected final boolean sendInterruptToTrackedThreads;
+    protected final Collection<TimeoutFutureWrapper> futures;
+    
+    public CheckRunner(SubmitterScheduler scheduler, long timeoutInMillis, 
+                       boolean sendInterruptToTrackedThreads, 
+                       Collection<TimeoutFutureWrapper> futures) {
+      super(scheduler, timeoutInMillis);
+      
+      this.timeoutInMillis = timeoutInMillis;
+      this.sendInterruptToTrackedThreads = sendInterruptToTrackedThreads;
+      this.futures = futures;
+    }
+
+    @Override
+    protected void run() {
+      TimeoutFutureWrapper fw = null;
+      Iterator<TimeoutFutureWrapper> it = futures.iterator();
+      long now = Clock.accurateForwardProgressingMillis();
+      while (it.hasNext()) {
+        fw = it.next();
+        if (now >= fw.expireTime || (now = Clock.accurateForwardProgressingMillis()) >= fw.expireTime) {
+          it.remove();
+          fw.future.cancel(sendInterruptToTrackedThreads);
+          fw = null;
+        } else {
+          /* since futures are added in order of expiration, 
+          we know at this point we don't need to inspect any more items*/
+          break;
+        }
+      }
+      
+      if (fw != null) {
+        // update our execution time to when the next expiration will occur
+        setScheduleDelay(fw.expireTime - now);
+        signalToRun();  // notify we still have work to do
+      } else {
+        // ensure schedule delay is set correctly
+        setScheduleDelay(timeoutInMillis);
+      }
+    }
+  }
+}

--- a/src/main/java/org/threadly/concurrent/future/watchdog/MixedTimeWatchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/watchdog/MixedTimeWatchdog.java
@@ -1,0 +1,191 @@
+package org.threadly.concurrent.future.watchdog;
+
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.util.ArgumentVerifier;
+
+/**
+ * A class which handles a collection of {@link ConstantTimeWatchdog} instances.  Because the 
+ * timeout for {@link ConstantTimeWatchdog} is set in the constructor 
+ * {@link ConstantTimeWatchdog#ConstantTimeWatchdog(long, boolean)}, you can 
+ * use this class to be more flexible and set the timeout at the time of watching the future.
+ * <p>
+ * Using {@link org.threadly.concurrent.future.CancelDebuggingListenableFuture} to wrap the futures 
+ * before providing to this class can provide an easier understanding of the state of a Future when 
+ * it was timed out by this class.
+ * 
+ * @since 5.40 (existed since 4.0.0 as org.threadly.concurrent.future.WatchdogCache)
+ */
+public class MixedTimeWatchdog {
+  protected static final int INSPECTION_INTERVAL_MILLIS = 10_000;
+  protected static final int DEFAULT_RESOLUTION_MILLIS = 200;
+
+  private static final AtomicReference<MixedTimeWatchdog> INTERRUPTING_WATCHDOG_CACHE = 
+      new AtomicReference<>();
+  private static final AtomicReference<MixedTimeWatchdog> NONINTERRUPTING_WATCHDOG_CACHE = 
+      new AtomicReference<>();
+  
+  /**
+   * Return a static / shared {@link MixedTimeWatchdog} instance.  This instance is backed by the 
+   * {@link org.threadly.concurrent.CentralThreadlyPool} which should be fine in most cases, but if 
+   * you have specific needs you can construct your own instance by 
+   * {@link #MixedTimeWatchdog(SubmitterScheduler, boolean)}, or if you need to specify a 
+   * specific timeout resolution using the 
+   * {@link #MixedTimeWatchdog(SubmitterScheduler, boolean, long)} constructor.
+   * <p>
+   * As long as those special cases are not needed, using a shared instance allows for potentially 
+   * improved efficiency.
+   * 
+   * @param sendInterruptOnFutureCancel If {@code true}, and a thread is provided with the future, 
+   *                                      an interrupt will be sent on timeout
+   * @return A shared {@link MixedTimeWatchdog} with the specified configuration
+   */
+  public static final MixedTimeWatchdog centralWatchdog(boolean sendInterruptOnFutureCancel) {
+    AtomicReference<MixedTimeWatchdog> ar = 
+        sendInterruptOnFutureCancel ? INTERRUPTING_WATCHDOG_CACHE : NONINTERRUPTING_WATCHDOG_CACHE;
+    MixedTimeWatchdog wd = ar.get();
+    if (wd == null) {
+      ar.compareAndSet(null, new MixedTimeWatchdog(AbstractWatchdog.getStaticScheduler(), 
+                                                      sendInterruptOnFutureCancel));
+      wd = ar.get();
+    }
+    
+    return wd;
+  }
+  
+  protected final SubmitterScheduler scheduler;
+  protected final boolean sendInterruptOnFutureCancel;
+  protected final ConcurrentMap<Long, ConstantTimeWatchdog> cachedDogs;
+  protected final Function<Long, ConstantTimeWatchdog> watchdogProducer;
+  protected final Runnable cacheCleaner;
+  protected final long resolutionMillis;
+  private final AtomicBoolean cleanerScheduled;
+
+  /**
+   * Constructs a new {@link MixedTimeWatchdog} with a scheduler of your choosing.  It is critical 
+   * that this scheduler has a free thread available to inspect futures which may not have 
+   * completed in the given timeout.  You may want to use a org.threadly.concurrent.limiter to 
+   * ensure that there are threads available.
+   * 
+   * @param scheduler Scheduler to schedule task to look for expired futures
+   * @param sendInterruptOnFutureCancel If {@code true}, and a thread is provided with the future, 
+   *                                      an interrupt will be sent on timeout
+   */
+  public MixedTimeWatchdog(SubmitterScheduler scheduler, boolean sendInterruptOnFutureCancel) {
+    this(scheduler, sendInterruptOnFutureCancel, DEFAULT_RESOLUTION_MILLIS);
+  }
+
+  /**
+   * Constructs a new {@link MixedTimeWatchdog} with a scheduler of your choosing.  It is critical 
+   * that this scheduler has a free thread available to inspect futures which may not have 
+   * completed in the given timeout.  You may want to use a org.threadly.concurrent.limiter to 
+   * ensure that there are threads available.
+   * <p>
+   * This constructor allows you to set the timeout resolutions.  Setting the resolution too large
+   * can result in futures timing out later than you expected.  Setting it too low results in 
+   * heavy memory consumption when used with a wide variety of timeouts.
+   * 
+   * @param scheduler Scheduler to schedule task to look for expired futures
+   * @param sendInterruptOnFutureCancel If {@code true}, and a thread is provided with the future, 
+   *                                      an interrupt will be sent on timeout
+   * @param resolutionMillis The resolution to allow timeout granularity
+   */
+  public MixedTimeWatchdog(SubmitterScheduler scheduler, boolean sendInterruptOnFutureCancel, 
+                           long resolutionMillis) {
+    ArgumentVerifier.assertGreaterThanZero(resolutionMillis, "resolutionMillis");
+    
+    this.scheduler = scheduler;
+    this.sendInterruptOnFutureCancel = sendInterruptOnFutureCancel;
+    cachedDogs = new ConcurrentHashMap<>();
+    watchdogProducer = (timeout) -> {
+      maybeScheduleCleaner();
+      return new ConstantTimeWatchdog(scheduler, timeout, sendInterruptOnFutureCancel);
+    };
+    cacheCleaner = new CleanRunner();
+    cleanerScheduled = new AtomicBoolean(false);
+    this.resolutionMillis = resolutionMillis;
+  }
+
+  /**
+   * Check how many futures are currently being monitored for completion.
+   * 
+   * @return The number of futures being monitored
+   */
+  public int getWatchingCount() {
+    int result = 0;
+    for (ConstantTimeWatchdog wd : cachedDogs.values()) {
+      result += wd.getWatchingCount();
+    }
+    return result;
+  }
+  
+  /**
+   * Watch a given {@link ListenableFuture} to ensure that it completes within the provided 
+   * time limit.  If the future is not marked as done by the time limit then it will be 
+   * completed by invoking {@link ListenableFuture#cancel(boolean)}.  Weather a {@code true} or 
+   * {@code false} will be provided to interrupt the running thread is dependent on how this 
+   * {@link MixedTimeWatchdog} was constructed.
+   * 
+   * @param timeoutInMillis Time in milliseconds that future should be completed within
+   * @param future Future to inspect to ensure completion
+   */
+  public void watch(long timeoutInMillis, ListenableFuture<?> future) {
+    long adjustedTimeout = timeoutInMillis / resolutionMillis; // int division to zero out to resolution
+    adjustedTimeout *= resolutionMillis;
+    if (adjustedTimeout != timeoutInMillis) {
+      adjustedTimeout += resolutionMillis;  // prefer timing out later rather than early
+    }
+    
+    // attempt around a cheap shortcut
+    if (future == null || future.isDone()) {
+      return;
+    }
+    
+    cachedDogs.computeIfAbsent(adjustedTimeout, watchdogProducer)
+              .watch(future);
+  }
+  
+  private void maybeScheduleCleaner() {
+    if (! cleanerScheduled.get() && cleanerScheduled.compareAndSet(false, true)) {
+      scheduler.schedule(cacheCleaner, INSPECTION_INTERVAL_MILLIS);
+    }
+  }
+  
+  /**
+   * Runnable which looks over all cached {@link Watchdog} instances to see if any are no longer 
+   * active.  Removing the inactive ones as they are found.  This also handles rescheduling itself 
+   * if future inspection may be needed.
+   * 
+   * @since 5.40
+   */
+  private class CleanRunner implements Runnable {
+    @Override
+    public void run() {
+      try {
+        Iterator<ConstantTimeWatchdog> it = cachedDogs.values().iterator();
+        while (it.hasNext()) {
+          if (! it.next().isActive()) {
+            it.remove();
+          }
+        }
+      } finally {
+        if (cachedDogs.isEmpty()) {
+          cleanerScheduled.set(false);
+          // must re-check state to ensure no concurrent Watchdog was added
+          if (! cachedDogs.isEmpty()) {
+            maybeScheduleCleaner();
+          }
+        } else {
+          scheduler.schedule(this, INSPECTION_INTERVAL_MILLIS);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/org/threadly/concurrent/future/watchdog/PollingWatchdog.java
+++ b/src/main/java/org/threadly/concurrent/future/watchdog/PollingWatchdog.java
@@ -1,0 +1,143 @@
+package org.threadly.concurrent.future.watchdog;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+import org.threadly.concurrent.CentralThreadlyPool;
+import org.threadly.concurrent.ReschedulingOperation;
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.util.ArgumentVerifier;
+import org.threadly.util.ExceptionUtils;
+
+/**
+ * This class is designed to help ensure a future completes with an arbitrary condition to 
+ * determine when a future should be canceled.  If the condition is time based then see 
+ * {@link ConstantTimeWatchdog} and {@link MixedTimeWatchdog} as possibly more efficient 
+ * options.  This class however can allow the condition to be independent from the submission to be 
+ * watched.  For example if you want to time something out after a lack of progress, but don't care 
+ * about the absolute time it has been running you can track that progress and provide a 
+ * {@link Supplier} to {@link #watch(Supplier, ListenableFuture)} which will return {@code true} 
+ * only once there has been no progress in X milliseconds.  The supplier will be invoked 
+ * regularly to check the state associated to the matching future.
+ * 
+ * @since 5.40
+ */
+public class PollingWatchdog extends AbstractWatchdog {
+  /**
+   * Constructs a new {@link PollingWatchdog}.  This constructor will use a default static scheduler 
+   * (which is lazily constructed).  This should be fine in most cases, but you can provide your 
+   * own scheduler if you have specific needs where the {@link CentralThreadlyPool} default is not 
+   * a good option.
+   * 
+   * @param pollFrequencyMillis Time in milliseconds that futures will be checked if they should be timed out
+   * @param sendInterruptOnFutureCancel If {@code true}, and a thread is provided with the future, 
+   *                                      an interrupt will be sent on timeout
+   */
+  public PollingWatchdog(long pollFrequencyMillis, boolean sendInterruptOnFutureCancel) {
+    this(getStaticScheduler(), pollFrequencyMillis, sendInterruptOnFutureCancel);
+  }
+  
+  /**
+   * Constructs a new {@link PollingWatchdog} with a scheduler of your choosing.  It is critical that 
+   * this scheduler has a free thread available to inspect futures which may not have completed in 
+   * the given timeout.  You may want to use a org.threadly.concurrent.limiter to ensure that 
+   * there are threads available.
+   * 
+   * @param scheduler Scheduler to schedule task to look for expired futures
+   * @param pollFrequencyMillis Time in milliseconds that futures will be checked if they should be timed out
+   * @param sendInterruptOnFutureCancel If {@code true}, and a thread is provided with the future, 
+   *                                      an interrupt will be sent on timeout
+   */
+  @SuppressWarnings("unchecked")
+  public PollingWatchdog(SubmitterScheduler scheduler, long pollFrequencyMillis, 
+                         boolean sendInterruptOnFutureCancel) {
+    super((futures) -> new CheckRunner(scheduler, pollFrequencyMillis, 
+                                       sendInterruptOnFutureCancel, 
+                                       (Collection<PollingFutureWrapper>) futures));
+    
+    // scheduler not null verified in CheckRunner
+    ArgumentVerifier.assertGreaterThanZero(pollFrequencyMillis, "pollFrequencyMillis");
+  }
+
+  /**
+   * Watch a given {@link ListenableFuture} to ensure that it completes within the constructed 
+   * time limit.  If the future is not marked as done by the time limit then it will be completed 
+   * by invoking {@link ListenableFuture#cancel(boolean)}.  Weather a {@code true} or 
+   * {@code false} will be provided to interrupt the running thread is dependent on how this 
+   * {@link PollingWatchdog} was constructed.
+   * <p>
+   * The provided {@link Supplier} will be invoked regularly as the state is polled.  Once it 
+   * returns {@code true} it will never be invoked again, and instead 
+   * {@link ListenableFuture#cancel(boolean)} will be invoked on the provided future. 
+   * 
+   * @param cancelTest Supplier to return {@code true} when the future should be canceled
+   * @param future Future to inspect to ensure completion
+   */
+  public void watch(Supplier<Boolean> cancelTest, ListenableFuture<?> future) {
+    if (future == null || future.isDone()) {
+      return;
+    }
+    
+    watchWrapper(new PollingFutureWrapper(cancelTest, future), future);
+  }
+
+  /**
+   * Just a simple wrapper class so we can hold not just the future, but what time the future will 
+   * expire at.
+   * 
+   * @since 5.40
+   */
+  protected class PollingFutureWrapper {
+    protected final Supplier<Boolean> cancelTest;
+    protected final ListenableFuture<?> future;
+
+    public PollingFutureWrapper(Supplier<Boolean> cancelTest, ListenableFuture<?> future) {
+      this.cancelTest = cancelTest;
+      this.future = future;
+    }
+  }
+
+  /**
+   * This runnable inspects over the queue looking for futures which have expired and need to be 
+   * canceled.  It may reschedule itself if it is not able to fully examine the queue (because not 
+   * all items are currently ready for inspection).
+   * 
+   * @since 5.40
+   */
+  protected static class CheckRunner extends ReschedulingOperation {
+    protected final boolean sendInterruptToTrackedThreads;
+    protected final Collection<PollingFutureWrapper> futures;
+    
+    public CheckRunner(SubmitterScheduler scheduler, long scheduleDelay, 
+                       boolean sendInterruptToTrackedThreads, 
+                       Collection<PollingFutureWrapper> futures) {
+      super(scheduler, scheduleDelay);
+      
+      this.sendInterruptToTrackedThreads = sendInterruptToTrackedThreads;
+      this.futures = futures;
+    }
+
+    @Override
+    protected void run() {
+      PollingFutureWrapper fw = null;
+      Iterator<PollingFutureWrapper> it = futures.iterator();
+      while (it.hasNext()) {
+        try {
+          fw = it.next();
+          if (fw.future.isDone() || fw.cancelTest.get()) {
+            it.remove();
+            fw.future.cancel(sendInterruptToTrackedThreads);
+          }
+        } catch (Throwable t) {
+          ExceptionUtils.handleException(t);
+        }
+      }
+      
+      if (! futures.isEmpty()) {
+        signalToRun();  // notify we still have work to do
+      }
+    }
+  }
+}

--- a/src/main/java/org/threadly/concurrent/future/watchdog/package-info.java
+++ b/src/main/java/org/threadly/concurrent/future/watchdog/package-info.java
@@ -1,0 +1,5 @@
+
+/**
+ * Implementations for monitoring futures and helping ensure they eventually complete.
+ */
+package org.threadly.concurrent.future.watchdog;

--- a/src/test/java/org/threadly/concurrent/future/WatchdogCacheTest.java
+++ b/src/test/java/org/threadly/concurrent/future/WatchdogCacheTest.java
@@ -9,7 +9,7 @@ import org.threadly.ThreadlyTester;
 import org.threadly.test.concurrent.TestUtils;
 import org.threadly.test.concurrent.TestableScheduler;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class WatchdogCacheTest extends ThreadlyTester {
   private static final int TIMEOUT = 1;
   
@@ -29,26 +29,11 @@ public class WatchdogCacheTest extends ThreadlyTester {
   }
   
   @Test
-  @SuppressWarnings("deprecation")
-  public void booleanSchedulerConstructorTest() {
-    watchdog = new WatchdogCache(true);
-    
-    assertNotNull(watchdog.scheduler);
-  }
-  
-  @Test
-  public void centralWatchdogCacheConstructorTest() {
-    watchdog = WatchdogCache.centralWatchdogCache(true);
-    
-    assertNotNull(watchdog.scheduler);
-  }
-  
-  @Test
   public void alreadyDoneFutureWatchTest() {
     ListenableFuture<Object> future = FutureUtils.immediateResultFuture(null);
     watchdog.watch(TIMEOUT, future);
-    
-    assertTrue(watchdog.cachedDogs.isEmpty());
+
+    assertEquals(0, watchdog.getWatchingCount());
   }
   
   @Test
@@ -61,33 +46,5 @@ public class WatchdogCacheTest extends ThreadlyTester {
     assertEquals(1, scheduler.tick());
     
     assertTrue(slf.isCancelled());
-  }
-  
-  @Test
-  public void cacheCleanTest() {
-    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
-    watchdog.watch(TIMEOUT, slf);
-    assertFalse(watchdog.cachedDogs.isEmpty());
-    
-    TestUtils.blockTillClockAdvances();
-    
-    assertEquals(2, scheduler.advance(WatchdogCache.INSPECTION_INTERVAL_MILLIS));
-    
-    assertTrue(watchdog.cachedDogs.isEmpty());
-  }
-  
-  @Test
-  public void resolutionTest() {
-    watchdog = new WatchdogCache(scheduler, true);
-    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
-    watchdog.watch(WatchdogCache.DEFAULT_RESOLUTION_MILLIS, slf);
-    watchdog.watch(WatchdogCache.DEFAULT_RESOLUTION_MILLIS / 2, slf);
-    watchdog.watch(WatchdogCache.DEFAULT_RESOLUTION_MILLIS / 4, slf);
-    
-    assertEquals(1, watchdog.cachedDogs.size());
-    
-    watchdog.watch(WatchdogCache.DEFAULT_RESOLUTION_MILLIS + 1, slf);
-    
-    assertEquals(2, watchdog.cachedDogs.size());
   }
 }

--- a/src/test/java/org/threadly/concurrent/future/watchdog/MixedTimeWatchdogTest.java
+++ b/src/test/java/org/threadly/concurrent/future/watchdog/MixedTimeWatchdogTest.java
@@ -1,0 +1,99 @@
+package org.threadly.concurrent.future.watchdog;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.ThreadlyTester;
+import org.threadly.concurrent.future.FutureUtils;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.SettableListenableFuture;
+import org.threadly.test.concurrent.TestUtils;
+import org.threadly.test.concurrent.TestableScheduler;
+import org.threadly.util.Clock;
+
+@SuppressWarnings("javadoc")
+public class MixedTimeWatchdogTest extends ThreadlyTester {
+  private static final int TIMEOUT = 2;
+  
+  private TestableScheduler scheduler;
+  private MixedTimeWatchdog watchdog;
+  
+  @Before
+  public void setup() {
+    scheduler = new TestableScheduler();
+    watchdog = new MixedTimeWatchdog(scheduler, true, 1);
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler = null;
+    watchdog = null;
+  }
+  
+  @SuppressWarnings("unused")
+  private static void waitForTimeout() {
+    if (TIMEOUT > 1) {
+      TestUtils.sleep(TIMEOUT);
+      Clock.accurateTimeNanos();
+    } else {
+      TestUtils.blockTillClockAdvances();
+    }
+  }
+  
+  @Test
+  public void centralWatchdogCacheConstructorTest() {
+    watchdog = MixedTimeWatchdog.centralWatchdog(true);
+    
+    assertNotNull(watchdog.scheduler);
+  }
+  
+  @Test
+  public void alreadyDoneFutureWatchTest() {
+    ListenableFuture<Object> future = FutureUtils.immediateResultFuture(null);
+    watchdog.watch(TIMEOUT, future);
+    
+    assertTrue(watchdog.cachedDogs.isEmpty());
+  }
+  
+  @Test
+  public void expiredFutureTest() {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    watchdog.watch(TIMEOUT, slf);
+
+    waitForTimeout();
+    
+    assertEquals(1, scheduler.tick());
+    
+    assertTrue(slf.isCancelled());
+  }
+  
+  @Test
+  public void cacheCleanTest() {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    watchdog.watch(TIMEOUT, slf);
+    assertFalse(watchdog.cachedDogs.isEmpty());
+
+    waitForTimeout();
+    
+    assertEquals(2, scheduler.advance(MixedTimeWatchdog.INSPECTION_INTERVAL_MILLIS));
+    
+    assertTrue(watchdog.cachedDogs.isEmpty());
+  }
+  
+  @Test
+  public void resolutionTest() {
+    watchdog = new MixedTimeWatchdog(scheduler, true);
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    watchdog.watch(MixedTimeWatchdog.DEFAULT_RESOLUTION_MILLIS, slf);
+    watchdog.watch(MixedTimeWatchdog.DEFAULT_RESOLUTION_MILLIS / 2, slf);
+    watchdog.watch(MixedTimeWatchdog.DEFAULT_RESOLUTION_MILLIS / 4, slf);
+    
+    assertEquals(1, watchdog.cachedDogs.size());
+    
+    watchdog.watch(MixedTimeWatchdog.DEFAULT_RESOLUTION_MILLIS + 1, slf);
+    
+    assertEquals(2, watchdog.cachedDogs.size());
+  }
+}

--- a/src/test/java/org/threadly/concurrent/future/watchdog/PollingWatchdogTest.java
+++ b/src/test/java/org/threadly/concurrent/future/watchdog/PollingWatchdogTest.java
@@ -1,0 +1,89 @@
+package org.threadly.concurrent.future.watchdog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threadly.concurrent.NoThreadScheduler;
+import org.threadly.concurrent.future.FutureUtils;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.SettableListenableFuture;
+
+@SuppressWarnings("javadoc")
+public class PollingWatchdogTest {
+  private NoThreadScheduler scheduler;
+  private PollingWatchdog watchdog;
+  private AtomicBoolean cancelFuture;
+  
+  @Before
+  public void setup() {
+    scheduler = new NoThreadScheduler();
+    watchdog = new PollingWatchdog(scheduler, 1, true);
+    cancelFuture = new AtomicBoolean(false);
+  }
+  
+  @After
+  public void cleanup() {
+    scheduler = null;
+    watchdog = null;
+    cancelFuture = null;
+  }
+  
+  @Test
+  public void isActiveTest() throws InterruptedException {
+    assertFalse(watchdog.isActive());
+    
+    ListenableFuture<?> future = FutureUtils.immediateResultFuture(null);
+    watchdog.watch(cancelFuture::get, future);
+    
+    assertFalse(watchdog.isActive());
+    
+    SettableListenableFuture<?> slf = new SettableListenableFuture<>();
+    watchdog.watch(cancelFuture::get, slf);
+
+    assertTrue(watchdog.isActive());
+    
+    cancelFuture.set(true);
+    assertEquals(1, scheduler.blockingTick(null));
+    
+    assertFalse(watchdog.isActive());
+  }
+  
+  @Test
+  public void alreadyDoneFutureWatchTest() {
+    ListenableFuture<?> future = FutureUtils.immediateResultFuture(null);
+    watchdog.watch(cancelFuture::get, future);
+
+    assertEquals(0, watchdog.getWatchingCount());
+  }
+  
+  @Test
+  public void futureFinishTest() {
+    SettableListenableFuture<?> slf = new SettableListenableFuture<>();
+    
+    watchdog.watch(cancelFuture::get, slf);
+
+    assertEquals(1, watchdog.getWatchingCount());
+    
+    slf.setResult(null);
+
+    assertEquals(0, watchdog.getWatchingCount());
+  }
+  
+  @Test
+  public void watchdogCancelFutureTest() throws InterruptedException {
+    SettableListenableFuture<?> slf = new SettableListenableFuture<>();
+    watchdog.watch(cancelFuture::get, slf);
+    
+    cancelFuture.set(true);
+    assertEquals(1, scheduler.blockingTick(null));
+    
+    assertTrue(slf.isCancelled());
+    assertEquals(0, watchdog.getWatchingCount());
+  }
+}


### PR DESCRIPTION
API Changes to Watchdog:
* Watchdog moved and renamed to org.threadly.concurrent.threadly.future.watchdog.ConstantTimeWatchdog
* WatchdogCache moved and renamed to org.threadly.concurrent.threadly.future.watchdog.MixedTimeWatchdog

This also adds PollingWatchdog to watch a future and expire / cancel it for an arbitrary reason.  This can be useful for creating watchdog behavior for failure in progress rather than an absolute timeout.