### PR TITLE
PriorityScheduler: Reduce Clock updates for Low / Starvable tasks

### DIFF
--- a/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
@@ -249,10 +249,12 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
     QueueSet queueSet = queueManager.getQueueSet(priority);
     OneTimeTaskWrapper result;
     if (delayInMillis == 0) {
-      queueSet.addExecute((result = new NoThreadOneTimeTaskWrapper(task, queueSet.executeQueue, 
+      queueSet.addExecute((result = new NoThreadOneTimeTaskWrapper(task, 
+                                                                   queueSet.executeQueue, 
                                                                    nowInMillis(false))));
     } else {
-      queueSet.addScheduled((result = new NoThreadOneTimeTaskWrapper(task, queueSet.scheduleQueue, 
+      queueSet.addScheduled((result = new NoThreadOneTimeTaskWrapper(task,  
+                                                                     queueSet.scheduleQueue, 
                                                                      nowInMillis(true) + delayInMillis)));
     }
     return result;
@@ -407,7 +409,7 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * @since 1.0.0
    */
   protected class NoThreadOneTimeTaskWrapper extends OneTimeTaskWrapper {
-    protected NoThreadOneTimeTaskWrapper(Runnable task, 
+    protected NoThreadOneTimeTaskWrapper(Runnable task,  
                                          Queue<? extends TaskWrapper> taskQueue, long runTime) {
       super(task, taskQueue, runTime);
     }
@@ -436,7 +438,8 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * @since 4.3.0
    */
   protected abstract class NoThreadRecurringTaskWrapper extends RecurringTaskWrapper {
-    protected NoThreadRecurringTaskWrapper(Runnable task, QueueSet queueSet, long firstRunTime) {
+    protected NoThreadRecurringTaskWrapper(Runnable task,  
+                                           QueueSet queueSet, long firstRunTime) {
       super(task, queueSet, firstRunTime);
     }
     

--- a/src/main/java/org/threadly/concurrent/ThreadlyInternalAccessor.java
+++ b/src/main/java/org/threadly/concurrent/ThreadlyInternalAccessor.java
@@ -3,9 +3,9 @@ package org.threadly.concurrent;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
 
+import org.threadly.concurrent.AbstractPriorityScheduler.AccurateRecurringDelayTaskWrapper;
+import org.threadly.concurrent.AbstractPriorityScheduler.AccurateRecurringRateTaskWrapper;
 import org.threadly.concurrent.AbstractPriorityScheduler.QueueSet;
-import org.threadly.concurrent.AbstractPriorityScheduler.RecurringDelayTaskWrapper;
-import org.threadly.concurrent.AbstractPriorityScheduler.RecurringRateTaskWrapper;
 import org.threadly.concurrent.AbstractPriorityScheduler.TaskWrapper;
 import org.threadly.concurrent.NoThreadScheduler.NoThreadRecurringDelayTaskWrapper;
 import org.threadly.concurrent.NoThreadScheduler.NoThreadRecurringRateTaskWrapper;
@@ -52,12 +52,12 @@ public final class ThreadlyInternalAccessor {
   public static Delayed doScheduleAtFixedRateAndGetDelayed(PriorityScheduler pScheduler, 
                                                            Runnable task, TaskPriority priority, 
                                                            long initialDelay, long periodInMillis) {
-    QueueSet queueSet = pScheduler.taskQueueManager.getQueueSet(priority);
-    RecurringRateTaskWrapper rrtw = 
-        new RecurringRateTaskWrapper(task, queueSet,
-                                     Clock.accurateForwardProgressingMillis() + initialDelay, 
-                                     periodInMillis);
-    pScheduler.addToScheduleQueue(queueSet, rrtw);
+    QueueSet queueSet = pScheduler.queueManager.getQueueSet(priority);
+    AccurateRecurringRateTaskWrapper rrtw = 
+        new AccurateRecurringRateTaskWrapper(task, queueSet,
+                                             Clock.accurateForwardProgressingMillis() + initialDelay, 
+                                             periodInMillis);
+    pScheduler.queueScheduled(queueSet, rrtw);
     return new DelayedTaskWrapper(rrtw);
   }
   
@@ -75,12 +75,12 @@ public final class ThreadlyInternalAccessor {
   public static Delayed doScheduleWithFixedDelayAndGetDelayed(PriorityScheduler pScheduler, 
                                                               Runnable task, TaskPriority priority, 
                                                               long initialDelay, long delayInMs) {
-    QueueSet queueSet = pScheduler.taskQueueManager.getQueueSet(priority);
-    RecurringDelayTaskWrapper rdtw = 
-        new RecurringDelayTaskWrapper(task, queueSet,
-                                      Clock.accurateForwardProgressingMillis() + initialDelay, 
-                                      delayInMs);
-    pScheduler.addToScheduleQueue(queueSet, rdtw);
+    QueueSet queueSet = pScheduler.queueManager.getQueueSet(priority);
+    AccurateRecurringDelayTaskWrapper rdtw = 
+        new AccurateRecurringDelayTaskWrapper(task, queueSet,
+                                             Clock.accurateForwardProgressingMillis() + initialDelay, 
+                                             delayInMs);
+    pScheduler.queueScheduled(queueSet, rdtw);
     return new DelayedTaskWrapper(rdtw);
   }
   

--- a/src/test/java/org/threadly/concurrent/AbstractPrioritySchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/AbstractPrioritySchedulerTest.java
@@ -6,7 +6,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
-import org.threadly.concurrent.AbstractPriorityScheduler.OneTimeTaskWrapper;
+import org.threadly.concurrent.AbstractPriorityScheduler.AccurateOneTimeTaskWrapper;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.test.concurrent.TestUtils;
 import org.threadly.util.Clock;
@@ -96,32 +96,32 @@ public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInte
       AbstractPriorityScheduler result = factory.makeAbstractPriorityScheduler(1);
       // add directly to avoid starting the consumer
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 1000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 1000));
       
       assertEquals(4, result.getQueuedTaskCount());
 
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 1000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 1000));
       
       assertEquals(8, result.getQueuedTaskCount());
       assertEquals(8, result.getQueuedTaskCount(null));
@@ -139,32 +139,32 @@ public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInte
       AbstractPriorityScheduler result = factory.makeAbstractPriorityScheduler(1);
       // add directly to avoid starting the consumer
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 1000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 1000));
       
       assertEquals(0, result.getQueuedTaskCount(TaskPriority.Starvable));
 
       result.getQueueManager().getQueueSet(TaskPriority.Starvable)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Starvable)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Starvable)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Starvable)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 1000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 1000));
       
       assertEquals(4, result.getQueuedTaskCount(TaskPriority.Starvable));
     } finally {
@@ -179,32 +179,32 @@ public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInte
       AbstractPriorityScheduler result = factory.makeAbstractPriorityScheduler(1);
       // add directly to avoid starting the consumer
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 1000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 1000));
       
       assertEquals(0, result.getQueuedTaskCount(TaskPriority.Low));
 
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 1000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 1000));
       
       assertEquals(4, result.getQueuedTaskCount(TaskPriority.Low));
     } finally {
@@ -219,32 +219,32 @@ public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInte
       AbstractPriorityScheduler result = factory.makeAbstractPriorityScheduler(1);
       // add directly to avoid starting the consumer
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 1000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 1000));
       
       assertEquals(4, result.getQueuedTaskCount(TaskPriority.High));
 
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 1000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 1000));
       
       assertEquals(4, result.getQueuedTaskCount(TaskPriority.High));
     } finally {
@@ -259,26 +259,26 @@ public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInte
       AbstractPriorityScheduler result = factory.makeAbstractPriorityScheduler(1);
       // add directly to avoid starting the consumer
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 60_000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 60_000));
       
       assertEquals(2, result.getWaitingForExecutionTaskCount());
 
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 60_000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 60_000));
       
       assertEquals(4, result.getWaitingForExecutionTaskCount());
       assertEquals(4, result.getWaitingForExecutionTaskCount(null));
@@ -296,32 +296,32 @@ public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInte
       AbstractPriorityScheduler result = factory.makeAbstractPriorityScheduler(1);
       // add directly to avoid starting the consumer
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 10_000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 10_000));
       
       assertEquals(0, result.getWaitingForExecutionTaskCount(TaskPriority.Low));
 
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 10_000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 10_000));
       
       assertEquals(3, result.getWaitingForExecutionTaskCount(TaskPriority.Low));
     } finally {
@@ -336,32 +336,32 @@ public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInte
       AbstractPriorityScheduler result = factory.makeAbstractPriorityScheduler(1);
       // add directly to avoid starting the consumer
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 10_000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 10_000));
       
       assertEquals(3, result.getWaitingForExecutionTaskCount(TaskPriority.High));
 
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Low)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 10_000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 10_000));
       
       assertEquals(3, result.getWaitingForExecutionTaskCount(TaskPriority.High));
     } finally {
@@ -376,32 +376,32 @@ public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInte
       AbstractPriorityScheduler result = factory.makeAbstractPriorityScheduler(1);
       // add directly to avoid starting the consumer
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.High)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 10_000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 10_000));
       
       assertEquals(0, result.getWaitingForExecutionTaskCount(TaskPriority.Starvable));
 
       result.getQueueManager().getQueueSet(TaskPriority.Starvable)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Starvable)
-            .executeQueue.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis()));
+            .executeQueue.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Starvable)
-            .scheduleQueue.add(0, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis()));
+            .scheduleQueue.add(0, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis()));
       result.getQueueManager().getQueueSet(TaskPriority.Starvable)
-            .scheduleQueue.add(1, new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                         Clock.lastKnownForwardProgressingMillis() + 10_000));
+            .scheduleQueue.add(1, new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                 Clock.lastKnownForwardProgressingMillis() + 10_000));
       
       assertEquals(3, result.getWaitingForExecutionTaskCount(TaskPriority.Starvable));
     } finally {

--- a/src/test/java/org/threadly/concurrent/NoThreadSchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/NoThreadSchedulerTest.java
@@ -15,7 +15,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
-import org.threadly.concurrent.AbstractPriorityScheduler.OneTimeTaskWrapper;
+import org.threadly.concurrent.AbstractPriorityScheduler.AccurateOneTimeTaskWrapper;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.test.concurrent.AsyncVerifier;
 import org.threadly.test.concurrent.TestRunnable;
@@ -562,9 +562,9 @@ public class NoThreadSchedulerTest extends ThreadlyTester {
     assertFalse(scheduler.hasTaskReadyToRun());
     
     scheduler.queueManager.highPriorityQueueSet
-             .addScheduled(new OneTimeTaskWrapper(DoNothingRunnable.instance(), 
-                                                  scheduler.queueManager.highPriorityQueueSet.scheduleQueue, 
-                                                  Clock.lastKnownForwardProgressingMillis()));
+             .addScheduled(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), 
+                                                          scheduler.queueManager.highPriorityQueueSet.scheduleQueue, 
+                                                          Clock.lastKnownForwardProgressingMillis()));
     
     // now should be true with scheduled task which is ready to run
     assertTrue(scheduler.hasTaskReadyToRun());
@@ -608,9 +608,9 @@ public class NoThreadSchedulerTest extends ThreadlyTester {
     assertTrue(scheduler.getDelayTillNextTask() > 0);
     
     scheduler.queueManager.highPriorityQueueSet
-             .addScheduled(new OneTimeTaskWrapper(DoNothingRunnable.instance(), 
-                                                  scheduler.queueManager.highPriorityQueueSet.scheduleQueue, 
-                                                  Clock.lastKnownForwardProgressingMillis()));
+             .addScheduled(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), 
+                                                          scheduler.queueManager.highPriorityQueueSet.scheduleQueue, 
+                                                          Clock.lastKnownForwardProgressingMillis()));
     
     // now should be true with scheduled task which is ready to run
     assertTrue(scheduler.getDelayTillNextTask() <= 0);

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueSetTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueSetTest.java
@@ -11,6 +11,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.threadly.ThreadlyTester;
+import org.threadly.concurrent.AbstractPriorityScheduler.AccurateOneTimeTaskWrapper;
 import org.threadly.concurrent.AbstractPriorityScheduler.OneTimeTaskWrapper;
 import org.threadly.concurrent.AbstractPriorityScheduler.QueueSet;
 import org.threadly.concurrent.AbstractPriorityScheduler.QueueSetListener;
@@ -35,8 +36,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   
   @Test
   public void addExecuteTest() {
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis());
+    OneTimeTaskWrapper task = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis());
     
     queueSet.addExecute(task);
     
@@ -46,8 +47,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   
   @Test
   public void addScheduledTest() {
-    TaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                              Clock.lastKnownForwardProgressingMillis() + 10);
+    TaskWrapper task = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                      Clock.lastKnownForwardProgressingMillis() + 10);
     
     queueSet.addScheduled(task);
     
@@ -59,8 +60,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   public void addScheduledOrderTest() {
     List<TaskWrapper> orderedList = new ArrayList<>(TEST_QTY);
     for (int i = 0; i < TEST_QTY; i++) {
-      orderedList.add(new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                             Clock.accurateForwardProgressingMillis() + i));
+      orderedList.add(new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                     Clock.accurateForwardProgressingMillis() + i));
     }
     List<TaskWrapper> randomList = new ArrayList<>(orderedList);
     Collections.shuffle(randomList);
@@ -80,8 +81,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   @Test
   public void removeCallableTest() {
     TestCallable callable = new TestCallable();
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(new ListenableFutureTask<>(false, callable), 
-                                                     null, Clock.lastKnownForwardProgressingMillis());
+    OneTimeTaskWrapper task = new AccurateOneTimeTaskWrapper(new ListenableFutureTask<>(false, callable), 
+                                                             null, Clock.lastKnownForwardProgressingMillis());
     
     assertFalse(queueSet.remove(callable));
     
@@ -99,8 +100,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   @Test
   public void removeRunnableTest() {
     TestRunnable runnable = new TestRunnable();
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(runnable, null, 
-                                                     Clock.lastKnownForwardProgressingMillis());
+    OneTimeTaskWrapper task = new AccurateOneTimeTaskWrapper(runnable, null, 
+                                                             Clock.lastKnownForwardProgressingMillis());
     
     assertFalse(queueSet.remove(runnable));
     
@@ -119,8 +120,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   public void queueSizeTest() {
     assertEquals(0, queueSet.queueSize());
     
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis());
+    OneTimeTaskWrapper task = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis());
     
     queueSet.executeQueue.add(task);
     queueSet.scheduleQueue.addFirst(task);
@@ -132,8 +133,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   public void drainQueueIntoTest() {
     List<TaskWrapper> depositList = new ArrayList<>(2);
     
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.lastKnownForwardProgressingMillis());
+    OneTimeTaskWrapper task = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.lastKnownForwardProgressingMillis());
     
     queueSet.executeQueue.add(task);
     
@@ -157,8 +158,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   
   @Test
   public void getNextTaskExecuteOnlyTest() {
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.accurateForwardProgressingMillis() + DELAY_TIME);
+    OneTimeTaskWrapper task = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.accurateForwardProgressingMillis() + DELAY_TIME);
     queueSet.executeQueue.add(task);
     
     assertTrue(queueSet.getNextTask() == task);
@@ -166,8 +167,8 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   
   @Test
   public void getNextTaskScheduleOnlyTest() {
-    OneTimeTaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                     Clock.accurateForwardProgressingMillis() + DELAY_TIME);
+    OneTimeTaskWrapper task = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                             Clock.accurateForwardProgressingMillis() + DELAY_TIME);
     queueSet.scheduleQueue.add(task);
     
     assertTrue(queueSet.getNextTask() == task);
@@ -175,10 +176,10 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   
   @Test
   public void getNextTaskExecuteFirstTest() {
-    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                            Clock.accurateForwardProgressingMillis());
-    OneTimeTaskWrapper scheduleTask = new OneTimeTaskWrapper(new TestRunnable(), null, 
-                                                             Clock.accurateForwardProgressingMillis() + DELAY_TIME);
+    OneTimeTaskWrapper executeTask = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                    Clock.accurateForwardProgressingMillis());
+    OneTimeTaskWrapper scheduleTask = new AccurateOneTimeTaskWrapper(new TestRunnable(), null, 
+                                                                     Clock.accurateForwardProgressingMillis() + DELAY_TIME);
     queueSet.executeQueue.add(executeTask);
     queueSet.scheduleQueue.add(scheduleTask);
     
@@ -187,10 +188,10 @@ public class PrioritySchedulerQueueSetTest extends ThreadlyTester {
   
   @Test
   public void getNextTaskScheduleFirstTest() {
-    OneTimeTaskWrapper executeTask = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                            Clock.accurateForwardProgressingMillis() + DELAY_TIME);
-    OneTimeTaskWrapper scheduleTask = new OneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
-                                                             Clock.lastKnownForwardProgressingMillis());
+    OneTimeTaskWrapper executeTask = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                    Clock.accurateForwardProgressingMillis() + DELAY_TIME);
+    OneTimeTaskWrapper scheduleTask = new AccurateOneTimeTaskWrapper(DoNothingRunnable.instance(), null, 
+                                                                     Clock.lastKnownForwardProgressingMillis());
     queueSet.executeQueue.add(executeTask);
     queueSet.scheduleQueue.add(scheduleTask);
     

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerTaskWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerTaskWrapperTest.java
@@ -76,5 +76,10 @@ public class PrioritySchedulerTaskWrapperTest extends ThreadlyTester {
       canExecuteCalled = true;
       return true;
     }
+
+    @Override
+    public long getScheduleDelay() {
+      return Clock.accurateForwardProgressingMillis() - getRunTime();
+    }
   }
 }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 import org.threadly.BlockingTestRunnable;
-import org.threadly.concurrent.AbstractPriorityScheduler.OneTimeTaskWrapper;
+import org.threadly.concurrent.AbstractPriorityScheduler.AccurateOneTimeTaskWrapper;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.wrapper.priority.DefaultPriorityWrapper;
 import org.threadly.test.concurrent.AsyncVerifier;
@@ -482,19 +482,19 @@ public class PrioritySchedulerTest extends AbstractPrioritySchedulerTest {
     
     PriorityScheduler scheduler = factory.makePriorityScheduler(1);
     try {
-      scheduler.addToScheduleQueue(scheduler.taskQueueManager.highPriorityQueueSet, 
-                                   new OneTimeTaskWrapper(new TestRunnable(), null, 
-                                                          Clock.lastKnownForwardProgressingMillis() + taskDelay));
+      scheduler.queueScheduled(scheduler.queueManager.highPriorityQueueSet, 
+                                   new AccurateOneTimeTaskWrapper(new TestRunnable(), null, 
+                                                                  Clock.lastKnownForwardProgressingMillis() + taskDelay));
 
-      assertEquals(1, scheduler.taskQueueManager.highPriorityQueueSet.scheduleQueue.size());
-      assertEquals(0, scheduler.taskQueueManager.lowPriorityQueueSet.scheduleQueue.size());
+      assertEquals(1, scheduler.queueManager.highPriorityQueueSet.scheduleQueue.size());
+      assertEquals(0, scheduler.queueManager.lowPriorityQueueSet.scheduleQueue.size());
       
-      scheduler.addToScheduleQueue(scheduler.taskQueueManager.lowPriorityQueueSet, 
-                                   new OneTimeTaskWrapper(new TestRunnable(), null, 
-                                                          Clock.lastKnownForwardProgressingMillis() + taskDelay));
+      scheduler.queueScheduled(scheduler.queueManager.lowPriorityQueueSet, 
+                                   new AccurateOneTimeTaskWrapper(new TestRunnable(), null, 
+                                                                  Clock.lastKnownForwardProgressingMillis() + taskDelay));
 
-      assertEquals(1, scheduler.taskQueueManager.highPriorityQueueSet.scheduleQueue.size());
-      assertEquals(1, scheduler.taskQueueManager.lowPriorityQueueSet.scheduleQueue.size());
+      assertEquals(1, scheduler.queueManager.highPriorityQueueSet.scheduleQueue.size());
+      assertEquals(1, scheduler.queueManager.lowPriorityQueueSet.scheduleQueue.size());
     } finally {
       factory.shutdown();
     }


### PR DESCRIPTION
This will still update the clock when the task is submitted to ensure a task never runs early.
However for Low and Starvable tasks this will avoid updating the clock for execution.

This does mean it comes with the risk that Low / Starvable priority tasks wont ever execute if:
  * The user disables the Clock update thread manually
  * No other Clock updates are happening (ie no additional scheduled tasks, no other library or user actions needing to update the clock)

So this is not exactly risk free, but it can significantly improve performance impacts from Low / Starvable priority tasks.  Not just when they are executed, but if they are next for execution and we need to see how long to park the thread.

I have done extensive JMH benchmarking to make sure there is no negative performance impacts from this.  Except for code complexity, there should be no negative trade offs I can find.

I did not want to store the state as a boolean in the TaskWrapper because:
  * It would increase the per-task memory overhead
  * It increases the state checks needed (was being seen as a performance impact in JMH)

Instead we use different class types to indicate this behavior state, which does require a fair bit more code.  I also wanted to prevent additional stat checks when submitting tasks, so I had to expand that code too.

@lwahlmeier What do you think?  This optimization should be nothing but benefit, but the benefit is super super small (I don't expect generally a lot of low / starvable priority tasks at volume).  It also comes with the minor risk outlined above.  So if you don't think it's worth it then I am good just closing.