### PR TITLE
PriorityScheduler: Avoid thread start for Starvable priority tasks

### DIFF
--- a/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
@@ -485,9 +485,10 @@ public abstract class AbstractPriorityScheduler extends AbstractSubmitterSchedul
      * just queued.  If a queue update comes in, this must be re-invoked to see what task is now 
      * next.  If there are no tasks ready to be executed this will simply return {@code null}.
      * 
+     * @param allowStarvable {@code true} to return starvable tasks if no other task is available and ready
      * @return Task to be executed next, or {@code null} if no tasks at all are queued
      */
-    public TaskWrapper getNextTask() {
+    public TaskWrapper getNextTask(boolean allowStarvable) {
       // First compare between high and low priority task queues
       // then depending on that state, we may check starvable
       TaskWrapper nextTask;
@@ -521,7 +522,9 @@ public abstract class AbstractPriorityScheduler extends AbstractSubmitterSchedul
         nextTask = nextHighPriorityTask;
       }
       
-      if (nextTask == null) {
+      if (! allowStarvable) {
+        return nextTask;
+      } else if (nextTask == null) {
         return starvablePriorityQueueSet.getNextTask();
       } else if (nextTask.getScheduleDelay() > 0) {
         TaskWrapper nextStarvableTask = starvablePriorityQueueSet.getNextTask();

--- a/src/main/java/org/threadly/concurrent/CentralThreadlyPool.java
+++ b/src/main/java/org/threadly/concurrent/CentralThreadlyPool.java
@@ -63,7 +63,7 @@ public class CentralThreadlyPool {
     genericThreadCount = 1; // must have at least one
     MASTER_SCHEDULER = // start with computation + 1 for interior management tasks and + 1 for shared use
         new PriorityScheduler(cpuCount + genericThreadCount + 1, 
-                              TaskPriority.High, LOW_PRIORITY_MAX_WAIT_IN_MS, 
+                              TaskPriority.High, LOW_PRIORITY_MAX_WAIT_IN_MS, false, 
                               new ConfigurableThreadFactory("CentralThreadlyPool-", false, 
                                                             true, Thread.NORM_PRIORITY, null, null));
     LOW_PRIORITY_MASTER_SCHEDULER = 

--- a/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
@@ -214,7 +214,7 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
           } else if (currentThread.isInterrupted()) {
             throw new InterruptedException();
           }
-          TaskWrapper nextTask = queueManager.getNextTask();
+          TaskWrapper nextTask = queueManager.getNextTask(true);
           if (nextTask == null) {
               LockSupport.park();
           } else {
@@ -314,7 +314,7 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * @return next ready task, or {@code null} if there are none
    */
   protected TaskWrapper getNextReadyTask() {
-    TaskWrapper tw = queueManager.getNextTask();
+    TaskWrapper tw = queueManager.getNextTask(true);
     if (tw == null || tw.getScheduleDelay() > 0) {
       return null;
     } else {
@@ -375,7 +375,7 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * @return Milliseconds till the next task is ready to run
    */
   public long getDelayTillNextTask() {
-    TaskWrapper tw = queueManager.getNextTask();
+    TaskWrapper tw = queueManager.getNextTask(true);
     if (tw != null) {
       return tw.getRunTime() - nowInMillis(true);
     } else {

--- a/src/main/java/org/threadly/concurrent/statistics/PrioritySchedulerStatisticTracker.java
+++ b/src/main/java/org/threadly/concurrent/statistics/PrioritySchedulerStatisticTracker.java
@@ -101,7 +101,30 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
   public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
                                            long maxWaitForLowPriorityInMs, 
                                            boolean useDaemonThreads) {
-    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, useDaemonThreads, 1000);
+    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, useDaemonThreads, 1000, false);
+  }
+  
+  /**
+   * Constructs a new thread pool, though no threads will be started till it accepts it's first 
+   * request.  This provides the extra parameters to tune what tasks submitted without a priority 
+   * will be scheduled as.  As well as the maximum wait for low priority tasks.  The longer low 
+   * priority tasks wait for a worker, the less chance they will have to create a thread.  But it 
+   * also makes low priority tasks execution time less predictable.    This will by 
+   * default start threads for {@link TaskPriority#Low} and higher priority tasks.
+   * <p>
+   * This defaults to inaccurate time.  Meaning that durations and delays may under report (but 
+   * NEVER OVER what they actually were).  This has the least performance impact.  If you want more 
+   * accurate time consider using one of the constructors that accepts a boolean for accurate time.
+   * 
+   * @param poolSize Thread pool size that should be maintained
+   * @param defaultPriority priority to give tasks which do not specify it
+   * @param maxWaitForLowPriorityInMs time low priority tasks wait for a worker
+   * @param threadFactory thread factory for producing new threads within executor
+   */
+  public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
+                                           long maxWaitForLowPriorityInMs, 
+                                           ThreadFactory threadFactory) {
+    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, DEFAULT_STARVABLE_STARTS_THREADS, threadFactory);
   }
   
   /**
@@ -118,12 +141,15 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
    * @param poolSize Thread pool size that should be maintained
    * @param defaultPriority priority to give tasks which do not specify it
    * @param maxWaitForLowPriorityInMs time low priority tasks wait for a worker
+   * @param stavableStartsThreads {@code true} to have TaskPriority.Starvable tasks start new threads
    * @param threadFactory thread factory for producing new threads within executor
    */
   public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
                                            long maxWaitForLowPriorityInMs, 
+                                           boolean stavableStartsThreads,  
                                            ThreadFactory threadFactory) {
-    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, threadFactory, 1000);
+    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, stavableStartsThreads,  
+         threadFactory, 1000, false);
   }
   
   /**
@@ -136,9 +162,12 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
    * NEVER OVER what they actually were).  This has the least performance impact.  If you want more 
    * accurate time consider using one of the constructors that accepts a boolean for accurate time.
    * 
+   * @deprecated Please use {@link #PrioritySchedulerStatisticTracker(int, int, boolean)}
+   * 
    * @param poolSize Thread pool size that should be maintained
    * @param maxStatisticWindowSize maximum number of samples to keep internally
    */
+  @Deprecated
   public PrioritySchedulerStatisticTracker(int poolSize, int maxStatisticWindowSize) {
     this(poolSize, DEFAULT_PRIORITY, 
          DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, DEFAULT_NEW_THREADS_DAEMON, maxStatisticWindowSize);
@@ -153,10 +182,13 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
    * NEVER OVER what they actually were).  This has the least performance impact.  If you want more 
    * accurate time consider using one of the constructors that accepts a boolean for accurate time.
    * 
+   * @deprecated Please use {@link #PrioritySchedulerStatisticTracker(int, boolean, int, boolean)}
+   * 
    * @param poolSize Thread pool size that should be maintained
    * @param useDaemonThreads {@code true} if newly created threads should be daemon
    * @param maxStatisticWindowSize maximum number of samples to keep internally
    */
+  @Deprecated
   public PrioritySchedulerStatisticTracker(int poolSize, boolean useDaemonThreads, 
                                            int maxStatisticWindowSize) {
     this(poolSize, DEFAULT_PRIORITY, DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, 
@@ -174,11 +206,14 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
    * NEVER OVER what they actually were).  This has the least performance impact.  If you want more 
    * accurate time consider using one of the constructors that accepts a boolean for accurate time.
    * 
+   * @deprecated Please use {@link #PrioritySchedulerStatisticTracker(int, TaskPriority, long, int, boolean)}
+   * 
    * @param poolSize Thread pool size that should be maintained
    * @param defaultPriority priority to give tasks which do not specify it
    * @param maxWaitForLowPriorityInMs time low priority tasks wait for a worker
    * @param maxStatisticWindowSize maximum number of samples to keep internally
    */
+  @Deprecated
   public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
                                            long maxWaitForLowPriorityInMs, 
                                            int maxStatisticWindowSize) {
@@ -197,12 +232,15 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
    * NEVER OVER what they actually were).  This has the least performance impact.  If you want more 
    * accurate time consider using one of the constructors that accepts a boolean for accurate time.
    * 
+   * @deprecated Please use {@link #PrioritySchedulerStatisticTracker(int, TaskPriority, long, boolean, int, boolean)}
+   * 
    * @param poolSize Thread pool size that should be maintained
    * @param defaultPriority priority to give tasks which do not specify it
    * @param maxWaitForLowPriorityInMs time low priority tasks wait for a worker
    * @param useDaemonThreads {@code true} if newly created threads should be daemon
    * @param maxStatisticWindowSize maximum number of samples to keep internally
    */
+  @Deprecated
   public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
                                            long maxWaitForLowPriorityInMs, 
                                            boolean useDaemonThreads, int maxStatisticWindowSize) {
@@ -221,12 +259,16 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
    * NEVER OVER what they actually were).  This has the least performance impact.  If you want more 
    * accurate time consider using one of the constructors that accepts a boolean for accurate time.
    * 
+   * @deprecated Please use 
+   *    {@link #PrioritySchedulerStatisticTracker(int, TaskPriority, long, ThreadFactory, int, boolean)}
+   * 
    * @param poolSize Thread pool size that should be maintained
    * @param defaultPriority priority to give tasks which do not specify it
    * @param maxWaitForLowPriorityInMs time low priority tasks wait for a worker
    * @param threadFactory thread factory for producing new threads within executor
    * @param maxStatisticWindowSize maximum number of samples to keep internally
    */
+  @Deprecated
   public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
                                            long maxWaitForLowPriorityInMs, 
                                            ThreadFactory threadFactory, 
@@ -283,7 +325,7 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
   public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
                                            long maxWaitForLowPriorityInMs, 
                                            int maxStatisticWindowSize, boolean accurateTime) {
-    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, 
+    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs,
          DEFAULT_NEW_THREADS_DAEMON, maxStatisticWindowSize, accurateTime);
   }
   
@@ -292,7 +334,8 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
    * request.  This provides the extra parameters to tune what tasks submitted without a priority 
    * will be scheduled as.  As well as the maximum wait for low priority tasks.  The longer low 
    * priority tasks wait for a worker, the less chance they will have to create a thread.  But it 
-   * also makes low priority tasks execution time less predictable.
+   * also makes low priority tasks execution time less predictable.  This will by 
+   * default start threads for {@link TaskPriority#Low} and higher priority tasks.
    * 
    * @param poolSize Thread pool size that should be maintained
    * @param defaultPriority priority to give tasks which do not specify it
@@ -305,8 +348,33 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
                                            long maxWaitForLowPriorityInMs, boolean useDaemonThreads, 
                                            int maxStatisticWindowSize, boolean accurateTime) {
     this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, 
+         DEFAULT_STARVABLE_STARTS_THREADS, 
          new ConfigurableThreadFactory(PrioritySchedulerStatisticTracker.class.getSimpleName() + "-", 
                                        true, useDaemonThreads, Thread.NORM_PRIORITY, null, null), 
+         maxStatisticWindowSize, accurateTime);
+  }
+  
+  /**
+   * Constructs a new thread pool, though no threads will be started till it accepts it's first 
+   * request.  This provides the extra parameters to tune what tasks submitted without a priority 
+   * will be scheduled as.  As well as the maximum wait for low priority tasks.  The longer low 
+   * priority tasks wait for a worker, the less chance they will have to create a thread.  But it 
+   * also makes low priority tasks execution time less predictable.  This will by 
+   * default start threads for {@link TaskPriority#Low} and higher priority tasks.
+   * 
+   * @param poolSize Thread pool size that should be maintained
+   * @param defaultPriority priority to give tasks which do not specify it
+   * @param maxWaitForLowPriorityInMs time low priority tasks wait for a worker
+   * @param threadFactory thread factory for producing new threads within executor
+   * @param maxStatisticWindowSize maximum number of samples to keep internally
+   * @param accurateTime {@code true} to ensure that delays and durations are not under reported
+   */
+  public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
+                                           long maxWaitForLowPriorityInMs, 
+                                           ThreadFactory threadFactory, 
+                                           int maxStatisticWindowSize, boolean accurateTime) {
+    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, 
+         DEFAULT_STARVABLE_STARTS_THREADS, threadFactory, 
          maxStatisticWindowSize, accurateTime);
   }
   
@@ -320,15 +388,17 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
    * @param poolSize Thread pool size that should be maintained
    * @param defaultPriority priority to give tasks which do not specify it
    * @param maxWaitForLowPriorityInMs time low priority tasks wait for a worker
+   * @param stavableStartsThreads {@code true} to have TaskPriority.Starvable tasks start new threads
    * @param threadFactory thread factory for producing new threads within executor
    * @param maxStatisticWindowSize maximum number of samples to keep internally
    * @param accurateTime {@code true} to ensure that delays and durations are not under reported
    */
   public PrioritySchedulerStatisticTracker(int poolSize, TaskPriority defaultPriority, 
                                            long maxWaitForLowPriorityInMs, 
+                                           boolean stavableStartsThreads,
                                            ThreadFactory threadFactory, 
                                            int maxStatisticWindowSize, boolean accurateTime) {
-    super(new StatisticWorkerPool(threadFactory, poolSize, 
+    super(new StatisticWorkerPool(threadFactory, poolSize, stavableStartsThreads, 
                                   new PriorityStatisticManager(maxStatisticWindowSize, accurateTime)), 
           defaultPriority, maxWaitForLowPriorityInMs);
     
@@ -491,8 +561,9 @@ public class PrioritySchedulerStatisticTracker extends PriorityScheduler
     protected final PriorityStatisticManager statsManager;
   
     protected StatisticWorkerPool(ThreadFactory threadFactory, int poolSize, 
+                                  boolean stavableStartsThreads, 
                                   PriorityStatisticManager statsManager) {
-      super(threadFactory, poolSize);
+      super(threadFactory, poolSize, stavableStartsThreads);
       
       this.statsManager = statsManager;
     }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
@@ -83,13 +83,29 @@ public class PrioritySchedulerQueueManagerTest extends ThreadlyTester {
     getNextReadyTaskExecuteTest(queueManager.lowPriorityQueueSet);
   }
   
+  @Test
+  public void getNextReadyTaskExecuteOnlyStavableTest() {
+    getNextReadyTaskExecuteTest(queueManager.starvablePriorityQueueSet);
+  }
+  
   private void getNextReadyTaskExecuteTest(QueueSet queueSet) {
     OneTimeTaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), queueSet.executeQueue, 
                                                      Clock.lastKnownForwardProgressingMillis());
     
     queueSet.addExecute(task);
     
-    assertTrue(task == queueManager.getNextTask());
+    assertTrue(task == queueManager.getNextTask(true));
+  }
+  
+  @Test
+  public void getNextReadyTaskIgnoreStarvablePriorityTest() {
+    OneTimeTaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), 
+                                                     queueManager.starvablePriorityQueueSet.executeQueue, 
+                                                     Clock.lastKnownForwardProgressingMillis());
+    
+    queueManager.starvablePriorityQueueSet.addExecute(task);
+    
+    assertEquals(null, queueManager.getNextTask(false));
   }
   
   @Test
@@ -102,13 +118,18 @@ public class PrioritySchedulerQueueManagerTest extends ThreadlyTester {
     getNextReadyTaskScheduledTest(queueManager.lowPriorityQueueSet);
   }
   
+  @Test
+  public void getNextReadyTaskScheduleOnlyStaravableTest() {
+    getNextReadyTaskScheduledTest(queueManager.starvablePriorityQueueSet);
+  }
+  
   private void getNextReadyTaskScheduledTest(QueueSet queueSet) {
     TaskWrapper task = new OneTimeTaskWrapper(DoNothingRunnable.instance(), queueSet.scheduleQueue, 
                                               Clock.lastKnownForwardProgressingMillis());
     
     queueSet.addScheduled(task);
     
-    assertTrue(task == queueManager.getNextTask());
+    assertTrue(task == queueManager.getNextTask(true));
   }
   
   @Test
@@ -123,11 +144,11 @@ public class PrioritySchedulerQueueManagerTest extends ThreadlyTester {
                                                       Clock.lastKnownForwardProgressingMillis());
     queueManager.highPriorityQueueSet.addScheduled(scheduleTask);
 
-    assertTrue(executeTask == queueManager.getNextTask());
-    assertTrue(executeTask == queueManager.getNextTask());  // execute task has not been removed yet
+    assertTrue(executeTask == queueManager.getNextTask(true));
+    assertTrue(executeTask == queueManager.getNextTask(true));  // execute task has not been removed yet
     // this should remove the execute task so we can get the scheduled task
     assertTrue(executeTask.canExecute(executeTask.getExecuteReference()));
-    assertTrue(scheduleTask == queueManager.getNextTask());
+    assertTrue(scheduleTask == queueManager.getNextTask(true));
   }
   
   @Test
@@ -142,11 +163,11 @@ public class PrioritySchedulerQueueManagerTest extends ThreadlyTester {
                                                             Clock.lastKnownForwardProgressingMillis());
     queueManager.highPriorityQueueSet.addExecute(executeTask);
 
-    assertTrue(scheduleTask == queueManager.getNextTask());
-    assertTrue(scheduleTask == queueManager.getNextTask());  // schedule task has not been removed yet
+    assertTrue(scheduleTask == queueManager.getNextTask(true));
+    assertTrue(scheduleTask == queueManager.getNextTask(true));  // schedule task has not been removed yet
  // this should remove the schedule task so we can get the execute task
     assertTrue(scheduleTask.canExecute(executeTask.getExecuteReference()));
-    assertTrue(executeTask == queueManager.getNextTask());
+    assertTrue(executeTask == queueManager.getNextTask(true));
   }
   
   @Test
@@ -161,7 +182,7 @@ public class PrioritySchedulerQueueManagerTest extends ThreadlyTester {
                                                             Clock.lastKnownForwardProgressingMillis());
     queueManager.lowPriorityQueueSet.addExecute(executeTask);
 
-    assertTrue(executeTask == queueManager.getNextTask());
+    assertTrue(executeTask == queueManager.getNextTask(true));
   }
   
   @Test
@@ -175,7 +196,7 @@ public class PrioritySchedulerQueueManagerTest extends ThreadlyTester {
     queueManager.highPriorityQueueSet.addScheduled(highTask);
     queueManager.lowPriorityQueueSet.addScheduled(lowTask);
 
-    assertTrue(highTask == queueManager.getNextTask());
+    assertTrue(highTask == queueManager.getNextTask(true));
   }
   
   @Test
@@ -189,7 +210,7 @@ public class PrioritySchedulerQueueManagerTest extends ThreadlyTester {
     queueManager.highPriorityQueueSet.addScheduled(highTask);
     queueManager.lowPriorityQueueSet.addScheduled(lowTask);
 
-    assertTrue(lowTask == queueManager.getNextTask());
+    assertTrue(lowTask == queueManager.getNextTask(true));
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerWorkerPoolTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerWorkerPoolTest.java
@@ -18,7 +18,7 @@ public class PrioritySchedulerWorkerPoolTest extends ThreadlyTester {
   
   @Before
   public void setup() {
-    workerPool = new WorkerPool(new ConfigurableThreadFactory(), 1);
+    workerPool = new WorkerPool(new ConfigurableThreadFactory(), 1, true);
     qm = new QueueManager(workerPool, 1000);
     
     workerPool.start(qm);

--- a/src/test/java/org/threadly/concurrent/StrictPriorityScheduler.java
+++ b/src/test/java/org/threadly/concurrent/StrictPriorityScheduler.java
@@ -69,7 +69,7 @@ public class StrictPriorityScheduler extends PriorityScheduler {
   public StrictPriorityScheduler(int poolSize, TaskPriority defaultPriority, 
                                  long maxWaitForLowPriorityInMs, 
                                  boolean useDaemonThreads) {
-    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, 
+    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, DEFAULT_STARVABLE_STARTS_THREADS, 
          new ConfigurableThreadFactory(PriorityScheduler.class.getSimpleName() + "-", 
                                        true, useDaemonThreads, Thread.NORM_PRIORITY, null, null));
   }
@@ -88,7 +88,27 @@ public class StrictPriorityScheduler extends PriorityScheduler {
    */
   public StrictPriorityScheduler(int poolSize, TaskPriority defaultPriority, 
                                  long maxWaitForLowPriorityInMs, ThreadFactory threadFactory) {
-    super(new WorkerPool(threadFactory, poolSize), defaultPriority, maxWaitForLowPriorityInMs);
+    this(poolSize, defaultPriority, maxWaitForLowPriorityInMs, DEFAULT_STARVABLE_STARTS_THREADS, threadFactory);
+  }
+
+  /**
+   * Constructs a new thread pool, though no threads will be started till it accepts it's first 
+   * request.  This provides the extra parameters to tune what tasks submitted without a priority 
+   * will be scheduled as.  As well as the maximum wait for low priority tasks.  The longer low 
+   * priority tasks wait for a worker, the less chance they will have to create a thread.  But it 
+   * also makes low priority tasks execution time less predictable.
+   * 
+   * @param poolSize Thread pool size that should be maintained
+   * @param defaultPriority priority to give tasks which do not specify it
+   * @param maxWaitForLowPriorityInMs time low priority tasks wait for a worker
+   * @param stavableStartsThreads {@code true} to have TaskPriority.Starvable tasks start new threads
+   * @param threadFactory thread factory for producing new threads within executor
+   */
+  public StrictPriorityScheduler(int poolSize, TaskPriority defaultPriority, 
+                                 long maxWaitForLowPriorityInMs, 
+                                 boolean stavableStartsThreads, ThreadFactory threadFactory) {
+    super(new WorkerPool(threadFactory, poolSize, stavableStartsThreads), 
+          defaultPriority, maxWaitForLowPriorityInMs);
   }
   
   private static void verifyOneTimeTaskQueueSet(QueueSet queueSet, OneTimeTaskWrapper task) {

--- a/src/test/java/org/threadly/concurrent/statistics/PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest.java
+++ b/src/test/java/org/threadly/concurrent/statistics/PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest.java
@@ -15,6 +15,7 @@ public class PrioritySchedulerStatisticTrackerStatisticWorkerPoolTest extends Pr
   @Override
   public void setup() {
     workerPool = localWorkerPool = new StatisticWorkerPool(new ConfigurableThreadFactory(), 1, 
+                                                           true, 
                                                            new PriorityStatisticManager(100, false));
     qm = new VisibilityPriorityScheduler.VisibilityQueueManager(workerPool, 1000);
     

--- a/src/test/java/org/threadly/concurrent/statistics/PrioritySchedulerStatisticTrackerTest.java
+++ b/src/test/java/org/threadly/concurrent/statistics/PrioritySchedulerStatisticTrackerTest.java
@@ -33,12 +33,6 @@ public class PrioritySchedulerStatisticTrackerTest extends PrioritySchedulerTest
     new PrioritySchedulerStatisticTracker(1, TaskPriority.High, 100, false);
     new PrioritySchedulerStatisticTracker(1, TaskPriority.High, 100, 
                                           new ConfigurableThreadFactory());
-    new PrioritySchedulerStatisticTracker(1, 100);
-    new PrioritySchedulerStatisticTracker(1, false, 100);
-    new PrioritySchedulerStatisticTracker(1, TaskPriority.High, 100, 100);
-    new PrioritySchedulerStatisticTracker(1, TaskPriority.High, 100, false, 100);
-    new PrioritySchedulerStatisticTracker(1, TaskPriority.High, 100, 
-                                          new ConfigurableThreadFactory(), 100);
     new PrioritySchedulerStatisticTracker(1, 100, true);
     new PrioritySchedulerStatisticTracker(1, false, 100, true);
     new PrioritySchedulerStatisticTracker(1, TaskPriority.High, 100, 100, true);
@@ -58,13 +52,13 @@ public class PrioritySchedulerStatisticTrackerTest extends PrioritySchedulerTest
   @SuppressWarnings("unused")
   public void constructorFail() {
     try {
-      new PrioritySchedulerStatisticTracker(0, TaskPriority.High, 1, null);
+      new PrioritySchedulerStatisticTracker(0, true);
       fail("Exception should have thrown");
     } catch (IllegalArgumentException e) {
       // expected
     }
     try {
-      new PrioritySchedulerStatisticTracker(1, TaskPriority.High, -1, null);
+      new PrioritySchedulerStatisticTracker(1, TaskPriority.High, -1);
       fail("Exception should have thrown");
     } catch (IllegalArgumentException e) {
       // expected
@@ -347,6 +341,18 @@ public class PrioritySchedulerStatisticTrackerTest extends PrioritySchedulerTest
                                                    long maxWaitForLowPriority) {
       PriorityScheduler result = new PrioritySchedulerStatisticTracker(poolSize, defaultPriority, 
                                                                        maxWaitForLowPriority);
+      executors.add(result);
+      
+      return result;
+    }
+
+    @Override
+    public PriorityScheduler makePriorityScheduler(int poolSize, TaskPriority defaultPriority,
+                                                   long maxWaitForLowPriority,
+                                                   boolean stavableStartsThreads) {
+      PriorityScheduler result = new PrioritySchedulerStatisticTracker(poolSize, defaultPriority, 
+                                                                       maxWaitForLowPriority, 
+                                                                       stavableStartsThreads);
       executors.add(result);
       
       return result;

--- a/src/test/java/org/threadly/concurrent/statistics/ThreadedStatisticPrioritySchedulerTests.java
+++ b/src/test/java/org/threadly/concurrent/statistics/ThreadedStatisticPrioritySchedulerTests.java
@@ -47,7 +47,9 @@ public class ThreadedStatisticPrioritySchedulerTests extends ThreadlyTester {
     scheduler.resetCollectedStats();
     
     assertEquals(-1, scheduler.getAverageExecutionDuration(), 0);
+    assertEquals(-1, scheduler.getAverageExecutionDelay(), 0);
     for (TaskPriority p : TaskPriority.values()) {
+      assertEquals(-1, scheduler.getAverageExecutionDuration(p), 0);
       assertEquals(-1, scheduler.getAverageExecutionDelay(p), 0);
     }
   }


### PR DESCRIPTION
This logic is designed to avoid the growth of threads around starvable priority tasks.
Because we need idle threads waiting for new tasks to be accepted, we can't simply just avoid starting threads, instead we will at times avoid pulling Starvable tasks since occuping the worker could result in new threads starting while the Starvable is running.
So thread starts are still possible, just a best effort to be reduced.  Specifically a starvable task will be consumed when:
* There is only one thread in the pool (thus allowing it to expand to at least two)
* There is at least two idle threads
* The pool is already at its max size anyways
* The pool is shutting down so the final queue is trying to be purged

This is particularly valuable for a pool like CentralThreadlyPool where the pool may have a very large max threads configured.
This new behavior is set by default, but can be changed back to the current master behavior with a newly provided constructor.  This seems safe for Starvable.  An earlier implementation allowed it to also be configured for low priority, but this seems potentially more dangerous since a long running low priority task could result in other tasks being starved.
This commit has a similar issue in that a long running starvable task could result in other starvable tasks not being run, nor having the pool expanded to run both.  This is assumed desired for the Starvable priorities, but not safe for others.

This PR is to resolve issue #258 

After a lot of benchmarking I am pretty confident in the performance.  @lwahlmeier Thoughts on the general behavior or implementation?