### PR TITLE
Add CompletableFutureAdapter implementation

### DIFF
--- a/src/main/java/org/threadly/concurrent/future/CompletableFutureAdapter.java
+++ b/src/main/java/org/threadly/concurrent/future/CompletableFutureAdapter.java
@@ -1,0 +1,121 @@
+package org.threadly.concurrent.future;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+/**
+ * This class helps in converting between threadly's {@link ListenableFuture} and java's provided 
+ * {@link CompletableFuture}.  The threadly project prefers {@link ListenableFuture} as it is able 
+ * to be more performant, as well as in some cases provide additional features.  Still, the 
+ * concepts are very similar, making it easy for this class to convert between the types.
+ * 
+ * @since 5.43
+ */
+public class CompletableFutureAdapter {
+  /**
+   * Convert from a {@link ListenableFuture} to {@link CompletableFuture}.
+   * 
+   * @param <T> Type of result provided by the future
+   * @param lf The future to adapt into a {@link CompletableFuture}
+   * @return A CompletableFuture instance which's state will be connected to the provided future
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public static <T> CompletableFuture<T> toCompletable(ListenableFuture<? extends T> lf) {
+    // no instanceof optimization so that CompletableFuture.getNumberOfDependents() behavior is predictable
+    return new AdaptedCompletableFuture<T>(lf);
+  }
+
+  /**
+   * Convert from a {@link CompletableFuture} to {@link ListenableFuture}.
+   * 
+   * @param <T> Type of result provided by the future
+   * @param cf The future to adapt into a {@link ListenableFuture}
+   * @return A ListenableFuture instance which's state will be connected to the provided future
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public static <T> ListenableFuture<T> toListenable(CompletableFuture<? extends T> cf) {
+    if (cf instanceof ListenableFuture) {
+      return (ListenableFuture)cf;
+    } else if (cf.isDone() && ! cf.isCompletedExceptionally()) {
+      try {
+        return FutureUtils.immediateResultFuture(cf.get());
+      } catch (InterruptedException e) {
+        // should not be possible
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      } catch (ExecutionException e) {
+        // should not be possible, rather than throw we just adapt
+        return FutureUtils.immediateFailureFuture(e.getCause());
+      }
+    }
+    
+    return new AdaptedListenableFuture<T>(cf);
+    
+  }
+  
+  /**
+   * Instance of {@link CompletableFuture} which is dependent on a provided 
+   * {@link ListenableFuture} for the state and result.  This class still implements the 
+   * {@link ListenableFuture} interface to allow it to be easily converted back if desired.
+   *
+   * @param <T> Type of result to be provided from the future
+   * @since 5.43
+   */
+  protected static class AdaptedCompletableFuture<T> extends CompletableFuture<T> 
+                                                     implements ListenableFuture<T> {
+    protected final ListenableFuture<? extends T> lf;
+    
+    public AdaptedCompletableFuture(ListenableFuture<? extends T> lf) {
+      this.lf = lf;
+      
+      lf.callback(new FutureCallback<T>() {
+        @Override
+        public void handleResult(T result) {
+          complete(result);
+        }
+
+        @Override
+        public void handleFailure(Throwable t) {
+          completeExceptionally(t);
+        }
+      });
+    }
+
+    @Override
+    public ListenableFuture<T> listener(Runnable listener, Executor executor,
+                                        ListenerOptimizationStrategy optimizeExecution) {
+      lf.listener(listener, executor, optimizeExecution);
+      
+      return this;
+    }
+
+    @Override
+    public StackTraceElement[] getRunningStackTrace() {
+      return lf.getRunningStackTrace();
+    }
+  }
+
+  /**
+   * Instance of {@link ListenableFuture} which is dependent on a provided 
+   * {@link CompletableFuture} for the state and result.
+   *
+   * @param <T> Type of result to be provided from the future
+   * @since 5.43
+   */
+  protected static class AdaptedListenableFuture<T> extends SettableListenableFuture<T> {
+    protected final CompletableFuture<? extends T> cf;
+
+    public AdaptedListenableFuture(CompletableFuture<? extends T> cf) {
+      this.cf = cf;
+      
+      cf.whenComplete((result, error) -> {
+        if (error != null) {
+          setFailure(error);
+        } else {
+          setResult(result);
+        }
+      });
+    }
+  }
+}

--- a/src/test/java/org/threadly/concurrent/future/CompletableFutureAdapterTest.java
+++ b/src/test/java/org/threadly/concurrent/future/CompletableFutureAdapterTest.java
@@ -1,0 +1,164 @@
+package org.threadly.concurrent.future;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+import org.threadly.test.concurrent.TestRunnable;
+
+@SuppressWarnings("javadoc")
+public class CompletableFutureAdapterTest {
+  @Test
+  public void adaptCompletedResultListenableFutureTest() throws InterruptedException, ExecutionException {
+    Object result = new Object();
+    ListenableFuture<?> lf = FutureUtils.immediateResultFuture(result);
+    
+    CompletableFuture<Object> cf = CompletableFutureAdapter.toCompletable(lf);
+    
+    assertTrue(cf.isDone());
+    assertTrue(result == cf.get());
+  }
+  
+  @Test
+  public void adaptCompletedFailureListenableFutureTest() throws InterruptedException {
+    Exception failure = new Exception();
+    ListenableFuture<?> lf = FutureUtils.immediateFailureFuture(failure);
+    
+    CompletableFuture<Object> cf = CompletableFutureAdapter.toCompletable(lf);
+    
+    assertTrue(cf.isDone());
+    assertTrue(cf.isCompletedExceptionally());
+    try {
+      cf.get();
+      fail("Exception should have thrown");
+    } catch (ExecutionException e) {
+      assertTrue(failure == e.getCause());
+    }
+  }
+  
+  @Test
+  public void adaptIncompletedResultListenableFutureTest() throws InterruptedException, ExecutionException {
+    Object result = new Object();
+    SettableListenableFuture<Object> lf = new SettableListenableFuture<>();
+    
+    CompletableFuture<Object> cf = CompletableFutureAdapter.toCompletable(lf);
+
+    assertFalse(cf.isDone());
+    lf.setResult(result);
+    assertTrue(cf.isDone());
+    assertTrue(result == cf.get());
+  }
+  
+  @Test
+  public void adaptInompletedFailureListenableFutureTest() throws InterruptedException {
+    Exception failure = new Exception();
+    SettableListenableFuture<Object> lf = new SettableListenableFuture<>();
+    
+    CompletableFuture<Object> cf = CompletableFutureAdapter.toCompletable(lf);
+
+    assertFalse(cf.isDone());
+    lf.setFailure(failure);
+    assertTrue(cf.isDone());
+    assertTrue(cf.isCompletedExceptionally());
+    try {
+      cf.get();
+      fail("Exception should have thrown");
+    } catch (ExecutionException e) {
+      assertTrue(failure == e.getCause());
+    }
+  }
+  
+  @Test
+  public void adaptCompletedResultCompletableFutureTest() throws InterruptedException, ExecutionException {
+    Object result = new Object();
+    CompletableFuture<Object> cf = CompletableFuture.completedFuture(result);
+    
+    ListenableFuture<?> lf = CompletableFutureAdapter.toListenable(cf);
+    
+    assertTrue(lf.isDone());
+    assertTrue(result == lf.get());
+  }
+  
+  @Test
+  public void adaptCompletedFailureCompletableFutureTest() throws InterruptedException {
+    Exception failure = new Exception();
+    CompletableFuture<Object> cf = new CompletableFuture<>();
+    cf.completeExceptionally(failure);
+
+    ListenableFuture<?> lf = CompletableFutureAdapter.toListenable(cf);
+    
+    assertTrue(lf.isDone());
+    try {
+      lf.get();
+      fail("Exception should have thrown");
+    } catch (ExecutionException e) {
+      assertTrue(failure == e.getCause());
+    }
+  }
+  
+  @Test
+  public void adaptIncompletedResultCompletableFutureTest() throws InterruptedException, ExecutionException {
+    Object result = new Object();
+    CompletableFuture<Object> cf = new CompletableFuture<>();
+
+    ListenableFuture<?> lf = CompletableFutureAdapter.toListenable(cf);
+
+    assertFalse(lf.isDone());
+    cf.complete(result);
+    assertTrue(lf.isDone());
+    assertTrue(result == lf.get());
+  }
+  
+  @Test
+  public void adaptInompletedFailureCompletableFutureTest() throws InterruptedException {
+    Exception failure = new Exception();
+    CompletableFuture<Object> cf = new CompletableFuture<>();
+
+    ListenableFuture<?> lf = CompletableFutureAdapter.toListenable(cf);
+
+    assertFalse(lf.isDone());
+    cf.completeExceptionally(failure);
+    assertTrue(lf.isDone());
+    try {
+      lf.get();
+      fail("Exception should have thrown");
+    } catch (ExecutionException e) {
+      assertTrue(failure == e.getCause());
+    }
+  }
+  
+  @Test
+  public void adaptBackToListenableFutureTest() {
+    ListenableFuture<?> lf = FutureUtils.immediateResultFuture(new Object());
+    CompletableFuture<Object> cf = CompletableFutureAdapter.toCompletable(lf);
+    
+    assertTrue(cf == CompletableFutureAdapter.toListenable(cf));
+  }
+  
+  @Test
+  public void adaptedListenableFutureListenerTest() {
+    // adapt twice so we are using the CompletableFuture implementation (as tested in adaptBackToListenableFutureTest)
+    ListenableFuture<?> lf = 
+        CompletableFutureAdapter.toListenable(
+            CompletableFutureAdapter.toCompletable(
+                FutureUtils.immediateResultFuture(new Object())));
+    
+    TestRunnable tr = new TestRunnable();
+    assertTrue(lf == lf.listener(tr));
+    assertTrue(tr.ranOnce());
+  }
+  
+  @Test
+  public void adaptedListenableFutureGetRunningStackTest() {
+    SettableListenableFuture<Object> slf = new SettableListenableFuture<>();
+    slf.setRunningThread(Thread.currentThread());
+    // adapt twice so we are using the CompletableFuture implementation (as tested in adaptBackToListenableFutureTest)
+    ListenableFuture<?> lf = 
+        CompletableFutureAdapter.toListenable(
+            CompletableFutureAdapter.toCompletable(slf));
+    
+    assertNotNull(lf.getRunningStackTrace());
+  }
+}

--- a/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
+++ b/src/test/java/org/threadly/concurrent/future/FutureUtilsTest.java
@@ -298,7 +298,7 @@ public class FutureUtilsTest extends ThreadlyTester {
   }
   
   @Test
-  public void invokeAfterAllCompleteTest() {
+  public void invokeAfterSingleCompleteTest() {
     List<SettableListenableFuture<Void>> futures = 
         Collections.singletonList(new SettableListenableFuture<>());
     TestRunnable tr = new TestRunnable();
@@ -308,6 +308,25 @@ public class FutureUtilsTest extends ThreadlyTester {
     assertEquals(0, tr.getRunCount());
     
     futures.get(0).setResult(null);
+    
+    assertTrue(tr.ranOnce());
+  }
+  
+  @Test
+  public void invokeAfterAllCompleteTest() {
+    SettableListenableFuture<Void> slf1 = new SettableListenableFuture<>();
+    SettableListenableFuture<Void> slf2 = new SettableListenableFuture<>();
+    List<SettableListenableFuture<Void>> futures = new ArrayList<>();
+    futures.add(slf1);
+    futures.add(slf2);
+    TestRunnable tr = new TestRunnable();
+    
+    FutureUtils.invokeAfterAllComplete(futures, tr);
+    
+    assertEquals(0, tr.getRunCount());
+    slf1.setResult(null);
+    assertEquals(0, tr.getRunCount());
+    slf2.setResult(null);
     
     assertTrue(tr.ranOnce());
   }


### PR DESCRIPTION
This class allows the easy conversion between threadly's `ListenableFuture` and java's `CompletableFuture`.

This resolves #231 and is relevant to the discussion in #221 .  Currently I don't think it's worth the compromises to switch to `CompletableFuture`, but at a minimum want to provide an easy way to go back and forth.

@lwahlmeier let me know your thoughts generally as well anything you see in this PR you think we can improve.  I want to include this before our next major release.