### PR TITLE
ListenableFuture: Ability to get error states without an ExecutionException

### DIFF
--- a/src/main/java/org/threadly/concurrent/future/CancelDebuggingListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/CancelDebuggingListenableFuture.java
@@ -69,10 +69,29 @@ public class CancelDebuggingListenableFuture<T> implements ListenableFuture<T> {
       throw e;
     }
   }
+
+  @Override
+  public Throwable getFailure() throws InterruptedException {
+    Throwable result = delegateFuture.getFailure();
+    if (result instanceof CancellationException) {
+      prepareCancellationException(result);
+    }
+    return result;
+  }
+
+  @Override
+  public Throwable getFailure(long timeout, TimeUnit unit) throws InterruptedException,
+                                                                  TimeoutException {
+    Throwable result = delegateFuture.getFailure(timeout, unit);
+    if (result instanceof CancellationException) {
+      prepareCancellationException(result);
+    }
+    return result;
+  }
   
-  private void prepareCancellationException(CancellationException e) {
+  private void prepareCancellationException(Throwable t) {
     if (cancelStack != null) {
-      Throwable rootCause = ExceptionUtils.getRootCause(e);
+      Throwable rootCause = ExceptionUtils.getRootCause(t);
       rootCause.initCause(new FutureProcessingStack(cancelStack));
     }
   }
@@ -85,6 +104,11 @@ public class CancelDebuggingListenableFuture<T> implements ListenableFuture<T> {
   @Override
   public boolean isDone() {
     return delegateFuture.isDone();
+  }
+
+  @Override
+  public boolean isCompletedExceptionally() {
+    return delegateFuture.isCompletedExceptionally();
   }
 
   @Override

--- a/src/main/java/org/threadly/concurrent/future/CompletableFutureAdapter.java
+++ b/src/main/java/org/threadly/concurrent/future/CompletableFutureAdapter.java
@@ -3,6 +3,8 @@ package org.threadly.concurrent.future;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * This class helps in converting between threadly's {@link ListenableFuture} and java's provided 
@@ -93,6 +95,17 @@ public class CompletableFutureAdapter {
     @Override
     public StackTraceElement[] getRunningStackTrace() {
       return lf.getRunningStackTrace();
+    }
+
+    @Override
+    public Throwable getFailure() throws InterruptedException {
+      return lf.getFailure();
+    }
+
+    @Override
+    public Throwable getFailure(long timeout, TimeUnit unit) throws InterruptedException,
+                                                                    TimeoutException {
+      return lf.getFailure(timeout, unit);
     }
   }
 

--- a/src/main/java/org/threadly/concurrent/future/ExecuteOnGetFutureTask.java
+++ b/src/main/java/org/threadly/concurrent/future/ExecuteOnGetFutureTask.java
@@ -76,4 +76,11 @@ public class ExecuteOnGetFutureTask<T> extends ListenableFutureTask<T> {
     
     return super.get();
   }
+  
+  @Override
+  public Throwable getFailure() throws InterruptedException {
+    executeIfNotStarted();
+    
+    return super.getFailure();
+  }
 }

--- a/src/main/java/org/threadly/concurrent/future/ImmediateFailureListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateFailureListenableFuture.java
@@ -34,6 +34,11 @@ public class ImmediateFailureListenableFuture<T> extends AbstractCompletedListen
   }
 
   @Override
+  public boolean isCompletedExceptionally() {
+    return true;
+  }
+
+  @Override
   public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
                                       ListenerOptimizationStrategy optimize) {
     if (invokeCompletedDirectly(executor, optimize)) {
@@ -72,5 +77,15 @@ public class ImmediateFailureListenableFuture<T> extends AbstractCompletedListen
   @Override
   public T get(long timeout, TimeUnit unit) throws ExecutionException {
     throw new ExecutionException(failure);
+  }
+
+  @Override
+  public Throwable getFailure() {
+    return failure;
+  }
+
+  @Override
+  public Throwable getFailure(long timeout, TimeUnit unit) {
+    return failure;
   }
 }

--- a/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ImmediateResultListenableFuture.java
@@ -143,6 +143,11 @@ public class ImmediateResultListenableFuture<T> extends AbstractCompletedListena
   public ImmediateResultListenableFuture(T result) {
     this.result = result;
   }
+
+  @Override
+  public boolean isCompletedExceptionally() {
+    return false;
+  }
   
   @Override
   public <TT extends Throwable> ListenableFuture<T> mapFailure(Class<TT> throwableType, 
@@ -225,5 +230,15 @@ public class ImmediateResultListenableFuture<T> extends AbstractCompletedListena
   @Override
   public T get(long timeout, TimeUnit unit) {
     return result;
+  }
+
+  @Override
+  public Throwable getFailure() {
+    return null;
+  }
+
+  @Override
+  public Throwable getFailure(long timeout, TimeUnit unit) {
+    return null;
   }
 }

--- a/src/main/java/org/threadly/concurrent/future/InternalFutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/InternalFutureUtils.java
@@ -548,7 +548,7 @@ class InternalFutureUtils {
         ListenableFuture<? extends T> f = it.next();
         futures.add(f);
         attachFutureDoneTask(f, count++);
-        }
+      }
       
       init(count);
       
@@ -793,21 +793,8 @@ class InternalFutureUtils {
 
     @Override
     protected void handleFutureDone(ListenableFuture<? extends T> f, int index) {
-      if (f.isCancelled()) {
-        // detect canceled conditions before an exception would have otherwise thrown
-        // canceled futures are ignored
-        return;
-      }
-      try {
-        f.get();
+      if (! f.isCompletedExceptionally()) {
         addResult(f, index);  // if no exception thrown, add future
-      } catch (ExecutionException e) {
-        // ignored
-      } catch (CancellationException e) {
-        // should not be possible due check at start on what should be an already done future
-        throw e;
-      } catch (InterruptedException e) {
-        // should not be possible since this should only be called once the future is already done
       }
     }
   }
@@ -834,20 +821,8 @@ class InternalFutureUtils {
 
     @Override
     protected void handleFutureDone(ListenableFuture<? extends T> f, int index) {
-      if (f.isCancelled()) {
-        // detect canceled conditions before an exception would have otherwise thrown 
-        addResult(f, index);
-        return;
-      }
-      try {
-        f.get();
-      } catch (ExecutionException e) {
+      if (f.isCompletedExceptionally()) {
         addResult(f, index); // failed so add it
-      } catch (CancellationException e) {
-        // should not be possible due check at start on what should be an already done future
-        throw e;
-      } catch (InterruptedException e) {
-        // should not be possible since this should only be called once the future is already done
       }
     }
   }

--- a/src/main/java/org/threadly/concurrent/future/InternalFutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/InternalFutureUtils.java
@@ -908,6 +908,11 @@ class InternalFutureUtils {
     }
 
     @Override
+    public boolean isCompletedExceptionally() {
+      return true;
+    }
+
+    @Override
     public ListenableFuture<T> callback(FutureCallback<? super T> callback, Executor executor, 
                                         ListenerOptimizationStrategy optimize) {
       CancellationException e = new CancellationException(cancelMessage);
@@ -941,13 +946,23 @@ class InternalFutureUtils {
     }
 
     @Override
-    public T get() throws ExecutionException {
+    public T get() {
       throw new CancellationException(cancelMessage);
     }
 
     @Override
-    public T get(long timeout, TimeUnit unit) throws ExecutionException {
+    public T get(long timeout, TimeUnit unit) {
       throw new CancellationException(cancelMessage);
+    }
+
+    @Override
+    public Throwable getFailure() {
+      return new CancellationException(cancelMessage);
+    }
+
+    @Override
+    public Throwable getFailure(long timeout, TimeUnit unit) {
+      return new CancellationException(cancelMessage);
     }
   }
 }

--- a/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
@@ -6,6 +6,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -59,6 +61,40 @@ public interface ListenableFuture<T> extends Future<T> {
      */
     SingleThreadIfExecutorMatchOrDone
   }
+  
+  /**
+   * Returns {@code true} if the future is both done and has completed with an error or was 
+   * canceled.  If this returns {@code true} the {@link Throwable} responsible for the error can 
+   * be retrieved using {@link #getFailure()};
+   * 
+   * @return {@code true} if this ListenableFuture completed by a thrown Exception or was canceled
+   */
+  public boolean isCompletedExceptionally();
+  
+  /**
+   * Similar to {@link #get()} except instead of providing a result, this will provide a thrown 
+   * exception if {@link #isCompletedExceptionally()} returns {@code true}.  If the future has not 
+   * completed yet this function will block until completion.  If the future completed normally, 
+   * this will return {@code null}.
+   * 
+   * @return Throwable thrown in computing the future or {@code null} if completed normally
+   * @throws InterruptedException If the current thread was interrupted while blocking
+   */
+  public Throwable getFailure() throws InterruptedException;
+  
+  /**
+   * Similar to {@link #get(long, TimeUnit)} except instead of providing a result, this will 
+   * provide a thrown exception if {@link #isCompletedExceptionally()} returns {@code true}.  If 
+   * the future has not completed yet this function will block until completion.  If the future 
+   * completed normally, this will return {@code null}.
+   * 
+   * @param timeout The maximum time to wait
+   * @param unit The time unit of the timeout argument
+   * @return Throwable thrown in computing the future or {@code null} if completed normally
+   * @throws InterruptedException If the current thread was interrupted while blocking
+   * @throws TimeoutException If the timeout was reached before the future completed
+   */
+  public Throwable getFailure(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException;
   
   /**
    * Transform this future's result into another result by applying the provided mapper function.  

--- a/src/main/java/org/threadly/concurrent/future/ListenableFutureTask.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFutureTask.java
@@ -197,7 +197,8 @@ public class ListenableFutureTask<T> extends FutureTask<T>
     }
   }
   
-  private int awaitDoneState(long awaitNanos) throws IllegalAccessException, IllegalArgumentException, InterruptedException {
+  private int awaitDoneState(long awaitNanos) throws IllegalAccessException, 
+                                                     IllegalArgumentException, InterruptedException {
     try {
       return ((Integer)AWAIT_DONE_METHOD.invoke(this, awaitNanos > 0, awaitNanos)).intValue();
     } catch (InvocationTargetException e) {

--- a/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/compatibility/AbstractExecutorServiceWrapper.java
@@ -308,6 +308,11 @@ abstract class AbstractExecutorServiceWrapper implements ScheduledExecutorServic
     }
 
     @Override
+    public boolean isCompletedExceptionally() {
+      return futureImp.isCompletedExceptionally();
+    }
+
+    @Override
     public T get() throws InterruptedException, ExecutionException {
       return futureImp.get();
     }
@@ -316,6 +321,17 @@ abstract class AbstractExecutorServiceWrapper implements ScheduledExecutorServic
     public T get(long timeout, TimeUnit unit) throws InterruptedException, 
                                                      ExecutionException, TimeoutException {
       return futureImp.get(timeout, unit);
+    }
+
+    @Override
+    public Throwable getFailure() throws InterruptedException {
+      return futureImp.getFailure();
+    }
+
+    @Override
+    public Throwable getFailure(long timeout, TimeUnit unit) throws InterruptedException,
+                                                                    TimeoutException {
+      return futureImp.getFailure(timeout, unit);
     }
 
     @Override

--- a/src/main/java/org/threadly/util/UnsafeAccess.java
+++ b/src/main/java/org/threadly/util/UnsafeAccess.java
@@ -71,4 +71,18 @@ public final class UnsafeAccess {
                                     "...Could not set Field to public: " + f, e);
     }
   }
+  
+  /**
+   * Takes in a {@link Method} and sets the accessibility to be public.
+   * 
+   * @param m Method to be modified
+   */
+  public static void setMethodToPublic(Method m) {
+    try {
+      SET_ACCESSIBLE.invoke(m, true);
+    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      throw new RuntimeException("Unsupported JVM version, please update threadly or file an issue" + 
+                                    "...Could not set Field to public: " + m, e);
+    }
+  }
 }

--- a/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
@@ -39,6 +39,16 @@ public class ExecuteOnGetFutureTaskTest extends ListenableFutureTaskTest {
   }
   
   @Test
+  public void executeInvokedByGetFailureTest() throws InterruptedException {
+    TestRunnable tr = new TestRunnable();
+    ExecuteOnGetFutureTask<?> geft = new ExecuteOnGetFutureTask<>(tr);
+    
+    assertNull(geft.getFailure());
+    
+    assertTrue(tr.ranOnce());
+  }
+  
+  @Test
   public void executeOnceTest() throws InterruptedException, ExecutionException {
     TestRunnable tr = new TestRunnable();
     ExecuteOnGetFutureTask<?> geft = new ExecuteOnGetFutureTask<>(tr);
@@ -46,6 +56,7 @@ public class ExecuteOnGetFutureTaskTest extends ListenableFutureTaskTest {
     geft.get();
     geft.run();
     geft.get(); // multiple get calls should not execute again either
+    geft.getFailure();
     geft.run();
     
     assertTrue(tr.ranOnce());

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureInterfaceTest.java
@@ -296,7 +296,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
       return null;
     }, scheduler);
     
-    assertEquals(1, scheduler.tick());
+    assertEquals(0, scheduler.tick());  // not executed, instead error is detected and returned in thread
 
     assertTrue(mappedLF.isDone());
     verifyFutureFailure(mappedLF, failure);
@@ -378,7 +378,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
       }, sts);
       
       new TestCondition(() -> started.get()).blockTillTrue();
-      assertFalse(mappedLF.cancel(false));
+      assertTrue(mappedLF.cancel(false));
       new TestCondition(() -> completed.get()).blockTillTrue();
     } finally {
       sts.shutdownNow();
@@ -475,7 +475,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
       return null;
     }, scheduler);
     
-    assertEquals(1, scheduler.tick());
+    assertEquals(0, scheduler.tick());  // not executed, instead error is detected and returned in thread
 
     assertTrue(mappedLF.isDone());
     verifyFutureFailure(mappedLF, failure);
@@ -689,7 +689,7 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
       return FutureUtils.immediateResultFuture(null);
     }, scheduler);
     
-    assertEquals(1, scheduler.tick());
+    assertEquals(0, scheduler.tick());  // failure state should be detected without execution
 
     assertTrue(mappedLF.isDone());
     verifyFutureFailure(mappedLF, failure);
@@ -908,11 +908,8 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
                                                      (t) -> { mapped.set(true); return new Object(); }, 
                                                      scheduler);
 
-    assertTrue(finalLF != lf);
-    assertFalse(finalLF.isDone());
-    assertEquals(1, scheduler.tick());
-    assertFalse(mapped.get());
-    assertTrue(finalLF.isDone());
+    assertTrue(finalLF == lf);  // optimized, no mapping, no new future needed
+    assertEquals(0, scheduler.tick());
   }
   
   @Test
@@ -924,12 +921,8 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
                                                 (t) -> { mapped.set(true); return null; }, 
                                                 scheduler);
 
-    assertTrue(finalLF != lf);
-    assertFalse(finalLF.isDone());
-    assertEquals(1, scheduler.tick());
-    assertTrue(finalLF.isDone());
-    assertFalse(mapped.get());
-    assertTrue(finalLF.isDone());
+    assertTrue(finalLF == lf);  // optimized, no mapping, no new future needed
+    assertEquals(0, scheduler.tick());
   }
   
   @Test
@@ -977,12 +970,8 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
                           (t) -> { mapped.set(true); return FutureUtils.immediateResultFuture(new Object()); }, 
                           scheduler);
 
-    assertTrue(finalLF != lf);
-    assertFalse(finalLF.isDone());
-    assertEquals(1, scheduler.tick());
-    assertTrue(finalLF.isDone());
-    assertFalse(mapped.get());
-    assertTrue(finalLF.isDone());
+    assertTrue(finalLF == lf);
+    assertEquals(0, scheduler.tick());
   }
   
   @Test
@@ -995,12 +984,8 @@ public abstract class ListenableFutureInterfaceTest extends ThreadlyTester {
                           (t) -> { mapped.set(true); return FutureUtils.immediateResultFuture(null); }, 
                           scheduler);
 
-    assertTrue(finalLF != lf);
-    assertFalse(finalLF.isDone());
-    assertEquals(1, scheduler.tick());
-    assertTrue(finalLF.isDone());
-    assertFalse(mapped.get());
-    assertTrue(finalLF.isDone());
+    assertTrue(finalLF == lf);
+    assertEquals(0, scheduler.tick());
   }
   
   @Test

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -196,6 +196,29 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     assertTrue(failure == tfc.getLastFailure());
   }
   
+  @Test
+  public void isCompletedExceptionallyTest() {
+    TestRunnable tr = new TestRuntimeFailureRunnable();
+    
+    ListenableFutureTask<Object> future = makeFutureTask(tr, null);
+    
+    assertFalse(future.isCompletedExceptionally());
+    future.run();
+    assertTrue(future.isCompletedExceptionally());
+  }
+  
+  @Test
+  public void isDoneByCancelTest() {
+    ListenableFutureTask<Object> future = makeFutureTask(DoNothingRunnable.instance(), null);
+    
+    assertFalse(future.isDone());
+    
+    assertTrue(future.cancel(false));
+    
+    assertTrue(future.isDone());
+    assertTrue(future.isCompletedExceptionally());
+  }
+  
   @Test (expected = ExecutionException.class)
   public void getExecutionExceptionTest() throws InterruptedException, ExecutionException {
     TestRunnable tr = new TestRuntimeFailureRunnable();

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -19,6 +19,7 @@ import org.threadly.test.concurrent.BlockingTestRunnable;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.test.concurrent.TestableScheduler;
 import org.threadly.util.Clock;
+import org.threadly.util.StackSuppressedRuntimeException;
 import org.threadly.util.StringUtils;
 
 @SuppressWarnings("javadoc")
@@ -56,7 +57,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   
   @Test (expected = IllegalStateException.class)
   public void setFailureResultFail() {
-    slf.setFailure(null);
+    slf.setFailure(new StackSuppressedRuntimeException());
     slf.setResult(null);
     fail("Should have thrown exception");
   }
@@ -64,7 +65,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   @Test
   public void setFailureResultTest() {
     slf = new SettableListenableFuture<>(false);
-    assertTrue(slf.setFailure(null));
+    assertTrue(slf.setFailure(new StackSuppressedRuntimeException()));
     assertFalse(slf.setResult(null));
   }
   
@@ -84,7 +85,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   
   @Test (expected = IllegalStateException.class)
   public void setFailureFailureFail() {
-    slf.setFailure(null);
+    slf.setFailure(new StackSuppressedRuntimeException());
     slf.setFailure(null);
     fail("Should have thrown exception");
   }
@@ -92,7 +93,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   @Test
   public void setFailureFailureTest() {
     slf = new SettableListenableFuture<>(false);
-    assertTrue(slf.setFailure(null));
+    assertTrue(slf.setFailure(new StackSuppressedRuntimeException()));
     assertFalse(slf.setFailure(null));
   }
   
@@ -124,6 +125,29 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     assertFalse(slf.setFailure(null));
   }
   
+  @Test
+  public void isCompletedExceptionallyWithFailureTest() {
+    assertFalse(slf.isCompletedExceptionally());
+    slf.setFailure(new StackSuppressedRuntimeException());
+    assertTrue(slf.isCompletedExceptionally());
+  }
+  
+  @Test
+  public void isCompletedExceptionallyWithResultTest() {
+    slf.setResult(null);
+    assertFalse(slf.isCompletedExceptionally());
+  }
+  
+  @Test
+  public void isDoneByCancelTest() {
+    assertFalse(slf.isDone());
+    
+    assertTrue(slf.cancel(false));
+    
+    assertTrue(slf.isDone());
+    assertTrue(slf.isCompletedExceptionally());
+  }
+  
   @Test (expected = IllegalStateException.class)
   public void clearResultFail() {
     slf.clearResult();
@@ -140,7 +164,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   
   @Test (expected = IllegalStateException.class)
   public void getAfterClearFailureResultFail() throws InterruptedException, ExecutionException {
-    slf.setFailure(null);
+    slf.setFailure(new StackSuppressedRuntimeException());
     slf.clearResult();
     slf.get();
     fail("Should have thrown exception");
@@ -161,7 +185,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     slf.listener(tr);
     
     if (failure) {
-      slf.setFailure(null);
+      slf.setFailure(new StackSuppressedRuntimeException());
     } else {
       slf.setResult(null);
     }
@@ -204,7 +228,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   
   @Test
   public void callbackExecutionExceptionTest() {
-    Throwable failure = new Exception();
+    Throwable failure = new StackSuppressedRuntimeException();
     TestFutureCallback tfc = new TestFutureCallback();
     slf.callback(tfc);
     
@@ -218,7 +242,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   
   @Test
   public void failureCallbackExecutionExceptionTest() {
-    Throwable failure = new Exception();
+    Throwable failure = new StackSuppressedRuntimeException();
     TestFutureCallback tfc = new TestFutureCallback();
     slf.failureCallback(tfc::handleFailure);
     
@@ -243,7 +267,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   
   @Test
   public void addAsCallbackFailureTest() throws InterruptedException {
-    Exception e = new Exception();
+    Exception e = new StackSuppressedRuntimeException();
     ListenableFuture<String> failureFuture = new ImmediateFailureListenableFuture<>(e);
     
     failureFuture.callback(slf);
@@ -303,6 +327,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
     assertTrue(slf.isDone());
   }
   
+  @Override
   @Test
   public void getResultTest() throws InterruptedException, ExecutionException {
     final String testResult = StringUtils.makeRandomString(5);
@@ -382,7 +407,7 @@ public class SettableListenableFutureTest extends ListenableFutureInterfaceTest 
   @Test
   public void getWithTimeoutExecutionExceptionTest() throws InterruptedException, 
                                                             TimeoutException {
-    Exception failure = new Exception();
+    Exception failure = new StackSuppressedRuntimeException();
     slf.setFailure(failure);
     
     try {

--- a/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
+++ b/src/test/java/org/threadly/concurrent/future/TestFutureImp.java
@@ -37,6 +37,11 @@ public class TestFutureImp implements ListenableFuture<Object> {
   }
 
   @Override
+  public boolean isCompletedExceptionally() {
+    return canceled;
+  }
+
+  @Override
   public Object get() throws ExecutionException {
     if (canceled) {
       throw new CancellationException();
@@ -45,11 +50,27 @@ public class TestFutureImp implements ListenableFuture<Object> {
   }
 
   @Override
-  public Object get(long timeout, TimeUnit unit) throws TimeoutException {
+  public Object get(long timeout, TimeUnit unit) throws ExecutionException, TimeoutException {
     if (canceled) {
       throw new CancellationException();
     }
     return result;
+  }
+
+  @Override
+  public Throwable getFailure() {
+    if (canceled) {
+      return new CancellationException();
+    }
+    return null;
+  }
+
+  @Override
+  public Throwable getFailure(long timeout, TimeUnit unit) throws TimeoutException {
+    if (canceled) {
+      return new CancellationException();
+    }
+    return null;
   }
 
   @Override


### PR DESCRIPTION
This adds to the API:
* `isCompletedExceptionally()` (as matches the JDK's CompletableFuture) to check if the future is done but in a non-result state
* `getFailure()` to block till done, then get the error if one was thrown

Being able to access the error state without the need to throw an `ExecutionException` will help with future performance improvements.
I also hope these ergonomics make it easier when only checking for failure results.

The second commit provides some initial ways the internal library can use this.  However these are future improvements to be made with mapping futures which are in an error state.

@lwahlmeier Any thoughts on this API?