### PR TITLE
Basic and safe initial Java 9 memory concepts

### DIFF
--- a/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
@@ -688,14 +688,13 @@ public abstract class AbstractPriorityScheduler extends AbstractSubmitterSchedul
     protected final Queue<? extends TaskWrapper> taskQueue;
     protected final long runTime;
     // optimization to avoid queue traversal on failure to remove, cheaper than AtomicBoolean
-    protected volatile boolean executed;
+    protected volatile boolean executed;  // default false
     
     public OneTimeTaskWrapper(Runnable task, Queue<? extends TaskWrapper> taskQueue, long runTime) {
       super(task);
       
       this.taskQueue = taskQueue;
       this.runTime = runTime;
-      this.executed = false;
     }
     
     @Override

--- a/src/main/java/org/threadly/concurrent/PriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/PriorityScheduler.java
@@ -701,7 +701,7 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
     public void prestartAllThreads() {
       int casPoolSize;
       while ((casPoolSize = currentPoolSize.get()) < maxPoolSize) {
-        if (currentPoolSize.compareAndSet(casPoolSize, casPoolSize + 1)) {
+        if (currentPoolSize.weakCompareAndSetVolatile(casPoolSize, casPoolSize + 1)) {
           makeNewWorker();
         }
       }
@@ -798,7 +798,7 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
       int casPoolSize;
       while (true) {
         if ((casPoolSize = currentPoolSize.get()) > maxPoolSize) {
-          if (currentPoolSize.compareAndSet(casPoolSize, casPoolSize - 1)) {
+          if (currentPoolSize.weakCompareAndSetVolatile(casPoolSize, casPoolSize - 1)) {
             worker.stopWorker();
             return null;
           } // else, retry, see if we need to shutdown
@@ -900,7 +900,7 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
         if (nextIdleWorker == null) {
           int casSize = currentPoolSize.get();
           if (casSize < maxPoolSize) {
-            if (currentPoolSize.compareAndSet(casSize, casSize + 1)) {
+            if (currentPoolSize.weakCompareAndSetVolatile(casSize, casSize + 1)) {
               // start a new worker for the next task
               makeNewWorker();
               break;

--- a/src/main/java/org/threadly/concurrent/PriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/PriorityScheduler.java
@@ -929,8 +929,8 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
     protected final WorkerPool workerPool;
     protected final Thread thread;
     protected volatile Worker nextIdleWorker = null;
-    protected volatile boolean waitingForUnpark = false;
-    private volatile boolean running = false;
+    protected volatile boolean waitingForUnpark; // default false
+    private volatile boolean running; // default false
     
     public Worker(WorkerPool workerPool, ThreadFactory threadFactory) {
       this.workerPool = workerPool;

--- a/src/main/java/org/threadly/concurrent/ReschedulingOperation.java
+++ b/src/main/java/org/threadly/concurrent/ReschedulingOperation.java
@@ -127,11 +127,11 @@ public abstract class ReschedulingOperation {
     while (true) {
       int casState = taskState.get();
       if (casState == -1) {
-        if (taskState.compareAndSet(-1, 0)) {
+        if (taskState.weakCompareAndSetVolatile(-1, 0)) {
           return true;
         }
       } else if (casState == 1) {
-        if (taskState.compareAndSet(1, 2)) {
+        if (taskState.weakCompareAndSetVolatile(1, 2)) {
           return false;
         }
       } else {
@@ -204,7 +204,7 @@ public abstract class ReschedulingOperation {
         } finally {
           casLoop: while (true) {
             if (taskState.get() == 1) {
-              if (taskState.compareAndSet(1, -1)) {
+              if (taskState.weakCompareAndSetVolatile(1, -1)) {
                 // set back to idle state, we are done
                 break runLoop;
               }

--- a/src/main/java/org/threadly/concurrent/SingleThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/SingleThreadScheduler.java
@@ -299,7 +299,7 @@ public class SingleThreadScheduler extends AbstractPriorityScheduler {
      * @return {@code true} if scheduler was started.
      */
     public boolean startIfNotRunning() {
-      if (state.get() == -1 && state.compareAndSet(-1, 0)) {
+      if (state.getPlain() == -1 && state.compareAndSet(-1, 0)) {
         execThread.start();
         
         return true;

--- a/src/main/java/org/threadly/concurrent/SingleThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/SingleThreadScheduler.java
@@ -321,7 +321,7 @@ public class SingleThreadScheduler extends AbstractPriorityScheduler {
     public List<Runnable> stop(boolean stopImmediately) {
       int stateVal = state.get();
       while (stateVal < 1) {
-        if (state.compareAndSet(stateVal, 1)) {
+        if (state.weakCompareAndSetVolatile(stateVal, 1)) {
           // we finish the shutdown immediately if requested, or if it was never started
           if (stopImmediately || stateVal == -1) {
             return finishShutdown();

--- a/src/main/java/org/threadly/concurrent/event/RunnableListenerHelper.java
+++ b/src/main/java/org/threadly/concurrent/event/RunnableListenerHelper.java
@@ -24,9 +24,9 @@ import org.threadly.util.Pair;
 public class RunnableListenerHelper {
   protected final Object listenersLock;
   protected final boolean callOnce;
-  protected volatile boolean done;
-  protected List<Runnable> inThreadListeners;
-  protected List<Pair<Runnable, Executor>> executorListeners;
+  protected volatile boolean done;  // default false
+  protected List<Runnable> inThreadListeners; // default null
+  protected List<Pair<Runnable, Executor>> executorListeners; // default null
   
   /**
    * Constructs a new {@link RunnableListenerHelper}.  This can call listeners only once, or every 
@@ -37,9 +37,6 @@ public class RunnableListenerHelper {
   public RunnableListenerHelper(boolean callListenersOnce) {
     this.listenersLock = new Object();
     this.callOnce = callListenersOnce;
-    this.done = false;
-    this.inThreadListeners = null;
-    this.executorListeners = null;
   }
   
   /**

--- a/src/main/java/org/threadly/concurrent/future/ExecuteOnGetFutureTask.java
+++ b/src/main/java/org/threadly/concurrent/future/ExecuteOnGetFutureTask.java
@@ -60,7 +60,7 @@ public class ExecuteOnGetFutureTask<T> extends ListenableFutureTask<T> {
    * that execution will only occur once.
    */
   protected void executeIfNotStarted() {
-    if (! executionStarted.get() && executionStarted.compareAndSet(false, true)) {
+    if (! executionStarted.getPlain() && executionStarted.compareAndSet(false, true)) {
       super.run();
     }
   }

--- a/src/main/java/org/threadly/concurrent/future/InternalFutureUtils.java
+++ b/src/main/java/org/threadly/concurrent/future/InternalFutureUtils.java
@@ -888,7 +888,7 @@ class InternalFutureUtils {
 
     @Override
     public void accept(Throwable t) {
-      if (! canceled.get() && canceled.compareAndSet(false, true)) {
+      if (! canceled.getPlain() && canceled.compareAndSet(false, true)) {
         FutureUtils.cancelIncompleteFutures(futures, interruptThread);
       }
     }

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/ExecutorLimiter.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/ExecutorLimiter.java
@@ -182,7 +182,7 @@ public class ExecutorLimiter implements SubmitterExecutor {
     while (true) {  // loop till we have a result
       int currentValue = currentlyRunning.get();
       if (currentValue < maxConcurrency) {
-        if (currentlyRunning.compareAndSet(currentValue, currentValue + 1)) {
+        if (currentlyRunning.weakCompareAndSetVolatile(currentValue, currentValue + 1)) {
           return true;
         } // else retry in while loop
       } else {

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/PrioritySchedulerServiceQueueLimitRejector.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/PrioritySchedulerServiceQueueLimitRejector.java
@@ -103,7 +103,7 @@ public class PrioritySchedulerServiceQueueLimitRejector extends SchedulerService
       if (casValue >= getQueueLimit()) {
         rejectedExecutionHandler.handleRejectedTask(task);
         return; // in case handler did not throw exception
-      } else if (queuedTaskCount.compareAndSet(casValue, casValue + 1)) {
+      } else if (queuedTaskCount.weakCompareAndSetVolatile(casValue, casValue + 1)) {
         try {
           parentScheduler.schedule(new DecrementingRunnable(task, queuedTaskCount), 
                                    delayInMillis, priority);

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/RateLimiterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/RateLimiterExecutor.java
@@ -322,14 +322,14 @@ public class RateLimiterExecutor implements SubmitterExecutor {
       if (scheduleDelay > maxScheduleDelayMillis) {
         return -1 ;  // let rejection handler invoke outside of lock
       } else {
-        if (scheduleDelay < 0) {
-          if (lastScheduleTime.compareAndSet(casLong, 
-                                             Double.doubleToRawLongBits(now + effectiveDelay))) {
+        if (scheduleDelay <= 0) {
+          if (lastScheduleTime.weakCompareAndSetVolatile(casLong, 
+                                                         Double.doubleToRawLongBits(now + effectiveDelay))) {
             return 0;
           } // else loop and retry
         } else {
-          if (lastScheduleTime.compareAndSet(casLong, 
-                                             Double.doubleToRawLongBits(lastTimeDouble + effectiveDelay))) {
+          if (lastScheduleTime.weakCompareAndSetVolatile(casLong, 
+                                                         Double.doubleToRawLongBits(lastTimeDouble + effectiveDelay))) {
             return (long)scheduleDelay;
           } // else loop and retry
         }

--- a/src/main/java/org/threadly/concurrent/wrapper/limiter/SubmitterSchedulerQueueLimitRejector.java
+++ b/src/main/java/org/threadly/concurrent/wrapper/limiter/SubmitterSchedulerQueueLimitRejector.java
@@ -109,7 +109,7 @@ public class SubmitterSchedulerQueueLimitRejector extends AbstractSubmitterSched
       if (casValue >= queuedTaskLimit) {
         rejectedExecutionHandler.handleRejectedTask(task);
         return; // in case handler did not throw exception
-      } else if (queuedTaskCount.compareAndSet(casValue, casValue + 1)) {
+      } else if (queuedTaskCount.weakCompareAndSetVolatile(casValue, casValue + 1)) {
         try {
           parentScheduler.schedule(new DecrementingRunnable(task, queuedTaskCount), delayInMillis);
         } catch (RejectedExecutionException e) {

--- a/src/main/java/org/threadly/util/AbstractService.java
+++ b/src/main/java/org/threadly/util/AbstractService.java
@@ -22,7 +22,7 @@ public abstract class AbstractService implements Service {
   
   @Override
   public boolean startIfNotStarted() {
-    if (state.get() == 0 && state.compareAndSet(0, 1)) {
+    if (state.getPlain() == 0 && state.compareAndSet(0, 1)) {
       startupService();
       
       return true;
@@ -47,7 +47,7 @@ public abstract class AbstractService implements Service {
   
   @Override
   public boolean stopIfRunning() {
-    if (state.get() == 1 && state.compareAndSet(1, 2)) {
+    if (state.getPlain() == 1 && state.compareAndSet(1, 2)) {
       shutdownService();
       
       return true;

--- a/src/main/java/org/threadly/util/ArrayIterator.java
+++ b/src/main/java/org/threadly/util/ArrayIterator.java
@@ -62,7 +62,7 @@ public class ArrayIterator<T> implements Iterator<T> {
   }
   
   protected final T[] array;
-  private int pos = 0;
+  private int pos;  // default 0
   
   /**
    * Construct a new {@link Iterator} that will start at position zero of the provided array.


### PR DESCRIPTION
With the support of java 11 as a minimum JDK version in 7.0 we now have access to the new memory modes introduced in java 9.  This appears to be the most descriptive detail of these modes I can find: http://gee.cs.oswego.edu/dl/html/j9mm.html

Descriptions in the javadocs help only some: https://docs.oracle.com/javase/9/docs/api/java/lang/invoke/VarHandle.html

Initially I had planned for more significant changes, but instead I decided to slowly introduce these.  The most obvious case is the introduction of `getPlain()` calls where we had other thread controls in place already.  See commit comments for more details.