### PR TITLE
Add ListenableFuture.as to the interface

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 7.0
+version = 7.1-SNAPSHOT
 org.gradle.parallel = false

--- a/src/main/java/org/threadly/concurrent/future/CompletableFutureAdapter.java
+++ b/src/main/java/org/threadly/concurrent/future/CompletableFutureAdapter.java
@@ -53,7 +53,6 @@ public class CompletableFutureAdapter {
     }
     
     return new AdaptedListenableFuture<T>(cf);
-    
   }
   
   /**

--- a/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
+++ b/src/main/java/org/threadly/concurrent/future/ListenableFuture.java
@@ -920,4 +920,19 @@ public interface ListenableFuture<T> extends Future<T> {
    * @return The stack trace currently executing the future, or {@code null} if unavailable
    */
   public StackTraceElement[] getRunningStackTrace();
+  
+  /**
+   * Used to convert the {@link ListenableFuture} to another form.  Unlike other mapping functions 
+   * which are designed to change the generic type, this is designed to convert out of a 
+   * {@link ListenableFuture} and to a completely different form.  The most common usage likely 
+   * would be to use {@link CompletableFutureAdapter#toCompletable(ListenableFuture)} to convert 
+   * to a {@link java.util.concurrent.CompletableFuture}.
+   * 
+   * @param <TT> The type of returned object
+   * @param conversionFunction Function used to convert this instance to the type
+   * @return The result provided from the {@code conversionFunction}
+   */
+  default <TT> TT as(Function<? super ListenableFuture<T>, ? extends TT> conversionFunction) {
+    return conversionFunction.apply(this);
+  }
 }


### PR DESCRIPTION
This resolves #278 by providing a `as` function to the interface.  This function is unlike other mappers, it enables an easy conversions out of the ListenableFuture type.