### PR TITLE
AbstractCompletableListenableFuture.cancel listener execution thread fix

### DIFF
--- a/src/test/java/org/threadly/concurrent/future/CompletableListenableFutureInterfaceTest.java
+++ b/src/test/java/org/threadly/concurrent/future/CompletableListenableFutureInterfaceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -391,6 +392,38 @@ public abstract class CompletableListenableFutureInterfaceTest extends Listenabl
   }
   
   @Test
+  public void cancelCompletableRunsListenerOnExceptedThreadTest() {
+    TestableScheduler scheduler = new TestableScheduler();
+    AbstractCompletableListenableFuture<String> slf = 
+        makeCompletableListenableFutureFactory().makeNewCompletable();
+    TestRunnable tr = new TestRunnable();
+    slf.listener(tr, scheduler);
+    
+    slf.cancel(false);
+    
+    assertTrue(slf.isCancelled());
+    assertFalse(tr.ranOnce());
+    assertEquals(1, scheduler.tick());
+    assertTrue(tr.ranOnce());
+  }
+  
+  @Test
+  public void cancelCompletableRunsListenerOnExceptedThreadOptimizedTest() {
+    TestableScheduler scheduler = new TestableScheduler();
+    AbstractCompletableListenableFuture<String> slf = 
+        makeCompletableListenableFutureFactory().makeNewCompletable(scheduler);
+    TestRunnable tr = new TestRunnable();
+    slf.listener(tr, scheduler, ListenerOptimizationStrategy.SingleThreadIfExecutorMatch);
+    
+    slf.cancel(false);
+    
+    assertTrue(slf.isCancelled());
+    assertFalse(tr.ranOnce());
+    assertEquals(1, scheduler.tick());
+    assertTrue(tr.ranOnce());
+  }
+  
+  @Test
   public void completeWithResultIsDoneTest() {
     AbstractCompletableListenableFuture<String> slf = 
         makeCompletableListenableFutureFactory().makeNewCompletable();
@@ -579,10 +612,23 @@ public abstract class CompletableListenableFutureInterfaceTest extends Listenabl
   }
   
   @Test
+  public void optimizeListenerNotDoneTest() {
+    TestableScheduler scheduler = new TestableScheduler();
+    AbstractCompletableListenableFuture<Void> slf = 
+        makeCompletableListenableFutureFactory().makeNewCompletable(scheduler);
+    
+    slf.listener(DoNothingRunnable.instance(), scheduler, ListenerOptimizationStrategy.SingleThreadIfExecutorMatch);
+    
+    slf.completeWithResult(null);  // we lied what thread it completes on
+    
+    assertEquals(0, scheduler.tick());  // one task for listener, despite scheduler match
+  }
+  
+  @Test
   public void dontOptimizeListenerNotDoneTest() {
     TestableScheduler scheduler = new TestableScheduler();
     AbstractCompletableListenableFuture<Void> slf = 
-        makeCompletableListenableFutureFactory().makeNewCompletable();
+        makeCompletableListenableFutureFactory().makeNewCompletable(scheduler);
     
     slf.listener(DoNothingRunnable.instance(), scheduler, ListenerOptimizationStrategy.InvokingThreadIfDone);
     
@@ -662,6 +708,7 @@ public abstract class CompletableListenableFutureInterfaceTest extends Listenabl
 
   protected interface CompletableListenableFutureFactory extends ListenableFutureFactory {
     public <T> AbstractCompletableListenableFuture<T> makeNewCompletable();
+    public <T> AbstractCompletableListenableFuture<T> makeNewCompletable(Executor executor);
     public AbstractCompletableListenableFuture<?> makeCanceledCompletable();
     public AbstractCompletableListenableFuture<Object> makeWithFailureCompletable(Exception e);
     public <T> AbstractCompletableListenableFuture<T> makeWithResultCompletable(T result);

--- a/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ExecuteOnGetFutureTaskTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -83,6 +84,12 @@ public class ExecuteOnGetFutureTaskTest extends ListenableFutureTaskTest {
     ListenableFutureInterfaceTest.flatMapStackDepthTest(future, future, 74, 15);
   }
   
+  @Test
+  @Override
+  public void optimizeListenerNotDoneTest() {
+    // test ignored due to listener type not capable of optimization
+  }
+  
   private class ExecuteOnGetFutureFactory implements ListenableRunnableFutureFactory {
     @Override
     public RunnableFuture<?> make(Runnable run) {
@@ -101,6 +108,12 @@ public class ExecuteOnGetFutureTaskTest extends ListenableFutureTaskTest {
 
     @Override
     public <T> ExecuteOnGetFutureTask<T> makeNewCompletable() {
+      return new ExecuteOnGetFutureTask<>(DoNothingRunnable.instance());
+    }
+
+    @Override
+    public <T> ExecuteOnGetFutureTask<T> makeNewCompletable(Executor executor) {
+      // executor ignored since future does not support this optimization
       return new ExecuteOnGetFutureTask<>(DoNothingRunnable.instance());
     }
 

--- a/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
+++ b/src/test/java/org/threadly/concurrent/future/ListenableFutureTaskTest.java
@@ -347,6 +347,11 @@ public class ListenableFutureTaskTest extends ListenableRunnableFutureInterfaceT
     }
 
     @Override
+    public <T> ListenableFutureTask<T> makeNewCompletable(Executor executor) {
+      return new ListenableFutureTask<>(DoNothingRunnable.instance(), null, executor);
+    }
+
+    @Override
     public ListenableFutureTask<?> makeCanceledCompletable() {
       ListenableFutureTask<?> lft = new ListenableFutureTask<>(DoNothingRunnable.instance());
       lft.cancel(false);

--- a/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
+++ b/src/test/java/org/threadly/concurrent/future/SettableListenableFutureTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -28,6 +29,7 @@ public class SettableListenableFutureTest extends CompletableListenableFutureInt
   }
   
   @After
+  @Override
   public void cleanup() {
     slf = null;
   }
@@ -601,6 +603,11 @@ public class SettableListenableFutureTest extends CompletableListenableFutureInt
     @Override
     public <T> SettableListenableFuture<T> makeNewCompletable() {
       return new SettableListenableFuture<>();
+    }
+
+    @Override
+    public <T> SettableListenableFuture<T> makeNewCompletable(Executor executor) {
+      return new SettableListenableFuture<>(true, executor);
     }
     
     @Override


### PR DESCRIPTION
This commit resolves #274
Issue #274 describes where AbstractCompletableListenableFuture.cancel may result in listeners with `SingleThreadIfExecutorMatchOrDone` or `SingleThreadIfExecutorMatch` optimization being executed on the thread canceling the future rather than the expected pool.
As commented this minimal overhead is unfortunate considering how corner case this condition is.  Which makes me partially reconsider the optimization capability entirely.